### PR TITLE
MAISTRA-417: Dynamic namespace support in multi-tenancy

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -145,8 +145,13 @@ func init() {
 		"Directory to watch for updates to config yaml files. If specified, the files will be used as the source of config, rather than a CRD client.")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.WatchedNamespaces, "appNamespace", "a", metav1.NamespaceAll,
 		"Specify the applications namespace list the controller manages, separated by comma; if not set, controller watches all namespaces")
+	if err := discoveryCmd.PersistentFlags().MarkDeprecated("appNamespace", "please use ${APP_NAMESPACE} environment variable instead"); err != nil {
+		panic(err)
+	}
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.PodLocalitySource, "podLocalitySource", "",
 		"node", "Specify where the controller should obtain the Pod's zone and region from (the pod's node or the pod itself)")
+	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.MemberRollName, "memberRollName", "", "",
+		"The name of the ServiceMeshMemberRoll resource.  If specified the server will monitor this resource to discover the application namespaces.")
 	discoveryCmd.PersistentFlags().DurationVar(&serverArgs.Config.ControllerOptions.ResyncPeriod, "resync", 60*time.Second,
 		"Controller resync interval")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.DomainSuffix, "domain", "cluster.local",

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -113,9 +113,9 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 	if hasKubeRegistry(args.Service.Registries) && meshConfig.IngressControllerMode != meshconfig.MeshConfig_OFF {
 		// Wrap the config controller with a cache.
 		s.ConfigStores = append(s.ConfigStores,
-			ingress.NewController(s.kubeClient, meshConfig, args.Config.ControllerOptions))
+			ingress.NewController(s.kubeClient, s.mrc, meshConfig, args.Config.ControllerOptions))
 
-		ingressSyncer, err := ingress.NewStatusSyncer(meshConfig, s.kubeClient, args.Config.ControllerOptions)
+		ingressSyncer, err := ingress.NewStatusSyncer(meshConfig, s.kubeClient, s.mrc, args.Config.ControllerOptions)
 		if err != nil {
 			log.Warnf("Disabled ingress status syncer due to %v", err)
 		} else {
@@ -406,7 +406,7 @@ func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCac
 		return nil, multierror.Prefix(err, "failed to open a config client.")
 	}
 
-	return controller.NewController(configClient, args.Config.ControllerOptions), nil
+	return controller.NewController(configClient, s.mrc, args.Config.ControllerOptions), nil
 }
 
 func (s *Server) makeFileMonitor(fileDir string, configController model.ConfigStore) error {

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -90,7 +90,7 @@ func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args
 	} else {
 		args.Config.ControllerOptions.EndpointMode = kubecontroller.EndpointsOnly
 	}
-	kubeRegistry := kubecontroller.NewController(s.kubeClient, s.metadataClient, args.Config.ControllerOptions)
+	kubeRegistry := kubecontroller.NewController(s.kubeClient, s.metadataClient, s.mrc, args.Config.ControllerOptions)
 	s.kubeRegistry = kubeRegistry
 	serviceControllers.AddRegistry(kubeRegistry)
 	return

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -128,7 +128,7 @@ func makeStatusSyncer(t *testing.T, client kubernetes.Interface) (*StatusSyncer,
 	// Restore env settings
 	defer setAndRestoreEnv(t, oldEnvs)
 
-	return NewStatusSyncer(&m, client, kubecontroller.Options{
+	return NewStatusSyncer(&m, client, nil, kubecontroller.Options{
 		WatchedNamespaces: testNamespace,
 		ResyncPeriod:      resync,
 	})

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -157,7 +157,7 @@ func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *Fak
 	metaV1.AddMetaToScheme(scheme)
 	metadataClient := metafake.NewSimpleMetadataClient(scheme)
 
-	c := NewController(clientSet, metadataClient, Options{
+	c := NewController(clientSet, metadataClient, nil, Options{
 		WatchedNamespaces: opts.watchedNamespaces, // default is all namespaces
 		ResyncPeriod:      resync,
 		DomainSuffix:      domainSuffix,

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -113,7 +113,7 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, metadata
 	var remoteKubeController kubeController
 	remoteKubeController.stopCh = stopCh
 	m.m.Lock()
-	kubectl := NewController(clientset, metadataClient, Options{
+	kubectl := NewController(clientset, metadataClient, nil, Options{
 		WatchedNamespaces: m.WatchedNamespaces,
 		ResyncPeriod:      m.ResyncPeriod,
 		DomainSuffix:      m.DomainSuffix,
@@ -139,7 +139,7 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, metadata
 	}
 	webhookConfigName := strings.ReplaceAll(validationWebhookConfigNameTemplate, validationWebhookConfigNameTemplateVar, m.secretNamespace)
 	if m.fetchCaRoot != nil {
-		nc := NewNamespaceController(m.fetchCaRoot, opts, clientset)
+		nc := NewNamespaceController(m.fetchCaRoot, opts, clientset, nil)
 		go nc.Run(stopCh)
 		go util.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, clientset, stopCh)
 		valicationWebhookController := util.CreateValidationWebhookController(clientset, dynamicClient, webhookConfigName,

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -34,6 +34,7 @@ import (
 
 	"istio.io/istio/pkg/listwatch"
 	"istio.io/istio/pkg/queue"
+	meshcontroller "istio.io/istio/pkg/servicemesh/controller"
 	certutil "istio.io/istio/security/pkg/util"
 )
 
@@ -65,7 +66,7 @@ type NamespaceController struct {
 }
 
 // NewNamespaceController returns a pointer to a newly constructed NamespaceController instance.
-func NewNamespaceController(data func() map[string]string, options Options, kubeClient kubernetes.Interface) *NamespaceController {
+func NewNamespaceController(data func() map[string]string, options Options, kubeClient kubernetes.Interface, mrc meshcontroller.MemberRollController) *NamespaceController {
 	c := &NamespaceController{
 		getData: data,
 		client:  kubeClient.CoreV1(),
@@ -86,6 +87,10 @@ func NewNamespaceController(data func() map[string]string, options Options, kube
 			},
 		}
 	})
+
+	if mrc != nil {
+		mrc.Register(mlw)
+	}
 
 	configmapInformer := cache.NewSharedIndexInformer(mlw, &v1.ConfigMap{}, options.ResyncPeriod,
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -34,7 +34,7 @@ func TestNamespaceController(t *testing.T) {
 	testdata := map[string]string{"key": "value"}
 	nc := NewNamespaceController(func() map[string]string {
 		return testdata
-	}, Options{}, client)
+	}, Options{}, client, nil)
 
 	stop := make(chan struct{})
 	nc.Run(stop)

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -240,7 +240,7 @@ func TestPodCacheEvents(t *testing.T) {
 	defer c.Stop()
 
 	ns := "default"
-	podCache := newPodCache(c, Options{WatchedNamespaces: ns})
+	podCache := newPodCache(c, nil, Options{WatchedNamespaces: ns})
 
 	f := podCache.onEvent
 


### PR DESCRIPTION
Cherry-pick of MAISTRA-417 changes for Istio 1.6 rebase.  This is the
first cherry-pick since the basic multi-tenancy changes were merged
upstream.