### PR TITLE
MAISTRA-1908: Fix tombstone handling in endpoints controller

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -238,7 +238,7 @@ func (e *endpointsController) onEvent(curr interface{}, event model.Event) error
 		}
 	}
 
-	return e.handleEvent(ep.Name, ep.Namespace, event, curr, func(obj interface{}, event model.Event) {
+	return e.handleEvent(ep.Name, ep.Namespace, event, ep, func(obj interface{}, event model.Event) {
 		ep := obj.(*v1.Endpoints)
 		e.c.updateEDS(ep, event)
 	})

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -172,7 +172,7 @@ func (esc *endpointSliceController) onEvent(curr interface{}, event model.Event)
 		}
 	}
 
-	return esc.handleEvent(ep.Labels[discoveryv1alpha1.LabelServiceName], ep.Namespace, event, curr, func(obj interface{}, event model.Event) {
+	return esc.handleEvent(ep.Labels[discoveryv1alpha1.LabelServiceName], ep.Namespace, event, ep, func(obj interface{}, event model.Event) {
 		esc.updateEDS(obj, event)
 	})
 }


### PR DESCRIPTION
It looks like the endpoints controller was going to the trouble of
detecting tombstones and retrieving the object, but then passing the
unconverted interface object to the handler, which would fail if the
passed object was a tombstone.  Unfortunately, it seems pretty hard to
test this case in the current framework.  This has all been rewritten
in upstream Istio.