### PR TITLE
MAISTRA-1666: Add `go mod vendor` as part of `make gen`

### DIFF
--- a/pkg/servicemesh/maistra.mk
+++ b/pkg/servicemesh/maistra.mk
@@ -50,3 +50,11 @@ maistra-gen-k8s-client:
 	@$(lister_gen) --input-dirs $(kube_api_packages) --output-package $(kube_listers_package) -h $(kube_go_header_text)
 	@$(informer_gen) --input-dirs $(kube_api_packages) --versioned-clientset-package $(kube_clientset_package)/$(kube_clientset_name) --listers-package $(kube_listers_package) --output-package $(kube_informers_package) -h $(kube_go_header_text)
 	@$(move_generated)
+
+.PHONY: vendor
+vendor:
+	@echo "updating vendor"
+	@go mod vendor
+	@echo "done updating vendor"
+
+gen: vendor


### PR DESCRIPTION
This is to make sure all PR's will have an updated
vendor directory. The `gencheck` prow job will ensure that.
