### PR TITLE
[MAISTRA-503] Fix the references to webHookName -> webHookConfigName

### DIFF
--- a/pilot/cmd/sidecar-injector/main.go
+++ b/pilot/cmd/sidecar-injector/main.go
@@ -83,7 +83,7 @@ var (
 				Port:                flags.port,
 				WebhookConfigFile:   flags.webhookConfigFile,
 				Namespace:           flags.namespace,
-				WebhookName:         flags.webhookName,
+				WebhookConfigName:   flags.webhookConfigName,
 				DeploymentName:      flags.deploymentName,
 				HealthCheckInterval: flags.healthCheckInterval,
 				HealthCheckFile:     flags.healthCheckFile,

--- a/pilot/pkg/kube/inject/config.go
+++ b/pilot/pkg/kube/inject/config.go
@@ -43,7 +43,7 @@ import (
 func (wh *Webhook) monitorWebhookChanges(stopC <-chan struct{}) chan struct{} {
 	webhookChangedCh := make(chan struct{}, 1000)
 	_, controller := cache.NewInformer(
-		wh.createInformerWebhookSource(wh.clientset, wh.webhookName),
+		wh.createInformerWebhookSource(wh.clientset, wh.webhookConfigName),
 		&v1beta1.MutatingWebhookConfiguration{},
 		0,
 		cache.ResourceEventHandlerFuncs{
@@ -124,7 +124,7 @@ func (wh *Webhook) rebuildWebhookConfig() error {
 	webhookConfig, err := rebuildWebhookConfigHelper(
 		wh.caFile,
 		wh.webhookConfigFile,
-		wh.webhookName,
+		wh.webhookConfigName,
 		wh.ownerRefs)
 	if err != nil {
 		log.Errorf("mutatingwebhookconfiguration (re)load failed: %v", err)
@@ -167,7 +167,7 @@ func loadCaCertPem(in io.Reader) ([]byte, error) {
 // so that the cluster-scoped mutatingwebhookconfiguration is properly
 // cleaned up when istio-galley is deleted.
 func rebuildWebhookConfigHelper(
-	caFile, webhookConfigFile, webhookName string,
+	caFile, webhookConfigFile, webhookConfigName string,
 	ownerRefs []metav1.OwnerReference,
 ) (*v1beta1.MutatingWebhookConfiguration, error) {
 	// load and validate configuration
@@ -193,7 +193,7 @@ func rebuildWebhookConfigHelper(
 	}
 
 	// the webhook name is fixed at startup time
-	webhookConfig.Name = webhookName
+	webhookConfig.Name = webhookConfigName
 
 	// update ownerRefs so configuration is cleaned up when the validation deployment is deleted.
 	webhookConfig.OwnerReferences = ownerRefs

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -82,7 +82,7 @@ type Webhook struct {
 	cert                 *tls.Certificate
 	namespace            string
 	deploymentName       string
-	webhookName          string
+	webhookConfigName    string
 	clientset            clientset.Interface
 	ownerRefs            []metav1.OwnerReference
 	webhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration
@@ -140,7 +140,7 @@ type WebhookParameters struct {
 	Namespace string
 
 	// Name of the webhook
-	WebhookName string
+	WebhookConfigName string
 
 	// The webhook deployment name
 	DeploymentName string
@@ -215,7 +215,7 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		caFile:                 p.CACertFile,
 		webhookConfigFile:      p.WebhookConfigFile,
 		deploymentName:         p.DeploymentName,
-		webhookName:            p.WebhookName,
+		webhookConfigName:      p.WebhookConfigName,
 		namespace:              p.Namespace,
 		clientset:              p.Clientset,
 	}


### PR DESCRIPTION
WebhooksConfigs were being created with the wrong name (the one in the
webHookName field), which is static. We should be referencing the
WebHookConfigName, which has a different name for each control plane.

This error was preventing the sidecar being attached to pods.