### PR TITLE
[MAISTRA-680] Add the env variable POD_NAMESPACE to telemetry deployment

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -211,8 +211,13 @@
           - {{ $.Values.telemetry.loadshedding.latencyThreshold }}
           - --loadsheddingMode
           - {{ $.Values.telemetry.loadshedding.mode }}
-        {{- if .Values.env }}
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        {{- if .Values.env }}
         {{- range $key, $val := .Values.env }}
         - name: {{ $key }}
           value: "{{ $val }}"


### PR DESCRIPTION
As some adapters might rely on that.

Currently kubernetesenv adapter is using istio-system namespace,
because this env variable does not exist, thus, if the control plane
is deployed in other namespace we see errors like that:

```
2019-07-23T13:32:01.096074Z	error	istio.io/istio/pkg/kube/secretcontroller/secretcontroller.go:148: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:i1:istio-mixer-service-account" cannot list resource "secrets" in API group "" in the namespace "istio-system"
```