### PR TITLE
MAISTRA-1159 Add missing label "release" to CRDs

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-11.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-11.yaml
@@ -6,6 +6,7 @@ metadata:
     app: mixer
     package: cloudwatch
     istio: mixer-adapter
+    release: istio
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -28,6 +29,7 @@ metadata:
     app: mixer
     package: dogstatsd
     istio: mixer-adapter
+    release: istio
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -73,6 +75,7 @@ metadata:
     app: mixer
     package: zipkin
     istio: mixer-adapter
+    release: istio
   annotations:
     "helm.sh/resource-policy": keep
 spec:


### PR DESCRIPTION
Some of CRDs are missing the "release" label. Our `patch-charts.sh` script only adds the `maistra-release` label to all objects that have the `release` label. The end result is that these CRDs don't have the `maistra-release` label, which is crucial for multi-version CRD handling.