### PR TITLE
Enable injecting additional annotations into pods (MAISTRA-518)

### DIFF
--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -83,6 +83,7 @@ func TestIntoResourceFile(t *testing.T) {
 		readinessPeriodSeconds       uint32
 		readinessFailureThreshold    uint32
 		tproxy                       bool
+		annotations                  map[string]string
 	}{
 		// "testdata/hello.yaml" is tested in http_test.go (with debug)
 		{
@@ -274,6 +275,7 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			annotations:                  map[string]string{"some-annotation/foo~bar": "foobar"},
 		},
 		{
 			in:                           "job.yaml",
@@ -284,6 +286,7 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			annotations:                  map[string]string{"some-annotation/foo~bar": "foobar"},
 		},
 		{
 			in:                           "replicaset.yaml",
@@ -294,6 +297,7 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			annotations:                  map[string]string{"some-annotation/foo~bar": "foobar"},
 		},
 		{
 			in:                           "replicationcontroller.yaml",
@@ -304,6 +308,7 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			annotations:                  map[string]string{"some-annotation/foo~bar": "foobar"},
 		},
 		{
 			in:                           "cronjob.yaml",
@@ -314,6 +319,7 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			annotations:                  map[string]string{"some-annotation/foo~bar": "foobar"},
 		},
 		{
 			in:                           "pod.yaml",
@@ -324,6 +330,7 @@ func TestIntoResourceFile(t *testing.T) {
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
 			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+			annotations:                  map[string]string{"some-annotation/foo~bar": "foobar"},
 		},
 		{
 			in:                           "hello-host-network.yaml",
@@ -531,6 +538,7 @@ func TestIntoResourceFile(t *testing.T) {
 				ReadinessPeriodSeconds:       c.readinessPeriodSeconds,
 				ReadinessFailureThreshold:    c.readinessFailureThreshold,
 				RewriteAppHTTPProbe:          false,
+				Annotations:                  c.annotations,
 			}
 			if c.imagePullPolicy != "" {
 				params.ImagePullPolicy = c.imagePullPolicy

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -38,6 +38,12 @@ const (
 [[- $readinessFailureThresholdValue := (annotation .ObjectMeta $readinessFailureThresholdKey {{ .ReadinessFailureThreshold }}) -]]
 [[- $readinessApplicationPortsValue := (annotation .ObjectMeta $readinessApplicationPortsKey (applicationPorts .Spec.Containers)) -]]
 rewriteAppHTTPProbe: {{ .RewriteAppHTTPProbe }}
+{{ if .Annotations }}
+annotations:
+{{ range $key, $value := .Annotations }}
+  {{ $key }}: {{ $value }}
+{{ end }}
+{{ end }}
 initContainers:
 - name: istio-init
   image: {{ .InitImage }}

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -7,11 +7,13 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","annotations":{"some-annotation/foo~bar":"foobar"},"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
     spec:
       template:
         metadata:
+          annotations:
+            some-annotation/foo~bar: foobar
           creationTimestamp: null
         spec:
           containers:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -7,7 +7,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","annotations":{"some-annotation/foo~bar":"foobar"},"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        some-annotation/foo~bar: foobar
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -7,7 +7,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","annotations":{"some-annotation/foo~bar":"foobar"},"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        some-annotation/foo~bar: foobar
       creationTimestamp: null
       name: pi
     spec:

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+    sidecar.istio.io/status: '{"version":"","annotations":{"some-annotation/foo~bar":"foobar"},"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+    some-annotation/foo~bar: foobar
   creationTimestamp: null
   name: hellopod
 spec:

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -8,7 +8,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","annotations":{"some-annotation/foo~bar":"foobar"},"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        some-annotation/foo~bar: foobar
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -10,7 +10,8 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","annotations":{"some-annotation/foo~bar":"foobar"},"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        some-annotation/foo~bar: foobar
       creationTimestamp: null
       labels:
         app: nginx

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations.patch
@@ -1,0 +1,58 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/initContainers/-",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/-",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-envoy",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"annotations\":{\"simple-annotation\":\"value\",\"some-annotation/foo~bar\":\"foobar\"},\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}",
+      "simple-annotation": "value",
+      "some-annotation/foo~bar": "foobar"
+    }
+  }
+]

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations.yaml
@@ -1,0 +1,7 @@
+spec:
+  initContainers:
+    - name: c0
+  containers:
+    - name: c1
+  volumes:
+    - name: v0

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations_template.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations_template.yaml
@@ -1,0 +1,22 @@
+annotations:
+  simple-annotation: value
+  some-annotation/foo~bar: foobar
+initContainers:
+- name: istio-init
+  image: example.com/init:latest
+containers:
+- name: istio-proxy
+  image: example.com/proxy:latest
+imagePullSecrets:
+- name: istio-image-pull-secrets
+volumes:
+- emptyDir:
+    medium: Memory
+  name: istio-envoy
+- name: istio-certs
+  secret:
+    [[ if eq .Spec.ServiceAccountName "" -]]
+    secretName: istio.default
+    [[ else -]]
+    secretName: [[ printf "istio.%s" .Spec.ServiceAccountName ]]
+    [[ end -]]

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -504,17 +504,15 @@ func escapeJSONPointerValue(in string) string {
 }
 
 func updateAnnotation(target map[string]string, added map[string]string) (patch []rfc6902PatchOperation) {
-	for key, value := range added {
-		if target == nil {
-			target = map[string]string{}
-			patch = append(patch, rfc6902PatchOperation{
-				Op:   "add",
-				Path: "/metadata/annotations",
-				Value: map[string]string{
-					key: value,
-				},
-			})
-		} else {
+	if target == nil {
+		target = map[string]string{}
+		patch = append(patch, rfc6902PatchOperation{
+			Op:    "add",
+			Path:  "/metadata/annotations",
+			Value: added,
+		})
+	} else {
+		for key, value := range added {
 			op := "add"
 			if target[key] != "" {
 				op = "replace"
@@ -665,6 +663,9 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	}
 
 	annotations := map[string]string{annotationStatus.name: status}
+	for k, v := range spec.Annotations {
+		annotations[k] = v
+	}
 
 	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec)
 	if err != nil {

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -605,12 +605,14 @@ func TestWebhookInject(t *testing.T) {
 			wantFile:     "TestWebhookInject_http_probe_nosidecar_rewrite.patch",
 			templateFile: "TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml",
 		},
+		{
+			inputFile:    "TestWebhookInject_annotations.yaml",
+			wantFile:     "TestWebhookInject_annotations.patch",
+			templateFile: "TestWebhookInject_annotations_template.yaml",
+		},
 	}
 
 	for i, c := range cases {
-		if c.inputFile != "TestWebhookInject_http_probe_nosidecar_rewrite.yaml" {
-			continue
-		}
 		input := filepath.Join("testdata/webhook", c.inputFile)
 		want := filepath.Join("testdata/webhook", c.wantFile)
 		templateFile := "TestWebhookInject_template.yaml"


### PR DESCRIPTION
When using Istio CNI through Multus CNI, the pod needs to contain an
annotation that tells Multus to use the Istio CNI plugin on the pod.
The annotation needs to be injected at pod creation time so that it 
already exists when the kubelet starts setting up the pod's network. 
Adding the annotation afterwards has no effect, since the pod's network 
has already been set up.  

For this reason, the sidecar-injector now allows you to specify any 
number of additional annotations to inject (in addition to the
(init)containers, volumes, etc.)