### PR TITLE
MAISTRA-417: Add support for dynamic namespaces in Galley

### DIFF
--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -286,7 +286,7 @@ func (sa *SourceAnalyzer) AddRunningKubeSource(k kube.Interfaces) {
 		}
 	}
 
-	src := apiserverNew(apiserver.Options{
+	src := apiserverNew(nil, apiserver.Options{
 		Client:  k,
 		Schemas: sa.kubeResources,
 	})

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schema/collection"
+	meshcontroller "istio.io/istio/pkg/servicemesh/controller"
 )
 
 type testAnalyzer struct {
@@ -251,7 +252,7 @@ func TestResourceFiltering(t *testing.T) {
 	prevApiserverNew := apiserverNew
 	defer func() { apiserverNew = prevApiserverNew }()
 	var recordedOptions apiserver.Options
-	apiserverNew = func(o apiserver.Options) *apiserver.Source {
+	apiserverNew = func(_ meshcontroller.MemberRollController, o apiserver.Options) *apiserver.Source {
 		recordedOptions = o
 		return nil
 	}

--- a/galley/pkg/config/source/kube/apiserver/source_dynamic_test.go
+++ b/galley/pkg/config/source/kube/apiserver/source_dynamic_test.go
@@ -426,7 +426,7 @@ func newOrFail(t *testing.T, ifaces kube.Interfaces, r collection.Schemas, sc st
 		Client:           ifaces,
 		StatusController: sc,
 	}
-	s := apiserver.New(o)
+	s := apiserver.New(nil, o)
 	if s == nil {
 		t.Fatal("Expected non nil source")
 	}

--- a/galley/pkg/config/source/kube/apiserver/status/controller_test.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller_test.go
@@ -41,7 +41,7 @@ func TestBasicStartStop(t *testing.T) {
 	c := NewController(subfield)
 	k, cl := setupClient()
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	defer c.Stop()
 
 	c.Report(diag.Messages{})
@@ -54,8 +54,8 @@ func TestDoubleStart(t *testing.T) {
 	c := NewController(subfield)
 	k, cl := setupClient()
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	defer c.Stop()
 
 	c.Report(diag.Messages{})
@@ -68,7 +68,7 @@ func TestDoubleStop(t *testing.T) {
 	c := NewController(subfield)
 	k, cl := setupClient()
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	c.Report(diag.Messages{})
 	g.Consistently(cl.Actions).Should(BeEmpty())
 	c.Stop()
@@ -81,7 +81,7 @@ func TestNoReconcilation(t *testing.T) {
 	c := NewController(subfield)
 	k, cl := setupClient()
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	c.UpdateResourceStatus(basicmeta.K8SCollection1.Name(), resource.NewFullName("foo", "bar"), "v1", "s1")
 	defer c.Stop()
 
@@ -105,7 +105,7 @@ func TestBasicReconcilation_BeforeUpdate(t *testing.T) {
 
 	k, cl := setupClientWithReactors(r, nil)
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	c.UpdateResourceStatus(basicmeta.K8SCollection1.Name(), resource.NewFullName("foo", "bar"), "v1", s)
 	c.Report(diag.Messages{})
 	defer c.Stop()
@@ -133,7 +133,7 @@ func TestBasicReconcilation_AfterUpdate(t *testing.T) {
 
 	k, cl := setupClientWithReactors(r, nil)
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	c.Report(diag.Messages{})
 	c.UpdateResourceStatus(
 		basicmeta.K8SCollection1.Name(), resource.NewFullName("foo", "bar"), "v1", s)
@@ -164,7 +164,7 @@ func TestBasicReconcilation_AfterUpdate_Othersubfield(t *testing.T) {
 
 	k, cl := setupClientWithReactors(r, nil)
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	c.Report(diag.Messages{})
 	c.UpdateResourceStatus(
 		basicmeta.K8SCollection1.Name(), resource.NewFullName("foo", "bar"), "v1", s)
@@ -205,7 +205,7 @@ func TestBasicReconcilation_NewStatus(t *testing.T) {
 		},
 	}
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	m := msg.NewInternalError(&e, "foo")
 	c.Report(diag.Messages{m})
 	defer c.Stop()
@@ -245,7 +245,7 @@ func TestBasicReconcilation_NewStatusOldNonMap(t *testing.T) {
 		},
 	}
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	m := msg.NewInternalError(&e, "foo")
 	c.Report(diag.Messages{m})
 	defer c.Stop()
@@ -281,7 +281,7 @@ func TestBasicReconcilation_UpdateError(t *testing.T) {
 		},
 	}
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	m := msg.NewInternalError(&e, "foo")
 	c.Report(diag.Messages{m})
 	defer c.Stop()
@@ -316,7 +316,7 @@ func TestBasicReconcilation_GetError(t *testing.T) {
 		},
 	}
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	m := msg.NewInternalError(&e, "foo")
 	c.Report(diag.Messages{m})
 	defer c.Stop()
@@ -348,7 +348,7 @@ func TestBasicReconcilation_VersionMismatch(t *testing.T) {
 		},
 	}
 
-	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0), basicmeta.MustGet().KubeCollections().All())
+	c.Start(rt.NewProvider(k, metav1.NamespaceAll, 0, nil), basicmeta.MustGet().KubeCollections().All())
 	m := msg.NewInternalError(&e, "foo")
 	c.Report(diag.Messages{m})
 	defer c.Stop()

--- a/galley/pkg/config/source/kube/apiserver/watcher.go
+++ b/galley/pkg/config/source/kube/apiserver/watcher.go
@@ -109,7 +109,7 @@ func (w *watcher) dispatch(h event.Handler) {
 func (w *watcher) handleEvent(c event.Kind, obj interface{}) {
 	object, ok := obj.(metav1.Object)
 	if !ok {
-		if obj = tombstone.RecoverResource(obj); object != nil {
+		if object = tombstone.RecoverResource(obj); object == nil {
 			// Tombstone recovery failed.
 			scope.Source.Warnf("Unable to extract object for event: %v", obj)
 			return

--- a/galley/pkg/config/source/kube/rt/dynamic.go
+++ b/galley/pkg/config/source/kube/rt/dynamic.go
@@ -73,6 +73,10 @@ func (p *Provider) getDynamicAdapter(r resource.Schema) *Adapter {
 				}
 			})
 
+			if p.mrc != nil {
+				p.mrc.Register(mlw)
+			}
+
 			informer := cache.NewSharedIndexInformer(mlw, &unstructured.Unstructured{}, p.resyncPeriod,
 				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 

--- a/galley/pkg/config/source/kube/rt/known.go
+++ b/galley/pkg/config/source/kube/rt/known.go
@@ -67,6 +67,10 @@ func (p *Provider) initKnownAdapters() {
 						}
 					})
 
+				if p.mrc != nil {
+					p.mrc.Register(mlw)
+				}
+
 				informer := cache.NewSharedIndexInformer(mlw, &v1.Service{}, p.resyncPeriod,
 					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
@@ -172,6 +176,10 @@ func (p *Provider) initKnownAdapters() {
 						}
 					})
 
+				if p.mrc != nil {
+					p.mrc.Register(mlw)
+				}
+
 				informer := cache.NewSharedIndexInformer(mlw, &v1.Pod{}, p.resyncPeriod,
 					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
@@ -217,6 +225,10 @@ func (p *Provider) initKnownAdapters() {
 						}
 					})
 
+				if p.mrc != nil {
+					p.mrc.Register(mlw)
+				}
+
 				informer := cache.NewSharedIndexInformer(mlw, &v1.Secret{}, p.resyncPeriod,
 					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
@@ -260,6 +272,10 @@ func (p *Provider) initKnownAdapters() {
 							},
 						}
 					})
+
+				if p.mrc != nil {
+					p.mrc.Register(mlw)
+				}
 
 				informer := cache.NewSharedIndexInformer(mlw, &v1.Endpoints{}, p.resyncPeriod,
 					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
@@ -316,6 +332,10 @@ func (p *Provider) initKnownAdapters() {
 							},
 						}
 					})
+
+				if p.mrc != nil {
+					p.mrc.Register(mlw)
+				}
 
 				informer := cache.NewSharedIndexInformer(mlw, &v1beta1.Ingress{}, p.resyncPeriod,
 					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
@@ -400,6 +420,10 @@ func (p *Provider) initKnownAdapters() {
 						}
 					})
 
+				if p.mrc != nil {
+					p.mrc.Register(mlw)
+				}
+
 				informer := cache.NewSharedIndexInformer(mlw, &appsv1.Deployment{}, p.resyncPeriod,
 					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
@@ -442,6 +466,10 @@ func (p *Provider) initKnownAdapters() {
 							},
 						}
 					})
+
+				if p.mrc != nil {
+					p.mrc.Register(mlw)
+				}
 
 				informer := cache.NewSharedIndexInformer(mlw, &v1.ConfigMap{}, p.resyncPeriod,
 					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})

--- a/galley/pkg/config/source/kube/rt/provider.go
+++ b/galley/pkg/config/source/kube/rt/provider.go
@@ -27,10 +27,11 @@ import (
 
 	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/pkg/config/schema/resource"
+	meshcontroller "istio.io/istio/pkg/servicemesh/controller"
 )
 
 var (
-	defaultProvider = NewProvider(nil, metav1.NamespaceAll, 0)
+	defaultProvider = NewProvider(nil, metav1.NamespaceAll, 0, nil)
 )
 
 // DefaultProvider returns a default provider that has no K8s connectivity enabled.
@@ -49,14 +50,17 @@ type Provider struct {
 
 	informers        informers.SharedInformerFactory
 	dynamicInterface dynamic.Interface
+
+	mrc meshcontroller.MemberRollController
 }
 
 // NewProvider returns a new instance of Provider.
-func NewProvider(interfaces kube.Interfaces, namespaces string, resyncPeriod time.Duration) *Provider {
+func NewProvider(interfaces kube.Interfaces, namespaces string, resyncPeriod time.Duration, mrc meshcontroller.MemberRollController) *Provider {
 	p := &Provider{
 		resyncPeriod: resyncPeriod,
 		interfaces:   interfaces,
 		namespaces:   strings.Split(namespaces, ","),
+		mrc:          mrc,
 	}
 
 	p.initKnownAdapters()

--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -326,7 +326,7 @@ func (p *Processing) createSourceAndStatusUpdater(schemas collection.Schemas) (
 			Schemas:           schemas,
 			StatusController:  statusCtl,
 		}
-		s := apiserver.New(o)
+		s := apiserver.New(p.args.MemberRollController, o)
 		src = s
 		updater = s
 	}

--- a/galley/pkg/server/settings/args.go
+++ b/galley/pkg/server/settings/args.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/config/schema/snapshots"
 	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/mcp/creds"
+	meshcontroller "istio.io/istio/pkg/servicemesh/controller"
 	"istio.io/istio/pkg/webhooks/validation/controller"
 	"istio.io/istio/pkg/webhooks/validation/server"
 )
@@ -166,6 +167,8 @@ type Args struct { // nolint:maligned
 
 	Snapshots       []string
 	TriggerSnapshot string
+
+	MemberRollController meshcontroller.MemberRollController
 }
 
 // DefaultArgs allocates an Args struct initialized with Galley's default configuration.

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -313,6 +313,7 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 	processingArgs.EnableServer = false
 	processingArgs.MeshConfigFile = args.Mesh.ConfigFile
 	processingArgs.EnableConfigAnalysis = true
+	processingArgs.MemberRollController = s.mrc
 
 	processing := components.NewProcessing(processingArgs)
 


### PR DESCRIPTION
Reworking dynamic namespace support in Galley for 1.6 rebase:

* MAISTRA-460: Fix galley's handling of tombstones
    
    Original commit Maistra-1.1 commit: 6d05bfca76

* MAISTRA-417: Add support for dynamic namespaces in Galley
    
    This is a rework of the original support for dynamic namespaces in
    galley.  Galley has changed significantly since then.  The changes for
    Maistra 1.1 can be found in the 4ec970763b commit.

