### PR TITLE
Feature/ior routetermination

### DIFF
--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -240,16 +240,6 @@ func (r *route) createRoute(metadata model.ConfigMeta, gateway *networking.Gatew
 		}
 	}
 
-	// ior.pilot.maistra.io/TLSTerminationType = {VAL}
-	//   Allowed Values: {TLSTerminationEdge, TLSTerminationPassthrough, TLSTerminationReencrypt}
-
-	// ior.pilot.maistra.io/InsecureEdgeTerminationPolicyType = {VAL}
-	//   Allowed Values: {InsecureEdgeTerminationPolicyNone, InsecureEdgeTerminationPolicyAllow, InsecureEdgeTerminationPolicyRedirect}
-
-	// ior.pilot.maistra.io/TLSCertificateSecret = {VAL}
-	//   Allowed Values: {ANY} Will corrispond to a Secret in the secrets API Controller
-	//   Expected Secret Properties Expected: Certificate, Key, CACertificate, DestinationCACertificate
-
 	serviceNamespace, serviceName, err := r.findService(gateway)
 	if err != nil {
 		return err


### PR DESCRIPTION
This allows customization of the generated route based on annotation attached to the Istio gateway. 

Three annotations will be detected, definitions below.

In Reference to #168 

```

ior.pilot.maistra.io/TLSTerminationType = {VAL}
  Allowed Values: {TLSTerminationEdge, TLSTerminationPassthrough, TLSTerminationReencrypt}

ior.pilot.maistra.io/InsecureEdgeTerminationPolicyType = {VAL}
  Allowed Values: {InsecureEdgeTerminationPolicyNone, InsecureEdgeTerminationPolicyAllow, InsecureEdgeTerminationPolicyRedirect}

ior.pilot.maistra.io/TLSCertificateSecret = {VAL}
  Allowed Values: {ANY} Will corrispond to a Secret in the secrets API Controller
  Expected Secret Properties Expected: Certificate, Key, CACertificate, DestinationCACertificate

```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
