### PR TITLE
MAISTRA-1897: Allow disabling IngressClass support

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -151,6 +151,8 @@ func init() {
 	}
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.Config.ControllerOptions.EnableNodePortGateways, "enableNodePortGateways",
 		true, "Whether to watch nodes and advertise their addresses as endpoints for gateways with NodePort services")
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.Config.ControllerOptions.EnableIngressClassName, "enableIngressClassName",
+		true, "Whether support processing Ingress resources that use the new ingressClassName field in their spec")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.PodLocalitySource, "podLocalitySource", "",
 		"node", "Specify where the controller should obtain the Pod's zone and region from (the pod's node or the pod itself)")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.MemberRollName, "memberRollName", "", "",

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -160,7 +160,7 @@ func NewController(client kubernetes.Interface, mrc meshcontroller.Controller, m
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
 	var classes *v1beta1.IngressClassInformer
-	if ingressClassSupported(client) {
+	if options.EnableIngressClassName && ingressClassSupported(client) {
 		sharedInformers := informers.NewSharedInformerFactory(client, options.ResyncPeriod)
 		i := sharedInformers.Networking().V1beta1().IngressClasses()
 		classes = &i

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -152,6 +152,12 @@ type Options struct {
 	// to allow gateways to advertise the node IP addresses as their endpoints,
 	// but requires istiod have cluster read permissions on nodes.
 	EnableNodePortGateways bool
+
+	// EnableIngressClassName determines whether the controller will support
+	// processing Kubernetes Ingress resources that use the new (as of 1.18)
+	// `ingressClassName` in their spec, or if it will only check the deprecated
+	// `kubernetes.io/ingress.class` annotation.
+	EnableIngressClassName bool
 }
 
 // EndpointMode decides what source to use to get endpoint information


### PR DESCRIPTION
This adds an option to istiod that allows disabling reading
IngressClass resources, which are cluster-scoped.  When this is
disabled, processing of Ingress resources that use the new (as of
Kubernetes v1.18) `ingressClassName` field in their spec is not
supported.  Only resources that use the deprecated annotation will be
processed.