### PR TITLE
MAISTRA-1206 Fix refreshing of DNS secrets

### DIFF
--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -339,11 +339,16 @@ func (wc *WebhookController) refreshSecret(scrt *v1.Secret) error {
 		return err
 	}
 
-	scrt.Data[ca.CertChainID] = chain
-	scrt.Data[ca.PrivateKeyID] = key
-	scrt.Data[ca.RootCertID] = caCert
+	secret, err := wc.core.Secrets(namespace).Get(scrtName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
 
-	_, err = wc.core.Secrets(namespace).Update(scrt)
+	secret.Data[ca.CertChainID] = chain
+	secret.Data[ca.PrivateKeyID] = key
+	secret.Data[ca.RootCertID] = caCert
+
+	_, err = wc.core.Secrets(namespace).Update(secret)
 	return err
 }
 


### PR DESCRIPTION
This function would previously update an object retrieved directly from a MultiListWatch, which does not work because the MLW prepends the namespace name in certain fields. It will now Get() a fresh copy from the API server before applying changes and attempting to Update()

