### PR TITLE
MAISTRA-1005 Do not expect namespaces to have a stable ordering

### DIFF
--- a/pkg/servicemesh/controller/controller.go
+++ b/pkg/servicemesh/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -123,6 +124,7 @@ func (smmrl *serviceMeshMemberRollListener) updateNamespaces(operation string, m
 		log.Infof("ServiceMeshMemberRoll using incorrect name %v, ignoring", memberRollName)
 	} else {
 		namespaces := smmrl.smmrc.getNamespaces(members)
+		sort.Strings(namespaces)
 		if !smmrl.checkEquality(smmrl.currentNamespaces, namespaces) {
 			smmrl.currentNamespaces = namespaces
 			log.Infof("ServiceMeshMemberRoll %v %s, namespaces now %q", memberRollName, operation, smmrl.currentNamespaces)


### PR DESCRIPTION
The ServiceMeshMemberRoll controller was previously checking the equality of the existing list of namespaces vs incoming using a simple for-loop that would report inequality in case of different ordering. This now became a problem when a bug in the operator caused it to repeatedly reconcile the MemberRoll, changing the order of namespaces in the process.

Note that this increases complexity of the equality check by quite a margin, but the changes in https://github.com/Maistra/istio/pull/51 could counteract this.