### PR TITLE
Fixes MAISTRA-334: Exclude Prometheus traffic in rule so that Kiali does not show it

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -837,7 +837,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
+  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
   actions:
   - handler: prometheus
     instances:

--- a/mixer/testdata/config/prometheus.yaml
+++ b/mixer/testdata/config/prometheus.yaml
@@ -206,7 +206,7 @@ metadata:
   name: promhttp
   namespace: istio-system
 spec:
-  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
+  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
   actions:
   - handler: prometheus
     instances:


### PR DESCRIPTION
Cherry-pick of https://github.com/istio/istio/pull/12251 from upstream