### PR TITLE
MAISTRA-1754 Set CNI container tag to 1.6-dev instead of latest

### DIFF
--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -39,7 +39,7 @@ components:
   cni:
      enabled: true
      hub: gcr.io/istio-testing
-     tag: latest
+     tag: 1.6-dev
      namespace: kube-system
 `
 		})).


### PR DESCRIPTION
This fixes the failing CNI integration test