### PR TITLE
WIP: Stop leaking goroutines in newMultiWatch

### DIFF
--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -263,6 +263,7 @@ func (mlw *multiListerWatcher) newMultiWatch(resourceVersions map[string]string,
 		o.ResourceVersion = resourceVersions[n]
 		w, err := lws.lw.Watch(*o)
 		if err != nil {
+			mlw.stopInternal()
 			return err
 		}
 


### PR DESCRIPTION
This fixes a goroutine leak in cases where Watch() is called again without a new List() inbetween Watch() calls. This happens when one of the underlying watches returns a ConnectionRefused error. See https://github.com/kubernetes/client-go/blob/3fe2abece89efc7b3a2da0ff549525f20f435263/tools/cache/reflector.go#L286

Note that I stumbled upon this leak while fixing another bug; this probably has other implications, so I'll mark it WIP for now.