### PR TITLE
Disable wasm download until we're ready for it

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -209,12 +209,13 @@ else
 fi
 
 # Donwload WebAssembly plugin files
-WASM_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR}
-for plugin in stats metadata_exchange
-do
-  FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.wasm"
-  download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.wasm
-done
+# BAVERY_TODO: Re-enable WASM in Maistra-1475
+#WASM_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR}
+#for plugin in stats metadata_exchange
+#do
+#  FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.wasm"
+#  download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.wasm
+#done
 
 # Copy native envoy binary to ISTIO_OUT
 echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/envoy"

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -208,8 +208,7 @@ else
   ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 fi
 
-# Donwload WebAssembly plugin files
-# BAVERY_TODO: Re-enable WASM in Maistra-1475
+# Because we separate Istio and proxy builds, we don't need to have these files
 #WASM_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR}
 #for plugin in stats metadata_exchange
 #do

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -38,7 +38,7 @@ ARG istio_version
 # Install Envoy.
 COPY envoy /usr/local/bin/envoy
 
-# Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
+# Environment variable indicating the exact proxy sha - for debugging or version-specific configs
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging
 ENV ISTIO_META_ISTIO_VERSION $istio_version
@@ -47,8 +47,8 @@ COPY pilot-agent /usr/local/bin/pilot-agent
 
 COPY envoy_policy.yaml.tmpl /var/lib/istio/envoy/envoy_policy.yaml.tmpl
 
-COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
-COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
+#COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
+#COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -38,7 +38,7 @@ ARG istio_version
 # Install Envoy.
 COPY envoy /usr/local/bin/envoy
 
-# Environment variable indicating the exact proxy sha - for debugging or version-specific configs
+# Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging
 ENV ISTIO_META_ISTIO_VERSION $istio_version
@@ -47,8 +47,8 @@ COPY pilot-agent /usr/local/bin/pilot-agent
 
 COPY envoy_policy.yaml.tmpl /var/lib/istio/envoy/envoy_policy.yaml.tmpl
 
-#COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
-#COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
+COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
+COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -71,8 +71,8 @@ ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap_v2.json: ${ISTIO_ENVOY_BOOTS
 	cp ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_PATH} ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap_v2.json
 
 # rule for wasm extensions.
-$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm: init
-$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm: init
+#$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm: init
+#$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm: init
 
 # Default proxy image.
 docker.proxyv2: BUILD_PRE=&& chmod 755 envoy pilot-agent

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -83,8 +83,8 @@ docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/envoy
 docker.proxyv2: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_policy.yaml.tmpl
-docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm
-docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm
+#docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm
+#docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm
 	$(DOCKER_RULE)
 
 docker.pilot: BUILD_PRE=&& chmod 755 pilot-discovery cacert.pem


### PR DESCRIPTION
Please provide a description for what this PR is for.
Currently, the Maistra build is broken because it's relying on downloading content from Google. This temporarily disables the WASM functionality until we implement it. 

The flow here is: 

* WASM extensions built in proxy and uploaded to Google storage
* The Istio build then attempts to download them from Google storage during the build. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
