### PR TITLE
Fix webhookName/webhookConfigName problems in sidecar injector

### DIFF
--- a/pilot/cmd/sidecar-injector/main.go
+++ b/pilot/cmd/sidecar-injector/main.go
@@ -83,6 +83,7 @@ var (
 				Port:                flags.port,
 				WebhookConfigFile:   flags.webhookConfigFile,
 				Namespace:           flags.namespace,
+				WebhookConfigName:   flags.webhookConfigName,
 				WebhookName:         flags.webhookName,
 				DeploymentName:      flags.deploymentName,
 				HealthCheckInterval: flags.healthCheckInterval,
@@ -138,7 +139,6 @@ func init() {
 		"Namespace of the deployment for the pod")
 	rootCmd.PersistentFlags().StringVar(&flags.deploymentName, "deployment-name", "istio-sidecar-injector",
 		"Name of the deployment for the pod")
-
 
 	rootCmd.PersistentFlags().DurationVar(&flags.healthCheckInterval, "healthCheckInterval", 0,
 		"Configure how frequently the health check file specified by --healthCheckFile should be updated")

--- a/pilot/pkg/kube/inject/config.go
+++ b/pilot/pkg/kube/inject/config.go
@@ -42,7 +42,7 @@ import (
 func (wh *Webhook) monitorWebhookChanges(stopC <-chan struct{}) chan struct{} {
 	webhookChangedCh := make(chan struct{}, 1000)
 	_, controller := cache.NewInformer(
-		wh.createInformerWebhookSource(wh.clientset, wh.webhookName),
+		wh.createInformerWebhookSource(wh.clientset, wh.webhookConfigName),
 		&v1beta1.MutatingWebhookConfiguration{},
 		0,
 		cache.ResourceEventHandlerFuncs{
@@ -123,7 +123,7 @@ func (wh *Webhook) rebuildWebhookConfig() error {
 	webhookConfig, err := rebuildWebhookConfigHelper(
 		wh.caFile,
 		wh.webhookConfigFile,
-		wh.webhookName,
+		wh.webhookConfigName,
 		wh.ownerRefs)
 	if err != nil {
 		log.Errorf("mutatingwebhookconfiguration (re)load failed: %v", err)
@@ -166,7 +166,7 @@ func loadCaCertPem(in io.Reader) ([]byte, error) {
 // so that the cluster-scoped mutatingwebhookconfiguration is properly
 // cleaned up when istio-galley is deleted.
 func rebuildWebhookConfigHelper(
-	caFile, webhookConfigFile, webhookName string,
+	caFile, webhookConfigFile, webhookConfigName string,
 	ownerRefs []metav1.OwnerReference,
 ) (*v1beta1.MutatingWebhookConfiguration, error) {
 	// load and validate configuration
@@ -192,7 +192,7 @@ func rebuildWebhookConfigHelper(
 	}
 
 	// the webhook name is fixed at startup time
-	webhookConfig.Name = webhookName
+	webhookConfig.Name = webhookConfigName
 
 	// update ownerRefs so configuration is cleaned up when the validation deployment is deleted.
 	webhookConfig.OwnerReferences = ownerRefs

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -82,6 +82,7 @@ type Webhook struct {
 	cert                 *tls.Certificate
 	namespace            string
 	deploymentName       string
+	webhookConfigName    string
 	webhookName          string
 	clientset            clientset.Interface
 	ownerRefs            []metav1.OwnerReference
@@ -139,7 +140,10 @@ type WebhookParameters struct {
 	// Namespace is the namespace in which the deployment and service resides.
 	Namespace string
 
-	// Name of the webhook
+	// Name of the mutatingwebhookconfiguration resource
+	WebhookConfigName string
+
+	// Name of the webhook in the mutatingwebhookconfiguration resource
 	WebhookName string
 
 	// The webhook deployment name
@@ -215,6 +219,7 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		caFile:                 p.CACertFile,
 		webhookConfigFile:      p.WebhookConfigFile,
 		deploymentName:         p.DeploymentName,
+		webhookConfigName:      p.WebhookConfigName,
 		webhookName:            p.WebhookName,
 		namespace:              p.Namespace,
 		clientset:              p.Clientset,


### PR DESCRIPTION
Before this commit, the webhookConfigName flag was totally ignored,
while the webhookName was used as the name of the
mutatingwebhookconfiguration resource, which didn't match the flag's
description.

The webhookConfigName is the name of the mutatingwebhookconfiguration
resource, while the webhookName is the name of the webhook entry in
that resource. Currently, the webhookName is not used, since the resource
is created from a YAML file instead of simply adding an additional
webhook entry to the existing resource.