### PR TITLE
MAISTRA-1873 Properly delete extensions from store when they disappear

### DIFF
--- a/pkg/servicemesh/controller/extension/controller.go
+++ b/pkg/servicemesh/controller/extension/controller.go
@@ -108,7 +108,7 @@ func NewControllerFromConfigFile(kubeConfig string, namespaces []string, mrc mem
 						return
 					}
 				}
-				store[extension.Namespace+"/"+extension.Name] = nil
+				delete(store, extension.Namespace+"/"+extension.Name)
 				log.Infof("Deleted extension %s/%s", extension.Namespace, extension.Name)
 			},
 		})


### PR DESCRIPTION
Previously, this would lead to the GetExtensions() call returning a slice including `nil` values