### PR TITLE
MAISTRA-1741 Store resourceVersions locally instead of returning them

### DIFF
--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -53,7 +53,8 @@ func setupMultiWatch(t *testing.T, namespaces []string, rvs map[string]string) (
 		t.Fatalf("failed to invoke List: %v", err)
 	}
 
-	if err := mlw.newMultiWatch(rvs, metav1.ListOptions{}); err != nil {
+	mlw.resourceVersions = rvs
+	if err := mlw.newMultiWatch(metav1.ListOptions{}); err != nil {
 		t.Fatalf("failed to create new multiWatch: %v", err)
 	}
 	return ws, mlw
@@ -215,7 +216,8 @@ func TestRacyMultiWatch(t *testing.T) {
 		return
 	}
 
-	if err := mlw.newMultiWatch(rsv, metav1.ListOptions{}); err != nil {
+	mlw.resourceVersions = rsv
+	if err := mlw.newMultiWatch(metav1.ListOptions{}); err != nil {
 		t.Error(err)
 		return
 	}


### PR DESCRIPTION
This will resolve the errors caused by changes in the cache reflector code. Returning resourceVersion "0" will make sure we're getting the latest object versions from cache when re-List()ing. When Watch()ing, we're injecting the stored resourceVersions we observed during List().

Note that this is merely a stop-gap solution that'll get things working again until we have a better implementation of MLW (or rather, an informer-based rewrite). Storing the resourceVersions is safe because we only do it while holding the mutex.