### PR TITLE
MAISTRA-1079: Replace deprecated API's (part 2)

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -15,6 +15,12 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+
+  selector:
+    matchLabels:
+        app: {{ template "galley.name" . }}
+        release: {{ .Release.Name }}
+        istio: galley
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -21,6 +21,11 @@ spec:
   replicas: 1
 {{- end }}
 {{- end }}
+  selector:
+    matchLabels:
+      {{- range $key, $val := $spec.labels }}
+      {{ $key }}: {{ $val }}
+      {{- end }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+
+  selector:
+    matchLabels:
+        app: {{ template "grafana.name" . }}
+        release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/istiocoredns/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/templates/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+
+  selector:
+    matchLabels:
+        app: {{ template "istiocoredns.name" . }}
+        release: {{ .Release.Name }}
   template:
     metadata:
       name: istiocoredns

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -16,6 +16,12 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+
+  selector:
+    matchLabels:
+        app: {{ template "security.name" . }}
+        release: {{ .Release.Name }}
+        istio: citadel
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+
+  selector:
+    matchLabels:
+        app: servicegraph
+        release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -15,6 +15,12 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
+
+  selector:
+    matchLabels:
+        app: {{ template "sidecar-injector.name" . }}
+        release: {{ .Release.Name }}
+        istio: sidecar-injector
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
@@ -11,6 +11,11 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+
+  selector:
+    matchLabels:
+        app: jaeger
+        release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
@@ -11,6 +11,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+
+  selector:
+    matchLabels:
+        app: zipkin
+        release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Add selectors to deployments. They were not necessary previously because
they were added by operator patch charts script.

They are needed here now because we run E2E tests that grab files directly
from this repo - and not from operator charts.