### PR TITLE
[maistra-1.1-future] sidecar-injector

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -165,6 +165,7 @@ type SidecarTemplateData struct {
 	ProxyConfig    *meshconfig.ProxyConfig
 	MeshConfig     *meshconfig.MeshConfig
 	Values         map[string]interface{}
+	ProxyUID       uint64
 }
 
 // Params describes configurable parameters for injecting istio proxy
@@ -528,7 +529,7 @@ func flippedContains(needle, haystack string) bool {
 
 // InjectionData renders sidecarTemplate with valuesConfig.
 func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *metav1.TypeMeta, deploymentMetadata *metav1.ObjectMeta, spec *corev1.PodSpec,
-	metadata *metav1.ObjectMeta, proxyConfig *meshconfig.ProxyConfig, meshConfig *meshconfig.MeshConfig) (
+	metadata *metav1.ObjectMeta, proxyConfig *meshconfig.ProxyConfig, meshConfig *meshconfig.MeshConfig, proxyUID uint64) (
 	*SidecarInjectionSpec, string, error) {
 
 	// If DNSPolicy is not ClusterFirst, the Envoy sidecar may not able to connect to Istio Pilot.
@@ -556,6 +557,7 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *
 		ProxyConfig:    proxyConfig,
 		MeshConfig:     meshConfig,
 		Values:         values,
+		ProxyUID:       proxyUID,
 	}
 
 	funcMap := template.FuncMap{
@@ -813,7 +815,8 @@ func IntoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 		podSpec,
 		metadata,
 		meshconfig.DefaultConfig,
-		meshconfig)
+		meshconfig,
+		DefaultSidecarProxyUID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -28,7 +28,10 @@
           "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333,\"scheme\":\"HTTPS\"},\"/app-health/second/livez\":{\"port\":9000}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -26,7 +26,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -30,7 +30,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +44,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
+
+const proxyUIDAnnotation = "sidecar.istio.io/proxyUID"
 
 var (
 	runtimeScheme = runtime.NewScheme()
@@ -667,7 +670,30 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		deployMeta.Name = pod.Name
 	}
 
-	spec, iStatus, err := InjectionData(wh.sidecarConfig.Template, wh.valuesConfig, wh.sidecarTemplateVersion, typeMetadata, deployMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig.DefaultConfig, wh.meshConfig) // nolint: lll
+	proxyUID, err := getProxyUID(pod)
+	if err != nil {
+		log.Infof("Could not get proxyUID from annotation: %v", err)
+	}
+	if proxyUID == nil {
+		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
+			uid := uint64(*pod.Spec.SecurityContext.RunAsUser) + 1
+			proxyUID = &uid
+		}
+		for _, c := range pod.Spec.Containers {
+			if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
+				uid := uint64(*c.SecurityContext.RunAsUser) + 1
+				if proxyUID == nil || uid > *proxyUID {
+					proxyUID = &uid
+				}
+			}
+		}
+	}
+	if proxyUID == nil {
+		uid := DefaultSidecarProxyUID
+		proxyUID = &uid
+	}
+
+	spec, iStatus, err := InjectionData(wh.sidecarConfig.Template, wh.valuesConfig, wh.sidecarTemplateVersion, typeMetadata, deployMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig.DefaultConfig, wh.meshConfig, *proxyUID) // nolint: lll
 	if err != nil {
 		handleError(fmt.Sprintf("Injection data: err=%v spec=%v\n", err, iStatus))
 		return toAdmissionResponse(err)
@@ -698,6 +724,19 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	}
 	totalSuccessfulInjections.Increment()
 	return &reviewResponse
+}
+
+func getProxyUID(pod corev1.Pod) (*uint64, error) {
+	if pod.Annotations != nil {
+		if annotationValue, found := pod.Annotations[proxyUIDAnnotation]; found {
+			proxyUID, err := strconv.ParseUint(annotationValue, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			return &proxyUID, nil
+		}
+	}
+	return nil, nil
 }
 
 func (wh *Webhook) serveInject(w http.ResponseWriter, r *http.Request) {

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -348,7 +348,7 @@ func addContainer(target, added []corev1.Container, basePath string) (patch []rf
 	first := len(target) == 0
 	var value interface{}
 	for _, add := range added {
-		if add.Name == "istio-proxy" && saJwtSecretMountName != "" {
+		if add.Name == sidecarContainerName && saJwtSecretMountName != "" {
 			// add service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
 			// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) to istio-proxy container,
 			// so that envoy could fetch/pass k8s sa jwt and pass to sds server, which will be used to request workload identity for the pod.
@@ -551,8 +551,11 @@ func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotation
 // Retain deprecated hardcoded container and volumes names to aid in
 // backwards compatible migration to the new SidecarInjectionStatus.
 var (
-	legacyInitContainerNames = []string{"istio-init", "enable-core-dump"}
-	legacyContainerNames     = []string{"istio-proxy"}
+	initContainerName    = "istio-init"
+	sidecarContainerName = "istio-proxy"
+
+	legacyInitContainerNames = []string{initContainerName, "enable-core-dump"}
+	legacyContainerNames     = []string{sidecarContainerName}
 	legacyVolumeNames        = []string{"istio-certs", "istio-envoy"}
 )
 
@@ -611,11 +614,17 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	log.Debugf("Object: %v", string(req.Object.Raw))
 	log.Debugf("OldObject: %v", string(req.OldObject.Raw))
 
+	partialInjection := false
 	if !injectRequired(ignoredNamespaces, wh.sidecarConfig, &pod.Spec, &pod.ObjectMeta) {
-		log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
-		totalSkippedInjections.Increment()
-		return &v1beta1.AdmissionResponse{
-			Allowed: true,
+		if wasInjectedThroughIstioctl(&pod) {
+			log.Infof("Performing partial injection into pre-injected pod %s/%s (injecting Multus annotation and runAsUser id)", pod.ObjectMeta.Namespace, podName)
+			partialInjection = true
+		} else {
+			log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
+			totalSkippedInjections.Increment()
+			return &v1beta1.AdmissionResponse{
+				Allowed: true,
+			}
 		}
 	}
 
@@ -699,14 +708,20 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		return toAdmissionResponse(err)
 	}
 
-	annotations := map[string]string{annotation.SidecarStatus.Name: iStatus}
+	var patchBytes []byte
+	if partialInjection {
+		patchBytes, err = createPartialPatch(&pod, wh.sidecarConfig.InjectedAnnotations, *proxyUID)
+	} else {
+		replaceProxyRunAsUserID(spec, *proxyUID)
 
-	// Add all additional injected annotations
-	for k, v := range wh.sidecarConfig.InjectedAnnotations {
-		annotations[k] = v
+		annotations := map[string]string{annotation.SidecarStatus.Name: iStatus}
+		// Add all additional injected annotations
+		for k, v := range wh.sidecarConfig.InjectedAnnotations {
+			annotations[k] = v
+		}
+		patchBytes, err = createPatch(&pod, injectionStatus(&pod), annotations, spec)
 	}
 
-	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec)
 	if err != nil {
 		handleError(fmt.Sprintf("AdmissionResponse: err=%v spec=%v\n", err, spec))
 		return toAdmissionResponse(err)
@@ -724,6 +739,92 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	}
 	totalSuccessfulInjections.Increment()
 	return &reviewResponse
+}
+
+func wasInjectedThroughIstioctl(pod *corev1.Pod) bool {
+	_, found := pod.Annotations[annotation.SidecarStatus.Name]
+	return found
+}
+
+func replaceProxyRunAsUserID(spec *SidecarInjectionSpec, proxyUID uint64) {
+	for i, c := range spec.InitContainers {
+		if c.Name == initContainerName {
+			for j, arg := range c.Args {
+				if arg == "-u" {
+					spec.InitContainers[i].Args[j+1] = strconv.FormatUint(proxyUID, 10)
+					break
+				}
+			}
+			break
+		}
+	}
+	for i, c := range spec.Containers {
+		if c.Name == sidecarContainerName {
+			if c.SecurityContext == nil {
+				securityContext := corev1.SecurityContext{}
+				spec.Containers[i].SecurityContext = &securityContext
+			}
+			proxyUIDasInt64 := int64(proxyUID)
+			spec.Containers[i].SecurityContext.RunAsUser = &proxyUIDasInt64
+			break
+		}
+	}
+}
+
+func createPartialPatch(pod *corev1.Pod, annotations map[string]string, proxyUID uint64) ([]byte, error) {
+	var patch []rfc6902PatchOperation
+	patch = append(patch, patchProxyRunAsUserID(pod, proxyUID)...)
+	patch = append(patch, updateAnnotation(pod.Annotations, annotations)...)
+	return json.Marshal(patch)
+}
+
+func patchProxyRunAsUserID(pod *corev1.Pod, proxyUID uint64) (patch []rfc6902PatchOperation) {
+	for i, c := range pod.Spec.InitContainers {
+		if c.Name == initContainerName {
+			for j, arg := range c.Args {
+				if arg == "-u" {
+					patch = append(patch, rfc6902PatchOperation{
+						Op:    "replace",
+						Path:  fmt.Sprintf("/spec/initContainers/%d/args/%d", i, j+1), // j+1 because the uid is the next argument (after -u)
+						Value: strconv.FormatUint(proxyUID, 10),
+					})
+					break
+				}
+			}
+			break
+		}
+	}
+
+	for i, c := range pod.Spec.Containers {
+		if c.Name == sidecarContainerName {
+			if c.SecurityContext == nil {
+				proxyUIDasInt64 := int64(proxyUID)
+				securityContext := corev1.SecurityContext{
+					RunAsUser: &proxyUIDasInt64,
+				}
+				patch = append(patch, rfc6902PatchOperation{
+					Op:    "add",
+					Path:  fmt.Sprintf("/spec/containers/%d/securityContext", i),
+					Value: securityContext,
+				})
+			} else if c.SecurityContext.RunAsUser == nil {
+				patch = append(patch, rfc6902PatchOperation{
+					Op:    "add",
+					Path:  fmt.Sprintf("/spec/containers/%d/securityContext/runAsUser", i),
+					Value: proxyUID,
+				})
+			} else {
+				patch = append(patch, rfc6902PatchOperation{
+					Op:    "replace",
+					Path:  fmt.Sprintf("/spec/containers/%d/securityContext/runAsUser", i),
+					Value: proxyUID,
+				})
+			}
+			break
+		}
+	}
+
+	return patch
 }
 
 func getProxyUID(pod corev1.Pod) (*uint64, error) {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1367,10 +1367,11 @@ func TestRunAndServe(t *testing.T) {
       "path":"/spec/containers/-",
       "value":{
          "name":"istio-proxy",
-         "resources":{
-
-         }
-      }
+		 "resources": {},
+		 "securityContext": {
+		   "runAsUser": 1337
+		 }
+	  }
    },
    {
       "op":"add",


### PR DESCRIPTION
I left out the commit adding annotation functionality, as that has already been implemented upstream - **we will have to look out for this in the operator repository, as the way to specify annotations is slightly different**: `injectedAnnotations` instead of `annotations`. For the UID injection I had to change a few more of the unit tests to make them pass.