### PR TITLE
MAISTRA-1862 Fix NilPointerException when images can't be pulled

### DIFF
--- a/mec/pkg/model/types.go
+++ b/mec/pkg/model/types.go
@@ -45,11 +45,10 @@ const (
 )
 
 func (i *ImageRef) String() string {
-	tag := i.Tag
 	if i.SHA256 != "" {
-		tag = fmt.Sprintf("sha256:%s", i.SHA256)
+		return fmt.Sprintf("%s/%s@sha256:%s", i.Hub, i.Repository, i.SHA256)
 	}
-	return fmt.Sprintf("%s/%s:%s", i.Hub, i.Repository, tag)
+	return fmt.Sprintf("%s/%s:%s", i.Hub, i.Repository, i.Tag)
 }
 
 func StringToImageRef(ref string) *ImageRef {

--- a/mec/pkg/server/worker.go
+++ b/mec/pkg/server/worker.go
@@ -88,8 +88,15 @@ func (w *Worker) processEvent(event ExtensionEvent) {
 		imageRef.SHA256 = extension.Status.Deployment.ContainerSHA256
 	}
 
-	img, err := w.pullStrategy.GetImage(imageRef)
-	if err != nil {
+	var img model.Image
+	var err error
+	if imageRef.SHA256 != "" {
+		img, err = w.pullStrategy.GetImage(imageRef)
+		if err != nil {
+			log.Errorf("Failed to check whether image is already present: %s", err)
+		}
+	}
+	if img == nil {
 		log.Infof("Image %s not present. Pulling", imageRef.String())
 		img, err = w.pullStrategy.PullImage(imageRef)
 		if err != nil {


### PR DESCRIPTION
This also improves logging by dropping some loglevels and always logging errors when calling pullStrategy.GetImage()
