### PR TITLE
Run sidecars with dynamically-determined user IDs

### DIFF
--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -28,7 +28,10 @@
           "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333,\"scheme\":\"HTTPS\"}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -15,7 +15,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -16,7 +16,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -17,7 +17,10 @@
       {
         "name": "istio-proxy",
         "image": "example.com/proxy:latest",
-        "resources": {}
+        "resources": {},
+        "securityContext": {
+          "runAsUser": 1337
+        }
       }
     ]
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -14,7 +14,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
@@ -32,7 +32,10 @@
           "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80},\"timeoutSeconds\":5},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333},\"timeoutSeconds\":5},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000},\"timeoutSeconds\":5}}"
         }
       ],
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -26,7 +26,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -30,7 +30,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
@@ -23,7 +23,10 @@
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
-      "resources": {}
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
     }
   },
   {

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -46,6 +46,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
+const proxyUIDAnnotation = "sidecar.istio.io/proxyUID"
+
 var (
 	runtimeScheme = runtime.NewScheme()
 	codecs        = serializer.NewCodecFactory(runtimeScheme)
@@ -394,7 +396,7 @@ func addContainer(target, added []corev1.Container, basePath string) (patch []rf
 	first := len(target) == 0
 	var value interface{}
 	for _, add := range added {
-		if add.Name == "istio-proxy" && saJwtSecretMountName != "" {
+		if add.Name == sidecarContainerName && saJwtSecretMountName != "" {
 			// add service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
 			// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) to istio-proxy container,
 			// so that envoy could fetch/pass k8s sa jwt and pass to sds server, which will be used to request workload identity for the pod.
@@ -681,8 +683,11 @@ func extractCanonicalServiceLabel(podLabels map[string]string, workloadName stri
 // Retain deprecated hardcoded container and volumes names to aid in
 // backwards compatible migration to the new SidecarInjectionStatus.
 var (
-	legacyInitContainerNames = []string{"istio-init", "enable-core-dump"}
-	legacyContainerNames     = []string{"istio-proxy"}
+	initContainerName    = "istio-init"
+	sidecarContainerName = "istio-proxy"
+
+	legacyInitContainerNames = []string{initContainerName, "enable-core-dump"}
+	legacyContainerNames     = []string{sidecarContainerName}
 	legacyVolumeNames        = []string{"istio-certs", "istio-envoy"}
 )
 
@@ -741,11 +746,17 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	log.Debugf("Object: %v", string(req.Object.Raw))
 	log.Debugf("OldObject: %v", string(req.OldObject.Raw))
 
+	partialInjection := false
 	if !injectRequired(ignoredNamespaces, wh.Config, &pod.Spec, &pod.ObjectMeta) {
-		log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
-		totalSkippedInjections.Increment()
-		return &v1beta1.AdmissionResponse{
-			Allowed: true,
+		if wasInjectedThroughIstioctl(&pod) {
+			log.Infof("Performing partial injection into pre-injected pod %s/%s (injecting Multus annotation and runAsUser id)", pod.ObjectMeta.Namespace, podName)
+			partialInjection = true
+		} else {
+			log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
+			totalSkippedInjections.Increment()
+			return &v1beta1.AdmissionResponse{
+				Allowed: true,
+			}
 		}
 	}
 
@@ -804,20 +815,50 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		deployMeta.Name = pod.Name
 	}
 
-	spec, iStatus, err := InjectionData(wh.Config.Template, wh.valuesConfig, wh.sidecarTemplateVersion, typeMetadata, deployMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig) // nolint: lll
+	proxyUID, err := getProxyUID(pod)
+	if err != nil {
+		log.Infof("Could not get proxyUID from annotation: %v", err)
+	}
+	if proxyUID == nil {
+		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
+			uid := uint64(*pod.Spec.SecurityContext.RunAsUser) + 1
+			proxyUID = &uid
+		}
+		for _, c := range pod.Spec.Containers {
+			if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
+				uid := uint64(*c.SecurityContext.RunAsUser) + 1
+				if proxyUID == nil || uid > *proxyUID {
+					proxyUID = &uid
+				}
+			}
+		}
+	}
+	if proxyUID == nil {
+		uid := DefaultSidecarProxyUID
+		proxyUID = &uid
+	}
+
+	spec, iStatus, err := InjectionData(wh.Config.Template, wh.valuesConfig, wh.sidecarTemplateVersion, typeMetadata, deployMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig, *proxyUID) // nolint: lll
 	if err != nil {
 		handleError(fmt.Sprintf("Injection data: err=%v spec=%v\n", err, iStatus))
 		return toAdmissionResponse(err)
 	}
 
-	annotations := map[string]string{annotation.SidecarStatus.Name: iStatus}
+	var patchBytes []byte
+	if partialInjection {
+		patchBytes, err = createPartialPatch(&pod, wh.Config.InjectedAnnotations, *proxyUID)
+	} else {
+		replaceProxyRunAsUserID(spec, *proxyUID)
 
-	// Add all additional injected annotations
-	for k, v := range wh.Config.InjectedAnnotations {
-		annotations[k] = v
+		annotations := map[string]string{annotation.SidecarStatus.Name: iStatus}
+		// Add all additional injected annotations
+		for k, v := range wh.Config.InjectedAnnotations {
+			annotations[k] = v
+		}
+		patchBytes, err = createPatch(&pod, injectionStatus(&pod), wh.revision,
+			annotations, spec, deployMeta.Name, wh.meshConfig)
 	}
 
-	patchBytes, err := createPatch(&pod, injectionStatus(&pod), wh.revision, annotations, spec, deployMeta.Name, wh.meshConfig)
 	if err != nil {
 		handleError(fmt.Sprintf("AdmissionResponse: err=%v spec=%v\n", err, spec))
 		return toAdmissionResponse(err)
@@ -835,6 +876,105 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	}
 	totalSuccessfulInjections.Increment()
 	return &reviewResponse
+}
+
+func wasInjectedThroughIstioctl(pod *corev1.Pod) bool {
+	_, found := pod.Annotations[annotation.SidecarStatus.Name]
+	return found
+}
+
+func replaceProxyRunAsUserID(spec *SidecarInjectionSpec, proxyUID uint64) {
+	for i, c := range spec.InitContainers {
+		if c.Name == initContainerName {
+			for j, arg := range c.Args {
+				if arg == "-u" {
+					spec.InitContainers[i].Args[j+1] = strconv.FormatUint(proxyUID, 10)
+					break
+				}
+			}
+			break
+		}
+	}
+	for i, c := range spec.Containers {
+		if c.Name == sidecarContainerName {
+			if c.SecurityContext == nil {
+				securityContext := corev1.SecurityContext{}
+				spec.Containers[i].SecurityContext = &securityContext
+			}
+			proxyUIDasInt64 := int64(proxyUID)
+			spec.Containers[i].SecurityContext.RunAsUser = &proxyUIDasInt64
+			break
+		}
+	}
+}
+
+func createPartialPatch(pod *corev1.Pod, annotations map[string]string, proxyUID uint64) ([]byte, error) {
+	var patch []rfc6902PatchOperation
+	patch = append(patch, patchProxyRunAsUserID(pod, proxyUID)...)
+	patch = append(patch, updateAnnotation(pod.Annotations, annotations)...)
+	return json.Marshal(patch)
+}
+
+func patchProxyRunAsUserID(pod *corev1.Pod, proxyUID uint64) (patch []rfc6902PatchOperation) {
+	for i, c := range pod.Spec.InitContainers {
+		if c.Name == initContainerName {
+			for j, arg := range c.Args {
+				if arg == "-u" {
+					patch = append(patch, rfc6902PatchOperation{
+						Op:    "replace",
+						Path:  fmt.Sprintf("/spec/initContainers/%d/args/%d", i, j+1), // j+1 because the uid is the next argument (after -u)
+						Value: strconv.FormatUint(proxyUID, 10),
+					})
+					break
+				}
+			}
+			break
+		}
+	}
+
+	for i, c := range pod.Spec.Containers {
+		if c.Name == sidecarContainerName {
+			if c.SecurityContext == nil {
+				proxyUIDasInt64 := int64(proxyUID)
+				securityContext := corev1.SecurityContext{
+					RunAsUser: &proxyUIDasInt64,
+				}
+				patch = append(patch, rfc6902PatchOperation{
+					Op:    "add",
+					Path:  fmt.Sprintf("/spec/containers/%d/securityContext", i),
+					Value: securityContext,
+				})
+			} else if c.SecurityContext.RunAsUser == nil {
+				patch = append(patch, rfc6902PatchOperation{
+					Op:    "add",
+					Path:  fmt.Sprintf("/spec/containers/%d/securityContext/runAsUser", i),
+					Value: proxyUID,
+				})
+			} else {
+				patch = append(patch, rfc6902PatchOperation{
+					Op:    "replace",
+					Path:  fmt.Sprintf("/spec/containers/%d/securityContext/runAsUser", i),
+					Value: proxyUID,
+				})
+			}
+			break
+		}
+	}
+
+	return patch
+}
+
+func getProxyUID(pod corev1.Pod) (*uint64, error) {
+	if pod.Annotations != nil {
+		if annotationValue, found := pod.Annotations[proxyUIDAnnotation]; found {
+			proxyUID, err := strconv.ParseUint(annotationValue, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			return &proxyUID, nil
+		}
+	}
+	return nil, nil
 }
 
 func (wh *Webhook) serveInject(w http.ResponseWriter, r *http.Request) {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1291,10 +1291,11 @@ func TestRunAndServe(t *testing.T) {
       "path":"/spec/containers/-",
       "value":{
          "name":"istio-proxy",
-         "resources":{
-
-         }
-      }
+		 "resources": {},
+		 "securityContext": {
+		   "runAsUser": 1337
+		 }
+	  }
    },
    {
       "op":"add",

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -102,8 +102,6 @@ spec:
       - name: app
         image: {{ $.Hub }}/app:{{ $.Tag }}
         imagePullPolicy: {{ $.PullPolicy }}
-        securityContext:
-          runAsUser: 1
         args:
           - --metrics=15014
           - --cluster

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -36,8 +36,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1
         args:
           - --metrics=15014
           - --cluster

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -37,8 +37,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1
         args:
           - --metrics=15014
           - --cluster

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -42,8 +42,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1
         args:
           - --metrics=15014
           - --cluster
@@ -105,8 +103,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1
         args:
           - --metrics=15014
           - --cluster

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -36,8 +36,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1
         args:
           - --metrics=15014
           - --cluster
@@ -93,8 +91,6 @@ spec:
       - name: app
         image: testing.hub/app:latest
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1
         args:
           - --metrics=15014
           - --cluster


### PR DESCRIPTION
Cherry-pick for 1.6.0 rebase including the following:

### Run sidecars with dynamically-determined user IDs

Squashed commit, incorporates changes from:

  * MAISTRA-551 Run sidecar with a dynamically-determined runAsUser ID

  * MAISTRA-611 Partial injection of just the annotation and runAsUser id

  * MAISTRA-668 Fix expected output of webhook injection

  The sidecar injector now sets the securityContext.runAsUser field
  regardless if it is specified in the sidecar template or not. This is
  to allow the sidecar template to not include the field, which is
  required to ensure that istioctl kube-inject outputs manifests that
  pass the SCC admission controller (if the runAsUser is specified, the
  SCC controller will reject the pod, as the uid won't be in the proper
  range). The sidecar injector then injects the correct runAsUser id even
  if it isn't specified in the template.