### PR TITLE
MAISTRA-1739 Fix validation of AuthorizationPolicy fields

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-in.yaml
@@ -24,6 +24,8 @@ spec:
       when:
         - key: "request.headers[X-header]"
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]
+        - key: "request.regex.headers[X-header-regex]"
+          values: ["some.*value"]
         - key: "source.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
         - key: "source.namespace"

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/all-fields-out.yaml
@@ -217,6 +217,11 @@ rules:
                     - header:
                         name: X-header
                         presentMatch: true
+              - header:
+                  name: X-header-regex
+                  safeRegexMatch:
+                    googleRe2: {}
+                    regex: some.*value
               - orIds:
                   ids:
                     - sourceIp:

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -33,23 +33,24 @@ type JwksInfo struct {
 }
 
 const (
-	attrRequestHeader    = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
-	attrSrcIP            = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrSrcNamespace     = "source.namespace"       // e.g. "default".
-	attrSrcUser          = "source.user"            // source identity, e.g. "cluster.local/ns/default/sa/productpage".
-	attrSrcPrincipal     = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
-	attrRequestPrincipal = "request.auth.principal" // authenticated principal of the request.
-	attrRequestAudiences = "request.auth.audiences" // intended audience(s) for this authentication information.
-	attrRequestPresenter = "request.auth.presenter" // authorized presenter of the credential.
-	attrRequestClaims    = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
-	attrDestIP           = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrDestPort         = "destination.port"       // must be in the range [0, 65535].
-	attrDestLabel        = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
-	attrDestName         = "destination.name"       // short service name, e.g. "productpage".
-	attrDestNamespace    = "destination.namespace"  // e.g. "default".
-	attrDestUser         = "destination.user"       // service account, e.g. "bookinfo-productpage".
-	attrConnSNI          = "connection.sni"         // server name indication, e.g. "www.example.com".
-	attrExperimental     = "experimental.envoy.filters."
+	attrRequestHeader      = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
+	attrRequestHeaderRegex = "request.regex.headers"  // header regex is surrounded by brackets, e.g. "request.regex.headers[X-Random-.*]".
+	attrSrcIP              = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrSrcNamespace       = "source.namespace"       // e.g. "default".
+	attrSrcUser            = "source.user"            // source identity, e.g. "cluster.local/ns/default/sa/productpage".
+	attrSrcPrincipal       = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+	attrRequestPrincipal   = "request.auth.principal" // authenticated principal of the request.
+	attrRequestAudiences   = "request.auth.audiences" // intended audience(s) for this authentication information.
+	attrRequestPresenter   = "request.auth.presenter" // authorized presenter of the credential.
+	attrRequestClaims      = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
+	attrDestIP             = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrDestPort           = "destination.port"       // must be in the range [0, 65535].
+	attrDestLabel          = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
+	attrDestName           = "destination.name"       // short service name, e.g. "productpage".
+	attrDestNamespace      = "destination.namespace"  // e.g. "default".
+	attrDestUser           = "destination.user"       // service account, e.g. "bookinfo-productpage".
+	attrConnSNI            = "connection.sni"         // server name indication, e.g. "www.example.com".
+	attrExperimental       = "experimental.envoy.filters."
 )
 
 // ParseJwksURI parses the input URI and returns the corresponding hostname, port, and whether SSL is used.
@@ -92,6 +93,8 @@ func ParseJwksURI(jwksURI string) (JwksInfo, error) {
 func ValidateAttribute(key string, values []string) error {
 	switch {
 	case hasPrefix(key, attrRequestHeader):
+		return validateMapKey(key)
+	case hasPrefix(key, attrRequestHeaderRegex):
 		return validateMapKey(key)
 	case isEqual(key, attrSrcIP):
 		return validateIPs(values)


### PR DESCRIPTION
It would previously detect the field `request.regex.headers` as invalid, even though it is supported.

I'm adding a hold as this will only go into 1.1.8