### PR TITLE
[MAISTRA-1744] Add route annotation propagation

### DIFF
--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -160,7 +160,8 @@ func (r *route) deleteRoute(route *v1.Route) error {
 	return nil
 }
 
-func (r *route) createRoute(metadata model.ConfigMeta, gateway *networking.Gateway, originalHost string, tls bool, originalAnnotations map[string]string) error {
+func (r *route) createRoute(metadata model.ConfigMeta, gateway *networking.Gateway,
+	originalHost string, tls bool, originalAnnotations map[string]string) error {
 	var wildcard = v1.WildcardPolicyNone
 	actualHost := originalHost
 

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -190,15 +190,11 @@ func (r *route) createRoute(metadata model.ConfigMeta, gateway *networking.Gatew
 		return err
 	}
 
-	//Propagate annotations to allow for openshift-acme
-	//https://github.com/tnozicka/openshift-acme
 	annotations := map[string]string{
 		originalHostAnnotation: originalHost,
 	}
 	for keyName, keyValue := range originalAnnotations {
-		// avoid propagating kubectl config
 		if !strings.HasPrefix(keyName, "kubectl.kubernetes.io") {
-			// otherwise add to route annotation
 			annotations[keyName] = keyValue
 		}
 	}

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -92,7 +92,6 @@ func (r *route) syncGatewaysAndRoutes() error {
 
 	for _, cfg := range configs {
 		gateway := cfg.Spec.(*networking.Gateway)
-		annotations := cfg.ConfigMeta.Annotations
 		iorLog.Debugf("Found Gateway: %s/%s", cfg.Namespace, cfg.Name)
 
 		for _, server := range gateway.Servers {
@@ -101,7 +100,7 @@ func (r *route) syncGatewaysAndRoutes() error {
 				if ok {
 					r.editRoute(host)
 				} else {
-					result = multierror.Append(r.createRoute(cfg.ConfigMeta, gateway, host, server.Tls != nil, annotations))
+					result = multierror.Append(r.createRoute(cfg.ConfigMeta, gateway, host, server.Tls != nil))
 				}
 
 			}
@@ -160,8 +159,7 @@ func (r *route) deleteRoute(route *v1.Route) error {
 	return nil
 }
 
-func (r *route) createRoute(metadata model.ConfigMeta, gateway *networking.Gateway,
-	originalHost string, tls bool, originalAnnotations map[string]string) error {
+func (r *route) createRoute(metadata model.ConfigMeta, gateway *networking.Gateway, originalHost string, tls bool) error {
 	var wildcard = v1.WildcardPolicyNone
 	actualHost := originalHost
 
@@ -194,7 +192,7 @@ func (r *route) createRoute(metadata model.ConfigMeta, gateway *networking.Gatew
 	annotations := map[string]string{
 		originalHostAnnotation: originalHost,
 	}
-	for keyName, keyValue := range originalAnnotations {
+	for keyName, keyValue := range metadata.Annotations {
 		if !strings.HasPrefix(keyName, "kubectl.kubernetes.io") {
 			annotations[keyName] = keyValue
 		}


### PR DESCRIPTION
This adds route annotation propagation to generated Openshift routes from Istio gateways. currently only excluding annotations from `kubectl.kubernetes.io` to reduce confusion. Could be more keys we would want to ignore, I'm open to discuss. 

Changes allow use of https://github.com/tnozicka/openshift-acme specific annoations within Istio generated routes. 

https://issues.redhat.com/browse/MAISTRA-1744

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
