### PR TITLE
Ensure Pilot can run without privileges for reading nodes

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -145,6 +145,8 @@ func init() {
 		"Directory to watch for updates to config yaml files. If specified, the files will be used as the source of config, rather than a CRD client.")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.WatchedNamespaces, "appNamespace", "a", metav1.NamespaceAll,
 		"Specify the applications namespace list the controller manages, separated by comma; if not set, controller watches all namespaces")
+	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.PodLocalitySource, "podLocalitySource", "",
+		"node", "Specify where the controller should obtain the Pod's zone and region from (the pod's node or the pod itself)")
 	discoveryCmd.PersistentFlags().DurationVar(&serverArgs.Config.ControllerOptions.ResyncPeriod, "resync", 60*time.Second,
 		"Controller resync interval")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.DomainSuffix, "domain", "cluster.local",

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -113,7 +113,7 @@ func TestIPReuse(t *testing.T) {
 	defer c.Stop()
 	initTestEnv(t, c.client, fx)
 
-	cache.WaitForCacheSync(c.stop, c.nodeMetadataInformer.HasSynced, c.pods.informer.HasSynced,
+	cache.WaitForCacheSync(c.stop, c.podLocalitySource.HasSynced, c.pods.informer.HasSynced,
 		c.services.HasSynced, c.endpoints.HasSynced)
 
 	createPod(t, c, "128.0.0.1", "pod")
@@ -192,8 +192,8 @@ func testPodCache(t *testing.T) {
 		// Pods in namespaces not watched by the controller.
 		generatePod("128.0.0.4", "cpod4", "nsc", "", "", map[string]string{"app": "prod-app-3"}, map[string]string{}),
 	}
-	cache.WaitForCacheSync(c.stop, c.nodeMetadataInformer.HasSynced, c.pods.informer.HasSynced,
-		c.services.HasSynced, c.endpoints.HasSynced)
+	cache.WaitForCacheSync(c.stop, c.podLocalitySource.HasSynced, c.pods.informer.HasSynced,
+		c.services.HasSynced, c.endpoints.HasSynced, c.podLocalitySource.HasSynced)
 
 	for _, pod := range pods {
 		pod := pod


### PR DESCRIPTION
By running Pilot with --podLocalitySource=pod, it reads the pod's labels
to determine pod locality instead of obtaining that information from the
pod's node. An additional controller with cluster-level privileges is
required to copy those labels from the node to the pod after the pod is
scheduled.

Cherry-pick for 1.6.0 rebase.