### PR TITLE
MAISTRA-1258 Don't Run() citadel's namespaceController

### DIFF
--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -291,7 +291,6 @@ func (sc *SecretController) Run(stopCh chan struct{}) {
 	cache.WaitForCacheSync(stopCh, sc.scrtController.HasSynced)
 
 	go sc.saController.Run(stopCh)
-	go sc.namespaceController.Run(stopCh)
 }
 
 // GetSecretName returns the secret name for a given service account name.


### PR DESCRIPTION
We don't need this controller, as its purpose is for citadel to be notified of newly-created namespaces. In Maistra, namespace updates like this are triggered through the MemberRollController.
