### PR TITLE
fix http to https redirection during container build for testing

### DIFF
--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -4,9 +4,10 @@ ARG istio_version
 
 # Install libc++. Note: we're installing Ubuntu 16.04 (Xenial) packages,
 # since we're using those on the build infrastructure.
-RUN curl -s http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN curl -s -L http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" \
     >/etc/apt/sources.list.d/llvm.list
+RUN apt-get install --no-install-recommends -y apt-transport-https
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libc++-8-dev libc++abi-8-dev
 

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -4,9 +4,10 @@ ARG istio_version
 
 # Install libc++. Note: we're installing Ubuntu 16.04 (Xenial) packages,
 # since we're using those on the build infrastructure.
-RUN curl -s http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN curl -s -L http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" \
     >/etc/apt/sources.list.d/llvm.list
+RUN apt-get install --no-install-recommends -y apt-transport-https
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libc++-8-dev libc++abi-8-dev
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -4,9 +4,10 @@ ARG istio_version
 
 # Install libc++. Note: we're installing Ubuntu 16.04 (Xenial) packages,
 # since we're using those on the build infrastructure.
-RUN curl -s http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN curl -s -L http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" \
     >/etc/apt/sources.list.d/llvm.list
+RUN apt-get install --no-install-recommends -y apt-transport-https
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libc++-8-dev libc++abi-8-dev
 


### PR DESCRIPTION
he E2E test steps include creating debug containers before the test runs. Even though the containers being created are not used during tests, if the creation is broken the test doesn't run.

The error message is:
```
Removing intermediate container e8f5e1306e47
Step 4 : RUN curl -s http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
---> Running in 4fd60e45a590
gpg: no valid OpenPGP data found.
The command '/bin/sh -c curl -s http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -' returned a non-zero code: 2
```
Because the curl tries http, and it is now redirecting to https. Without the -L option it does not get redirected, failing to download the key.

The redirection is also causing the apt-get install command to fail, because the sources are now redirecting from http to https. The error message is:

```
Step 6 : RUN apt-get update && apt-get install --no-install-recommends -y libc+-8-dev libc+abi-8-dev
---> Running in 5696ac9402ed
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:3 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
Get:6 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [1073 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1443 kB]
Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [621 kB]
Get:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6282 B]
Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1023 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.3 kB]
Get:12 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8807 B]
Reading package lists...
E: The method driver /usr/lib/apt/methods/https could not be found.
The command '/bin/sh -c apt-get update && apt-get install --no-install-recommends -y libc+-8-dev libc+abi-8-dev' returned a non-zero code: 100
```

The package `apt-transport-https` needs to be installed in order for the apt-get install command to accept the https redirection.