### PR TITLE
MAISTRA-1723: Allow disabling NodePort gateway support

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -149,6 +149,8 @@ func init() {
 	if err := discoveryCmd.PersistentFlags().MarkDeprecated("appNamespace", "please use ${APP_NAMESPACE} environment variable instead"); err != nil {
 		panic(err)
 	}
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.Config.ControllerOptions.EnableNodePortGateways, "enableNodePortGateways",
+		true, "Whether to watch nodes and advertise their addresses as endpoints for gateways with NodePort services")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.PodLocalitySource, "podLocalitySource", "",
 		"node", "Specify where the controller should obtain the Pod's zone and region from (the pod's node or the pod itself)")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.MemberRollName, "memberRollName", "", "",


### PR DESCRIPTION
This adds an option to istiod that can disable the support for
NodePort gateways.  With this disabled, istiod will not create an
informer for Node objects, which removes the need for cluster-wide
read permissions on these.
