### PR TITLE
MAISTRA-668 Fix expected output of webhook injection

### DIFF
--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_annotations.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -28,7 +28,10 @@
           "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -26,7 +26,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pilot/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -30,7 +30,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {


### PR DESCRIPTION
The sidecar injector now sets the securityContext.runAsUser field
regardless if it is specified in the sidecar template or not. This is
to allow the sidecar template to not include the field, which is
required to ensure that istioctl kube-inject outputs manifests that
pass the SCC admission controller (if the runAsUser is specified, the
SCC controller will reject the pod, as the uid won't be in the proper
range). The sidecar injector then injects the correct runAsUser id even
if it isn't specified in the template.