### PR TITLE
MAISTRA-1967: Fix private destination rules in root namespace

### DIFF
--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -18,15 +18,24 @@ import (
 	"fmt"
 
 	networking "istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/pkg/config/visibility"
 )
 
 // This function merges one or more destination rules for a given host string
 // into a single destination rule. Note that it does not perform inheritance style merging.
 // IOW, given three dest rules (*.foo.com, *.foo.com, *.com), calling this function for
 // each config will result in a final dest rule set (*.foo.com, and *.com).
-func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig Config) {
+//
+// The following is the merge logic:
+// 1. Unique subsets (based on subset name) are concatenated to the original rule's list of subsets
+// 2. If the original rule did not have any top level traffic policy, traffic policies from the new rule will be
+// used.
+// 3. If the original rule did not have any exportTo, exportTo settings from the new rule will be used.
+func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig Config, exportToMap map[visibility.Instance]bool) {
 	rule := destRuleConfig.Spec.(*networking.DestinationRule)
 	resolvedHost := ResolveShortnameToFQDN(rule.Host, destRuleConfig.ConfigMeta)
+
 	if mdr, exists := p.destRule[resolvedHost]; exists {
 		// Deep copy destination rule, to prevent mutate it later when merge with a new one.
 		// This can happen when there are more than one destination rule of same host in one namespace.
@@ -39,6 +48,8 @@ func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfi
 		}
 		// we have an another destination rule for same host.
 		// concatenate both of them -- essentially add subsets from one to other.
+		// Note: we only add the subsets and do not overwrite anything else like exportTo or top level
+		// traffic policies if they already exist
 		for _, subset := range rule.Subsets {
 			if _, ok := existingSubset[subset.Name]; !ok {
 				// if not duplicated, append
@@ -56,10 +67,18 @@ func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfi
 		if mergedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
 			mergedRule.TrafficPolicy = rule.TrafficPolicy
 		}
+
+		// If there is no exportTo in the existing rule and
+		// the incoming rule has an explicit exportTo, use the
+		// one from the incoming rule.
+		if len(p.exportTo[resolvedHost]) == 0 && len(exportToMap) > 0 {
+			p.exportTo[resolvedHost] = exportToMap
+		}
 		return
 	}
 
 	// DestinationRule does not exist for the resolved host so add it
 	p.hosts = append(p.hosts, resolvedHost)
 	p.destRule[resolvedHost] = &destRuleConfig
+	p.exportTo[resolvedHost] = exportToMap
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -105,6 +105,7 @@ type PushContext struct {
 	//  exportedDestRulesByNamespace: all dest rules pertaining to a service exported by a namespace
 	namespaceLocalDestRules      map[string]*processedDestRules
 	exportedDestRulesByNamespace map[string]*processedDestRules
+	rootNamespaceLocalDestRules  *processedDestRules
 
 	// clusterLocalHosts extracted from the MeshConfig
 	clusterLocalHosts host.Names
@@ -748,6 +749,14 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 				return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[hostname]
 			}
 		}
+	} else {
+		// If this is a namespace local DR in the same namespace, this must be meant for this proxy, so we do not
+		// need to worry about overriding other DRs with *.local type rules here. If we ignore this, then exportTo=. in
+		// root namespace would always be ignored
+		if hostname, ok := MostSpecificHostMatch(service.Hostname,
+			ps.rootNamespaceLocalDestRules.hosts); ok {
+			return ps.rootNamespaceLocalDestRules.destRule[hostname]
+		}
 	}
 
 	// 2. select destination rule from service namespace
@@ -775,7 +784,6 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 
 	// 4. if no public/private rule in calling proxy's namespace matched, and no public rule in the
 	// target service's namespace matched, search for any exported destination rule in the config root namespace
-	// NOTE: This does mean that we are effectively ignoring private dest rules in the config root namespace
 	if out := ps.getExportedDestinationRuleFromNamespace(ps.Mesh.RootNamespace, service.Hostname, proxy.ConfigNamespace); out != nil {
 		return out
 	}
@@ -993,6 +1001,7 @@ func (ps *PushContext) updateContext(
 	} else {
 		ps.namespaceLocalDestRules = oldPushContext.namespaceLocalDestRules
 		ps.exportedDestRulesByNamespace = oldPushContext.exportedDestRulesByNamespace
+		ps.rootNamespaceLocalDestRules = oldPushContext.rootNamespaceLocalDestRules
 	}
 
 	if authnChanged {
@@ -1399,6 +1408,14 @@ func (ps *PushContext) initDestinationRules(env *Environment) error {
 	return nil
 }
 
+func newProcessedDestRules() *processedDestRules {
+	return &processedDestRules{
+		hosts:    make([]host.Name, 0),
+		exportTo: map[host.Name]map[visibility.Instance]bool{},
+		destRule: map[host.Name]*Config{},
+	}
+}
+
 // SetDestinationRules is updates internal structures using a set of configs.
 // Split out of DestinationRule expensive conversions, computed once per push.
 // This also allows tests to inject a config without having the mock.
@@ -1409,6 +1426,7 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 	sortConfigByCreationTime(configs)
 	namespaceLocalDestRules := make(map[string]*processedDestRules)
 	exportedDestRulesByNamespace := make(map[string]*processedDestRules)
+	rootNamespaceLocalDestRules := newProcessedDestRules()
 
 	for i := range configs {
 		rule := configs[i].Spec.(*networking.DestinationRule)
@@ -1425,11 +1443,7 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 			// a proxy from this namespace will first look here for the destination rule for a given service
 			// This pool consists of both public/private destination rules.
 			if _, exist := namespaceLocalDestRules[configs[i].Namespace]; !exist {
-				namespaceLocalDestRules[configs[i].Namespace] = &processedDestRules{
-					hosts:    make([]host.Name, 0),
-					exportTo: map[host.Name]map[visibility.Instance]bool{},
-					destRule: map[host.Name]*Config{},
-				}
+				namespaceLocalDestRules[configs[i].Namespace] = newProcessedDestRules()
 			}
 			// Merge this destination rule with any public/private dest rules for same host in the same namespace
 			// If there are no duplicates, the dest rule will be added to the list
@@ -1447,15 +1461,14 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 
 		if !isPrivateOnly {
 			if _, exist := exportedDestRulesByNamespace[configs[i].Namespace]; !exist {
-				exportedDestRulesByNamespace[configs[i].Namespace] = &processedDestRules{
-					hosts:    make([]host.Name, 0),
-					exportTo: map[host.Name]map[visibility.Instance]bool{},
-					destRule: map[host.Name]*Config{},
-				}
+				exportedDestRulesByNamespace[configs[i].Namespace] = newProcessedDestRules()
 			}
 			// Merge this destination rule with any other exported dest rule for the same host in the same namespace
 			// If there are no duplicates, the dest rule will be added to the list
 			ps.mergeDestinationRule(exportedDestRulesByNamespace[configs[i].Namespace], configs[i], exportToMap)
+		} else if configs[i].Namespace == ps.Mesh.RootNamespace {
+			// Keep track of private root namespace destination rules
+			ps.mergeDestinationRule(rootNamespaceLocalDestRules, configs[i], exportToMap)
 		}
 	}
 
@@ -1470,6 +1483,7 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 
 	ps.namespaceLocalDestRules = namespaceLocalDestRules
 	ps.exportedDestRulesByNamespace = exportedDestRulesByNamespace
+	ps.rootNamespaceLocalDestRules = rootNamespaceLocalDestRules
 }
 
 func (ps *PushContext) initAuthorizationPolicies(env *Environment) error {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -74,10 +74,14 @@ type PushContext struct {
 	// Service related
 	// TODO: move to a sub struct
 
-	// privateServices are reachable within the same namespace.
+	// privateServices are reachable within the same namespace, with exportTo "."
 	privateServicesByNamespace map[string][]*Service
-	// publicServices are services reachable within the mesh.
+	// publicServices are services reachable within the mesh with exportTo "*"
 	publicServices []*Service
+	// servicesExportedToNamespace are services that were made visible to this namespace
+	// by an exportTo explicitly specifying this namespace.
+	servicesExportedToNamespace map[string][]*Service
+
 	// ServiceByHostnameAndNamespace has all services, indexed by hostname then namespace.
 	ServiceByHostnameAndNamespace map[host.Name]map[string]*Service `json:"-"`
 	// ServiceAccounts contains a map of hostname and port to service accounts.
@@ -88,14 +92,19 @@ type PushContext struct {
 	QuotaSpecBinding []Config `json:"-"`
 
 	// VirtualService related
+	// this contains all the virtual services with exportTo "." and current namespace
 	privateVirtualServicesByNamespace map[string][]Config
-	publicVirtualServices             []Config
+	// This contains all virtual services visible to this namespace extracted from
+	// exportTos that explicitly contained this namespace.
+	virtualServicesExportedToNamespace map[string][]Config
+	// This contains all virtual services whose exportTo is "*"
+	publicVirtualServices []Config
 
-	// destination rules are of two types:
+	// destination rules are of three types:
 	//  namespaceLocalDestRules: all public/private dest rules pertaining to a service defined in a given namespace
-	//  namespaceExportedDestRules: all public dest rules pertaining to a service defined in a namespace
-	namespaceLocalDestRules    map[string]*processedDestRules
-	namespaceExportedDestRules map[string]*processedDestRules
+	//  exportedDestRulesByNamespace: all dest rules pertaining to a service exported by a namespace
+	namespaceLocalDestRules      map[string]*processedDestRules
+	exportedDestRulesByNamespace map[string]*processedDestRules
 
 	// clusterLocalHosts extracted from the MeshConfig
 	clusterLocalHosts host.Names
@@ -153,6 +162,8 @@ type Gateway struct {
 type processedDestRules struct {
 	// List of dest rule hosts. We match with the most specific host first
 	hosts []host.Name
+	// Map of dest rule host to the list of namespaces to which this destination rule has been exported to
+	exportTo map[host.Name]map[visibility.Instance]bool
 	// Map of dest rule host and the merged destination rules for that host
 	destRule map[host.Name]*Config
 }
@@ -448,19 +459,21 @@ func init() {
 func NewPushContext() *PushContext {
 	// TODO: detect push in progress, don't update status if set
 	return &PushContext{
-		publicServices:                    []*Service{},
-		privateServicesByNamespace:        map[string][]*Service{},
-		publicVirtualServices:             []Config{},
-		privateVirtualServicesByNamespace: map[string][]Config{},
-		namespaceLocalDestRules:           map[string]*processedDestRules{},
-		namespaceExportedDestRules:        map[string]*processedDestRules{},
-		sidecarsByNamespace:               map[string][]*SidecarScope{},
-		envoyFiltersByNamespace:           map[string][]*EnvoyFilterWrapper{},
-		gatewaysByNamespace:               map[string][]Config{},
-		allGateways:                       []Config{},
-		ServiceByHostnameAndNamespace:     map[host.Name]map[string]*Service{},
-		ProxyStatus:                       map[string]map[string]ProxyPushStatus{},
-		ServiceAccounts:                   map[host.Name]map[int][]string{},
+		publicServices:                     []*Service{},
+		privateServicesByNamespace:         map[string][]*Service{},
+		servicesExportedToNamespace:        map[string][]*Service{},
+		publicVirtualServices:              []Config{},
+		privateVirtualServicesByNamespace:  map[string][]Config{},
+		virtualServicesExportedToNamespace: map[string][]Config{},
+		namespaceLocalDestRules:            map[string]*processedDestRules{},
+		exportedDestRulesByNamespace:       map[string]*processedDestRules{},
+		sidecarsByNamespace:                map[string][]*SidecarScope{},
+		envoyFiltersByNamespace:            map[string][]*EnvoyFilterWrapper{},
+		gatewaysByNamespace:                map[string][]Config{},
+		allGateways:                        []Config{},
+		ServiceByHostnameAndNamespace:      map[host.Name]map[string]*Service{},
+		ProxyStatus:                        map[string]map[string]ProxyPushStatus{},
+		ServiceAccounts:                    map[host.Name]map[int][]string{},
 	}
 }
 
@@ -587,13 +600,14 @@ func (ps *PushContext) Services(proxy *Proxy) []*Service {
 
 	out := make([]*Service, 0)
 
-	// First add private services
+	// First add private services and explicitly exportedTo services
 	if proxy == nil {
 		for _, privateServices := range ps.privateServicesByNamespace {
 			out = append(out, privateServices...)
 		}
 	} else {
 		out = append(out, ps.privateServicesByNamespace[proxy.ConfigNamespace]...)
+		out = append(out, ps.servicesExportedToNamespace[proxy.ConfigNamespace]...)
 	}
 
 	// Second add public services
@@ -610,15 +624,16 @@ func (ps *PushContext) VirtualServices(proxy *Proxy, gateways map[string]bool) [
 	out := make([]Config, 0)
 
 	// filter out virtual services not reachable
-	// First private virtual service
+	// First add private virtual services and explicitly exportedTo virtual services
 	if proxy == nil {
 		for _, virtualSvcs := range ps.privateVirtualServicesByNamespace {
 			configs = append(configs, virtualSvcs...)
 		}
 	} else {
 		configs = append(configs, ps.privateVirtualServicesByNamespace[proxy.ConfigNamespace]...)
+		configs = append(configs, ps.virtualServicesExportedToNamespace[proxy.ConfigNamespace]...)
 	}
-	// Second public virtual service
+	// Second add public virtual services.
 	configs = append(configs, ps.publicVirtualServices...)
 
 	for _, cfg := range configs {
@@ -739,7 +754,7 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 	svcNs := service.Attributes.Namespace
 
 	// This can happen when finding the subset labels for a proxy in root namespace.
-	// Because based on a pure cluster name, we do not know the service and
+	// Because based on a pure cluster's fqdn, we do not know the service and
 	// construct a fake service without setting Attributes at all.
 	if svcNs == "" {
 		for _, svc := range ps.Services(proxy) {
@@ -751,24 +766,33 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 	}
 
 	// 3. if no private/public rule matched in the calling proxy's namespace,
-	// check the target service's namespace for public rules
-	if svcNs != "" && ps.namespaceExportedDestRules[svcNs] != nil {
-		if hostname, ok := MostSpecificHostMatch(service.Hostname,
-			ps.namespaceExportedDestRules[svcNs].hosts); ok {
-			return ps.namespaceExportedDestRules[svcNs].destRule[hostname]
+	// check the target service's namespace for exported rules
+	if svcNs != "" {
+		if out := ps.getExportedDestinationRuleFromNamespace(svcNs, service.Hostname, proxy.ConfigNamespace); out != nil {
+			return out
 		}
 	}
 
 	// 4. if no public/private rule in calling proxy's namespace matched, and no public rule in the
-	// target service's namespace matched, search for any public destination rule in the config root namespace
+	// target service's namespace matched, search for any exported destination rule in the config root namespace
 	// NOTE: This does mean that we are effectively ignoring private dest rules in the config root namespace
-	if ps.namespaceExportedDestRules[ps.Mesh.RootNamespace] != nil {
-		if hostname, ok := MostSpecificHostMatch(service.Hostname,
-			ps.namespaceExportedDestRules[ps.Mesh.RootNamespace].hosts); ok {
-			return ps.namespaceExportedDestRules[ps.Mesh.RootNamespace].destRule[hostname]
-		}
+	if out := ps.getExportedDestinationRuleFromNamespace(ps.Mesh.RootNamespace, service.Hostname, proxy.ConfigNamespace); out != nil {
+		return out
 	}
 
+	return nil
+}
+
+func (ps *PushContext) getExportedDestinationRuleFromNamespace(owningNamespace string, hostname host.Name, clientNamespace string) *Config {
+	if ps.exportedDestRulesByNamespace[owningNamespace] != nil {
+		if specificHostname, ok := MostSpecificHostMatch(hostname, ps.exportedDestRulesByNamespace[owningNamespace].hosts); ok {
+			// Check if the dest rule for this host is actually exported to the proxy's (client) namespace
+			exportToMap := ps.exportedDestRulesByNamespace[owningNamespace].exportTo[specificHostname]
+			if len(exportToMap) == 0 || exportToMap[visibility.Public] || exportToMap[visibility.Instance(clientNamespace)] {
+				return ps.exportedDestRulesByNamespace[owningNamespace].destRule[specificHostname]
+			}
+		}
+	}
 	return nil
 }
 
@@ -946,6 +970,7 @@ func (ps *PushContext) updateContext(
 		}
 	} else {
 		ps.privateServicesByNamespace = oldPushContext.privateServicesByNamespace
+		ps.servicesExportedToNamespace = oldPushContext.servicesExportedToNamespace
 		ps.publicServices = oldPushContext.publicServices
 		ps.ServiceByHostnameAndNamespace = oldPushContext.ServiceByHostnameAndNamespace
 		ps.ServiceAccounts = oldPushContext.ServiceAccounts
@@ -957,6 +982,7 @@ func (ps *PushContext) updateContext(
 		}
 	} else {
 		ps.privateVirtualServicesByNamespace = oldPushContext.privateVirtualServicesByNamespace
+		ps.virtualServicesExportedToNamespace = oldPushContext.virtualServicesExportedToNamespace
 		ps.publicVirtualServices = oldPushContext.publicVirtualServices
 	}
 
@@ -966,7 +992,7 @@ func (ps *PushContext) updateContext(
 		}
 	} else {
 		ps.namespaceLocalDestRules = oldPushContext.namespaceLocalDestRules
-		ps.namespaceExportedDestRules = oldPushContext.namespaceExportedDestRules
+		ps.exportedDestRulesByNamespace = oldPushContext.exportedDestRulesByNamespace
 	}
 
 	if authnChanged {
@@ -1048,10 +1074,25 @@ func (ps *PushContext) initServiceRegistry(env *Environment) error {
 				ps.publicServices = append(ps.publicServices, s)
 			}
 		} else {
-			if s.Attributes.ExportTo[visibility.Private] {
-				ps.privateServicesByNamespace[ns] = append(ps.privateServicesByNamespace[ns], s)
-			} else {
+			// if service has exportTo ~ - i.e. not visible to anyone, ignore all exportTos
+			// if service has exportTo *, make public and ignore all other exportTos
+			// if service has exportTo ., replace with current namespace
+			if s.Attributes.ExportTo[visibility.Public] {
 				ps.publicServices = append(ps.publicServices, s)
+				continue
+			} else if s.Attributes.ExportTo[visibility.None] {
+				continue
+			} else {
+				// . or other namespaces
+				for exportTo := range s.Attributes.ExportTo {
+					if exportTo == visibility.Private || string(exportTo) == ns {
+						// exportTo with same namespace is effectively private
+						ps.privateServicesByNamespace[ns] = append(ps.privateServicesByNamespace[ns], s)
+					} else {
+						// exportTo is a specific target namespace
+						ps.servicesExportedToNamespace[string(exportTo)] = append(ps.servicesExportedToNamespace[string(exportTo)], s)
+					}
+				}
 			}
 		}
 		if _, f := ps.ServiceByHostnameAndNamespace[s.Hostname]; !f {
@@ -1102,6 +1143,7 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) error {
 // Caches list of virtual services
 func (ps *PushContext) initVirtualServices(env *Environment) error {
 	ps.privateVirtualServicesByNamespace = map[string][]Config{}
+	ps.virtualServicesExportedToNamespace = map[string][]Config{}
 	ps.publicVirtualServices = []Config{}
 	virtualServices, err := env.List(collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(), NamespaceAll)
 	if err != nil {
@@ -1124,7 +1166,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 	// the RDS code. See separateVSHostsAndServices in route/route.go
 	sortConfigByCreationTime(vservices)
 
-	vservices = mergeVirtualServicesIfNeeded(vservices)
+	vservices = mergeVirtualServicesIfNeeded(vservices, ps.defaultVirtualServiceExportTo)
 
 	// convert all shortnames in virtual services into FQDNs
 	for _, r := range vservices {
@@ -1194,23 +1236,41 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 		rule := virtualService.Spec.(*networking.VirtualService)
 		if len(rule.ExportTo) == 0 {
 			// No exportTo in virtualService. Use the global default
-			// TODO: We currently only honor ., * and ~
+			// We only honor ., *
 			if ps.defaultVirtualServiceExportTo[visibility.Private] {
 				// add to local namespace only
-				ps.privateVirtualServicesByNamespace[ns] = append(ps.privateVirtualServicesByNamespace[ns], virtualService)
+				ps.privateVirtualServicesByNamespace[ns] =
+					append(ps.privateVirtualServicesByNamespace[ns], virtualService)
 			} else if ps.defaultVirtualServiceExportTo[visibility.Public] {
 				ps.publicVirtualServices = append(ps.publicVirtualServices, virtualService)
 			}
 		} else {
-			// TODO: we currently only process the first element in the array
-			// and currently only consider . or * which maps to public/private
-			if visibility.Instance(rule.ExportTo[0]) == visibility.Private {
-				// add to local namespace only
-				ps.privateVirtualServicesByNamespace[ns] = append(ps.privateVirtualServicesByNamespace[ns], virtualService)
-			} else {
-				// ~ is not valid in the exportTo fields in virtualServices, services, destination rules
-				// and we currently only allow . or *. So treat this as public export
+			exportToMap := make(map[visibility.Instance]bool)
+			for _, e := range rule.ExportTo {
+				exportToMap[visibility.Instance(e)] = true
+			}
+			// if vs has exportTo ~ - i.e. not visible to anyone, ignore all exportTos
+			// if vs has exportTo *, make public and ignore all other exportTos
+			// if vs has exportTo ., replace with current namespace
+			if exportToMap[visibility.Public] {
 				ps.publicVirtualServices = append(ps.publicVirtualServices, virtualService)
+				continue
+			} else if exportToMap[visibility.None] {
+				// not possible
+				continue
+			} else {
+				// . or other namespaces
+				for exportTo := range exportToMap {
+					if exportTo == visibility.Private || string(exportTo) == ns {
+						// exportTo with same namespace is effectively private
+						ps.privateVirtualServicesByNamespace[ns] =
+							append(ps.privateVirtualServicesByNamespace[ns], virtualService)
+					} else {
+						// exportTo is a specific target namespace
+						ps.virtualServicesExportedToNamespace[string(exportTo)] =
+							append(ps.virtualServicesExportedToNamespace[string(exportTo)], virtualService)
+					}
+				}
 			}
 		}
 	}
@@ -1348,52 +1408,54 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 	// we take the first one.
 	sortConfigByCreationTime(configs)
 	namespaceLocalDestRules := make(map[string]*processedDestRules)
-	namespaceExportedDestRules := make(map[string]*processedDestRules)
+	exportedDestRulesByNamespace := make(map[string]*processedDestRules)
 
 	for i := range configs {
 		rule := configs[i].Spec.(*networking.DestinationRule)
 		rule.Host = string(ResolveShortnameToFQDN(rule.Host, configs[i].ConfigMeta))
-		// Store in an index for the config's namespace
-		// a proxy from this namespace will first look here for the destination rule for a given service
-		// This pool consists of both public/private destination rules.
-		// TODO: when exportTo is fully supported, only add the rule here if exportTo is '.'
+		exportToMap := make(map[visibility.Instance]bool)
+		for _, e := range rule.ExportTo {
+			exportToMap[visibility.Instance(e)] = true
+		}
+		// add only if the dest rule is exported with . or * or explicit exportTo containing this namespace
 		// The global exportTo doesn't matter here (its either . or * - both of which are applicable here)
-		if _, exist := namespaceLocalDestRules[configs[i].Namespace]; !exist {
-			namespaceLocalDestRules[configs[i].Namespace] = &processedDestRules{
-				hosts:    make([]host.Name, 0),
-				destRule: map[host.Name]*Config{},
-			}
-		}
-		// Merge this destination rule with any public/private dest rules for same host in the same namespace
-		// If there are no duplicates, the dest rule will be added to the list
-		ps.mergeDestinationRule(namespaceLocalDestRules[configs[i].Namespace], configs[i])
-		isPubliclyExported := false
-		if len(rule.ExportTo) == 0 {
-			// No exportTo in destinationRule. Use the global default
-			// TODO: We currently only honor ., * and ~
-			if ps.defaultDestinationRuleExportTo[visibility.Public] {
-				isPubliclyExported = true
-			}
-		} else {
-			// TODO: we currently only process the first element in the array
-			// and currently only consider . or * which maps to public/private
-			if visibility.Instance(rule.ExportTo[0]) != visibility.Private {
-				// ~ is not valid in the exportTo fields in virtualServices, services, destination rules
-				// and we currently only allow . or *. So treat this as public export
-				isPubliclyExported = true
-			}
-		}
-
-		if isPubliclyExported {
-			if _, exist := namespaceExportedDestRules[configs[i].Namespace]; !exist {
-				namespaceExportedDestRules[configs[i].Namespace] = &processedDestRules{
+		if len(exportToMap) == 0 || exportToMap[visibility.Public] || exportToMap[visibility.Private] ||
+			exportToMap[visibility.Instance(configs[i].Namespace)] {
+			// Store in an index for the config's namespace
+			// a proxy from this namespace will first look here for the destination rule for a given service
+			// This pool consists of both public/private destination rules.
+			if _, exist := namespaceLocalDestRules[configs[i].Namespace]; !exist {
+				namespaceLocalDestRules[configs[i].Namespace] = &processedDestRules{
 					hosts:    make([]host.Name, 0),
+					exportTo: map[host.Name]map[visibility.Instance]bool{},
 					destRule: map[host.Name]*Config{},
 				}
 			}
-			// Merge this destination rule with any public dest rule for the same host in the same namespace
+			// Merge this destination rule with any public/private dest rules for same host in the same namespace
 			// If there are no duplicates, the dest rule will be added to the list
-			ps.mergeDestinationRule(namespaceExportedDestRules[configs[i].Namespace], configs[i])
+			ps.mergeDestinationRule(namespaceLocalDestRules[configs[i].Namespace], configs[i], exportToMap)
+		}
+
+		isPrivateOnly := false
+		// No exportTo in destinationRule. Use the global default
+		// We only honor . and *
+		if len(rule.ExportTo) == 0 && ps.defaultDestinationRuleExportTo[visibility.Private] {
+			isPrivateOnly = true
+		} else if len(rule.ExportTo) == 1 && exportToMap[visibility.Private] {
+			isPrivateOnly = true
+		}
+
+		if !isPrivateOnly {
+			if _, exist := exportedDestRulesByNamespace[configs[i].Namespace]; !exist {
+				exportedDestRulesByNamespace[configs[i].Namespace] = &processedDestRules{
+					hosts:    make([]host.Name, 0),
+					exportTo: map[host.Name]map[visibility.Instance]bool{},
+					destRule: map[host.Name]*Config{},
+				}
+			}
+			// Merge this destination rule with any other exported dest rule for the same host in the same namespace
+			// If there are no duplicates, the dest rule will be added to the list
+			ps.mergeDestinationRule(exportedDestRulesByNamespace[configs[i].Namespace], configs[i], exportToMap)
 		}
 	}
 
@@ -1402,12 +1464,12 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 	for ns := range namespaceLocalDestRules {
 		sort.Sort(host.Names(namespaceLocalDestRules[ns].hosts))
 	}
-	for ns := range namespaceExportedDestRules {
-		sort.Sort(host.Names(namespaceExportedDestRules[ns].hosts))
+	for ns := range exportedDestRulesByNamespace {
+		sort.Sort(host.Names(exportedDestRulesByNamespace[ns].hosts))
 	}
 
 	ps.namespaceLocalDestRules = namespaceLocalDestRules
-	ps.namespaceExportedDestRules = namespaceExportedDestRules
+	ps.exportedDestRulesByNamespace = exportedDestRulesByNamespace
 }
 
 func (ps *PushContext) initAuthorizationPolicies(env *Environment) error {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -524,8 +524,26 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 			},
 		},
 	}
+	destinationRuleRootNamespaceLocal := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule1",
+			Namespace: "istio-system",
+		},
+		Spec: &networking.DestinationRule{
+			Host:     testhost,
+			ExportTo: []string{"."},
+			Subsets: []*networking.Subset{
+				{
+					Name: "subset9",
+				},
+				{
+					Name: "subset10",
+				},
+			},
+		},
+	}
 	ps.SetDestinationRules([]Config{destinationRuleNamespace1, destinationRuleNamespace2,
-		destinationRuleNamespace3, destinationRuleRootNamespace})
+		destinationRuleNamespace3, destinationRuleRootNamespace, destinationRuleRootNamespaceLocal})
 	cases := []struct {
 		proxyNs     string
 		serviceNs   string
@@ -571,21 +589,33 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 			serviceNs:   "random",
 			wantSubsets: []string{"subset5", "subset6"},
 		},
+		{
+			proxyNs:     "istio-system",
+			serviceNs:   "random",
+			wantSubsets: []string{"subset9", "subset10"},
+		},
+		{
+			proxyNs:     "istio-system",
+			serviceNs:   "istio-system",
+			wantSubsets: []string{"subset9", "subset10"},
+		},
 	}
 	for _, tt := range cases {
-		destRuleConfig := ps.DestinationRule(&Proxy{ConfigNamespace: tt.proxyNs},
-			&Service{Hostname: host.Name(testhost), Attributes: ServiceAttributes{Namespace: tt.serviceNs}})
-		if destRuleConfig == nil {
-			t.Fatalf("proxy in %s namespace: dest rule is nil, expected subsets %+v", tt.proxyNs, tt.wantSubsets)
-		}
-		destRule := destRuleConfig.Spec.(*networking.DestinationRule)
-		var gotSubsets []string
-		for _, ss := range destRule.Subsets {
-			gotSubsets = append(gotSubsets, ss.Name)
-		}
-		if !reflect.DeepEqual(gotSubsets, tt.wantSubsets) {
-			t.Fatalf("proxy in %s namespace: want %+v, got %+v", tt.proxyNs, tt.wantSubsets, gotSubsets)
-		}
+		t.Run(fmt.Sprintf("%s-%s", tt.proxyNs, tt.serviceNs), func(t *testing.T) {
+			destRuleConfig := ps.DestinationRule(&Proxy{ConfigNamespace: tt.proxyNs},
+				&Service{Hostname: host.Name(testhost), Attributes: ServiceAttributes{Namespace: tt.serviceNs}})
+			if destRuleConfig == nil {
+				t.Fatalf("proxy in %s namespace: dest rule is nil, expected subsets %+v", tt.proxyNs, tt.wantSubsets)
+			}
+			destRule := destRuleConfig.Spec.(*networking.DestinationRule)
+			var gotSubsets []string
+			for _, ss := range destRule.Subsets {
+				gotSubsets = append(gotSubsets, ss.Name)
+			}
+			if !reflect.DeepEqual(gotSubsets, tt.wantSubsets) {
+				t.Fatalf("want %+v, got %+v", tt.wantSubsets, gotSubsets)
+			}
+		})
 	}
 }
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -29,6 +28,7 @@ import (
 	securityBeta "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
@@ -399,7 +399,7 @@ func scopeToSidecar(scope *SidecarScope) string {
 	return scope.Config.Namespace + "/" + scope.Config.Name
 }
 
-func TestSetDestinationRule(t *testing.T) {
+func TestSetDestinationRuleMerging(t *testing.T) {
 	ps := NewPushContext()
 	ps.defaultDestinationRuleExportTo = map[visibility.Instance]bool{visibility.Public: true}
 	testhost := "httpbin.org"
@@ -439,7 +439,7 @@ func TestSetDestinationRule(t *testing.T) {
 	}
 	ps.SetDestinationRules([]Config{destinationRuleNamespace1, destinationRuleNamespace2})
 	subsetsLocal := ps.namespaceLocalDestRules["test"].destRule[host.Name(testhost)].Spec.(*networking.DestinationRule).Subsets
-	subsetsExport := ps.namespaceExportedDestRules["test"].destRule[host.Name(testhost)].Spec.(*networking.DestinationRule).Subsets
+	subsetsExport := ps.exportedDestRulesByNamespace["test"].destRule[host.Name(testhost)].Spec.(*networking.DestinationRule).Subsets
 	if len(subsetsLocal) != 4 {
 		t.Errorf("want %d, but got %d", 4, len(subsetsLocal))
 	}
@@ -449,75 +449,334 @@ func TestSetDestinationRule(t *testing.T) {
 	}
 }
 
-func TestSubsetToLabels(t *testing.T) {
+func TestSetDestinationRuleWithExportTo(t *testing.T) {
 	ps := NewPushContext()
-	ps.defaultDestinationRuleExportTo = map[visibility.Instance]bool{visibility.Public: true}
-	ps.Mesh = &meshconfig.MeshConfig{
-		RootNamespace: "istio-system",
-	}
+	ps.Mesh = &meshconfig.MeshConfig{RootNamespace: "istio-system"}
 	testhost := "httpbin.org"
 	destinationRuleNamespace1 := Config{
 		ConfigMeta: ConfigMeta{
 			Name:      "rule1",
-			Namespace: "test",
+			Namespace: "test1",
 		},
 		Spec: &networking.DestinationRule{
-			Host: testhost,
+			Host:     testhost,
+			ExportTo: []string{".", "ns1"},
 			Subsets: []*networking.Subset{
 				{
 					Name: "subset1",
 				},
 				{
-					Name:   "subset2",
-					Labels: map[string]string{},
+					Name: "subset2",
 				},
+			},
+		},
+	}
+	destinationRuleNamespace2 := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule2",
+			Namespace: "test2",
+		},
+		Spec: &networking.DestinationRule{
+			Host:     testhost,
+			ExportTo: []string{"test2", "ns1", "test1"},
+			Subsets: []*networking.Subset{
 				{
 					Name: "subset3",
-					Labels: map[string]string{
-						"a": "b",
-					},
+				},
+				{
+					Name: "subset4",
 				},
 			},
 		},
 	}
-	proxy := &Proxy{
-		Metadata:        &NodeMetadata{IstioVersion: "1.6.0"},
-		ConfigNamespace: "test",
+	destinationRuleNamespace3 := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule3",
+			Namespace: "test3",
+		},
+		Spec: &networking.DestinationRule{
+			Host:     testhost,
+			ExportTo: []string{"test1", "test2", "*"},
+			Subsets: []*networking.Subset{
+				{
+					Name: "subset5",
+				},
+				{
+					Name: "subset6",
+				},
+			},
+		},
 	}
-
-	ps.SetDestinationRules([]Config{destinationRuleNamespace1})
-
-	for _, test := range []struct {
-		name     string
-		subset   string
-		expected labels.Collection
+	destinationRuleRootNamespace := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule4",
+			Namespace: "istio-system",
+		},
+		Spec: &networking.DestinationRule{
+			Host: testhost,
+			Subsets: []*networking.Subset{
+				{
+					Name: "subset7",
+				},
+				{
+					Name: "subset8",
+				},
+			},
+		},
+	}
+	ps.SetDestinationRules([]Config{destinationRuleNamespace1, destinationRuleNamespace2,
+		destinationRuleNamespace3, destinationRuleRootNamespace})
+	cases := []struct {
+		proxyNs     string
+		serviceNs   string
+		wantSubsets []string
 	}{
 		{
-			name:     "No labels",
-			subset:   "subset1",
-			expected: nil,
+			proxyNs:     "test1",
+			serviceNs:   "test1",
+			wantSubsets: []string{"subset1", "subset2"},
 		},
 		{
-			name:     "Empty labels",
-			subset:   "subset2",
-			expected: nil,
+			proxyNs:     "test1",
+			serviceNs:   "test2",
+			wantSubsets: []string{"subset1", "subset2"},
 		},
 		{
-			name:   "With labels",
-			subset: "subset3",
-			expected: labels.Collection{
-				{
-					"a": "b",
-				},
-			},
+			proxyNs:     "test2",
+			serviceNs:   "test1",
+			wantSubsets: []string{"subset3", "subset4"},
 		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			labelsCollection := ps.SubsetToLabels(proxy, test.subset, host.Name(testhost))
-			if cmp.Diff(labelsCollection, test.expected) != "" {
-				t.Errorf("want %v, but got %v", test.expected, labelsCollection)
-			}
-		})
+		{
+			proxyNs:     "test3",
+			serviceNs:   "test1",
+			wantSubsets: []string{"subset5", "subset6"},
+		},
+		{
+			proxyNs:     "ns1",
+			serviceNs:   "test1",
+			wantSubsets: []string{"subset1", "subset2"},
+		},
+		{
+			proxyNs:     "ns1",
+			serviceNs:   "random",
+			wantSubsets: []string{"subset7", "subset8"},
+		},
+		{
+			proxyNs:     "random",
+			serviceNs:   "random",
+			wantSubsets: []string{"subset7", "subset8"},
+		},
+		{
+			proxyNs:     "test3",
+			serviceNs:   "random",
+			wantSubsets: []string{"subset5", "subset6"},
+		},
+	}
+	for _, tt := range cases {
+		destRuleConfig := ps.DestinationRule(&Proxy{ConfigNamespace: tt.proxyNs},
+			&Service{Hostname: host.Name(testhost), Attributes: ServiceAttributes{Namespace: tt.serviceNs}})
+		if destRuleConfig == nil {
+			t.Fatalf("proxy in %s namespace: dest rule is nil, expected subsets %+v", tt.proxyNs, tt.wantSubsets)
+		}
+		destRule := destRuleConfig.Spec.(*networking.DestinationRule)
+		var gotSubsets []string
+		for _, ss := range destRule.Subsets {
+			gotSubsets = append(gotSubsets, ss.Name)
+		}
+		if !reflect.DeepEqual(gotSubsets, tt.wantSubsets) {
+			t.Fatalf("proxy in %s namespace: want %+v, got %+v", tt.proxyNs, tt.wantSubsets, gotSubsets)
+		}
+	}
+}
+
+func TestVirtualServiceWithExportTo(t *testing.T) {
+	ps := NewPushContext()
+	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "zzz"})}
+	ps.Mesh = env.Mesh()
+	ps.ServiceDiscovery = env
+	configStore := NewFakeStore()
+
+	rule1 := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule1",
+			Namespace: "test1",
+			Type:      collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Kind(),
+			Group:     collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Group(),
+			Version:   collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Version(),
+		},
+		Spec: &networking.VirtualService{
+			Hosts:    []string{"rule1.com"},
+			ExportTo: []string{".", "ns1"},
+		},
+	}
+	rule2 := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule2",
+			Namespace: "test2",
+			Type:      collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Kind(),
+			Group:     collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Group(),
+			Version:   collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Version(),
+		},
+		Spec: &networking.VirtualService{
+			Hosts:    []string{"rule2.com"},
+			ExportTo: []string{"test2", "ns1", "test1"},
+		},
+	}
+	rule3 := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule3",
+			Namespace: "test3",
+			Type:      collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Kind(),
+			Group:     collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Group(),
+			Version:   collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Version(),
+		},
+		Spec: &networking.VirtualService{
+			Hosts:    []string{"rule3.com"},
+			ExportTo: []string{"test1", "test2", "*"},
+		},
+	}
+	rootNS := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "zzz",
+			Namespace: "zzz",
+			Type:      collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Kind(),
+			Group:     collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Group(),
+			Version:   collections.IstioNetworkingV1Alpha3Virtualservices.Resource().Version(),
+		},
+		Spec: &networking.VirtualService{
+			Hosts: []string{"rootNS.com"},
+		},
+	}
+
+	if _, err := configStore.Create(rule1); err != nil {
+		t.Fatalf("could not create rule1")
+	}
+	if _, err := configStore.Create(rule2); err != nil {
+		t.Fatalf("could not create rule2")
+	}
+	if _, err := configStore.Create(rule3); err != nil {
+		t.Fatalf("could not create rule3")
+	}
+	if _, err := configStore.Create(rootNS); err != nil {
+		t.Fatalf("could not create rootNS")
+	}
+
+	store := istioConfigStore{ConfigStore: configStore}
+	env.IstioConfigStore = &store
+	ps.initDefaultExportMaps()
+	if err := ps.initVirtualServices(env); err != nil {
+		t.Fatalf("init virtual services failed: %v", err)
+	}
+
+	cases := []struct {
+		proxyNs   string
+		wantHosts []string
+	}{
+		{
+			proxyNs:   "test1",
+			wantHosts: []string{"rule1.com", "rule2.com", "rule3.com", "rootNS.com"},
+		},
+		{
+			proxyNs:   "test2",
+			wantHosts: []string{"rule2.com", "rule3.com", "rootNS.com"},
+		},
+		{
+			proxyNs:   "ns1",
+			wantHosts: []string{"rule1.com", "rule2.com", "rule3.com", "rootNS.com"},
+		},
+		{
+			proxyNs:   "random",
+			wantHosts: []string{"rule3.com", "rootNS.com"},
+		},
+	}
+	for _, tt := range cases {
+		rules := ps.VirtualServices(&Proxy{ConfigNamespace: tt.proxyNs}, map[string]bool{constants.IstioMeshGateway: true})
+		gotHosts := make([]string, 0)
+		for _, r := range rules {
+			vs := r.Spec.(*networking.VirtualService)
+			gotHosts = append(gotHosts, vs.Hosts...)
+		}
+		if !reflect.DeepEqual(gotHosts, tt.wantHosts) {
+			t.Errorf("proxy in %s namespace: want %+v, got %+v", tt.proxyNs, tt.wantHosts, gotHosts)
+		}
+	}
+}
+
+func TestServiceWithExportTo(t *testing.T) {
+	ps := NewPushContext()
+	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "zzz"})}
+	ps.Mesh = env.Mesh()
+	ps.ServiceDiscovery = env
+
+	svc1 := &Service{
+		Hostname: "svc1",
+		Attributes: ServiceAttributes{
+			Namespace: "test1",
+			ExportTo:  map[visibility.Instance]bool{visibility.Private: true, visibility.Instance("ns1"): true},
+		},
+	}
+	svc2 := &Service{
+		Hostname: "svc2",
+		Attributes: ServiceAttributes{
+			Namespace: "test2",
+			ExportTo: map[visibility.Instance]bool{visibility.Instance("test1"): true,
+				visibility.Instance("ns1"):   true,
+				visibility.Instance("test2"): true},
+		},
+	}
+	svc3 := &Service{
+		Hostname: "svc3",
+		Attributes: ServiceAttributes{
+			Namespace: "test3",
+			ExportTo: map[visibility.Instance]bool{visibility.Instance("test1"): true,
+				visibility.Public:            true,
+				visibility.Instance("test2"): true},
+		},
+	}
+	svc4 := &Service{
+		Hostname: "svc4",
+		Attributes: ServiceAttributes{
+			Namespace: "test4",
+		},
+	}
+	env.ServiceDiscovery = &localServiceDiscovery{
+		services: []*Service{svc1, svc2, svc3, svc4},
+	}
+	ps.initDefaultExportMaps()
+	if err := ps.initServiceRegistry(env); err != nil {
+		t.Fatalf("init services failed: %v", err)
+	}
+
+	cases := []struct {
+		proxyNs   string
+		wantHosts []string
+	}{
+		{
+			proxyNs:   "test1",
+			wantHosts: []string{"svc1", "svc2", "svc3", "svc4"},
+		},
+		{
+			proxyNs:   "test2",
+			wantHosts: []string{"svc2", "svc3", "svc4"},
+		},
+		{
+			proxyNs:   "ns1",
+			wantHosts: []string{"svc1", "svc2", "svc3", "svc4"},
+		},
+		{
+			proxyNs:   "random",
+			wantHosts: []string{"svc3", "svc4"},
+		},
+	}
+	for _, tt := range cases {
+		services := ps.Services(&Proxy{ConfigNamespace: tt.proxyNs})
+		gotHosts := make([]string, 0)
+		for _, r := range services {
+			gotHosts = append(gotHosts, string(r.Hostname))
+		}
+		if !reflect.DeepEqual(gotHosts, tt.wantHosts) {
+			t.Errorf("proxy in %s namespace: want %+v, got %+v", tt.proxyNs, tt.wantHosts, gotHosts)
+		}
 	}
 }
 
@@ -635,4 +894,41 @@ func TestIsClusterLocal(t *testing.T) {
 			g.Expect(clusterLocal).To(Equal(c.expected))
 		})
 	}
+}
+
+// MockDiscovery is an in-memory ServiceDiscover with mock services
+type localServiceDiscovery struct {
+	services []*Service
+}
+
+func (l *localServiceDiscovery) Services() ([]*Service, error) {
+	return l.services, nil
+}
+
+func (l *localServiceDiscovery) GetService(hostname host.Name) (*Service, error) {
+	panic("implement me")
+}
+
+func (l *localServiceDiscovery) InstancesByPort(svc *Service, servicePort int, labels labels.Collection) ([]*ServiceInstance, error) {
+	panic("implement me")
+}
+
+func (l *localServiceDiscovery) GetProxyServiceInstances(proxy *Proxy) ([]*ServiceInstance, error) {
+	panic("implement me")
+}
+
+func (l *localServiceDiscovery) GetProxyWorkloadLabels(proxy *Proxy) (labels.Collection, error) {
+	panic("implement me")
+}
+
+func (l *localServiceDiscovery) ManagementPorts(addr string) PortList {
+	panic("implement me")
+}
+
+func (l *localServiceDiscovery) WorkloadHealthCheckInfo(addr string) ProbeList {
+	panic("implement me")
+}
+
+func (l *localServiceDiscovery) GetIstioServiceAccounts(svc *Service, ports []int) []string {
+	panic("implement me")
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -446,7 +446,7 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (errs error) {
 
 // ValidateDestinationRule checks proxy policies
 var ValidateDestinationRule = registerValidateFunc("ValidateDestinationRule",
-	func(_, _ string, msg proto.Message) (errs error) {
+	func(_, namespace string, msg proto.Message) (errs error) {
 		rule, ok := msg.(*networking.DestinationRule)
 		if !ok {
 			return fmt.Errorf("cannot cast to destination rule")
@@ -460,16 +460,57 @@ var ValidateDestinationRule = registerValidateFunc("ValidateDestinationRule",
 			errs = appendErrors(errs, validateSubset(subset))
 		}
 
-		errs = appendErrors(errs, validateExportTo(rule.ExportTo))
+		errs = appendErrors(errs, validateExportTo(namespace, rule.ExportTo, false))
 		return
 	})
 
-func validateExportTo(exportTo []string) (errs error) {
+func validateExportTo(namespace string, exportTo []string, isServiceEntry bool) (errs error) {
 	if len(exportTo) > 0 {
-		if len(exportTo) > 1 {
-			errs = appendErrors(errs, fmt.Errorf("exportTo should have only one entry (. or *) in the current release"))
-		} else {
-			errs = appendErrors(errs, visibility.Instance(exportTo[0]).Validate())
+		// Make sure there are no duplicates
+		exportToMap := make(map[string]struct{})
+		for _, e := range exportTo {
+			key := e
+			if visibility.Instance(e) == visibility.Private {
+				// substitute this with the current namespace so that we
+				// can check for duplicates like ., namespace
+				key = namespace
+			}
+			if _, exists := exportToMap[key]; exists {
+				if key != e {
+					errs = appendErrors(errs, fmt.Errorf("duplicate entries in exportTo: . and current namespace %s", namespace))
+				} else {
+					errs = appendErrors(errs, fmt.Errorf("duplicate entries in exportTo for entry %s", e))
+				}
+			} else {
+				// if this is a serviceEntry, allow ~ in exportTo as it can be used to create
+				// a service that is not even visible within the local namespace to anyone other
+				// than the proxies of that service.
+				if isServiceEntry && visibility.Instance(e) == visibility.None {
+					exportToMap[key] = struct{}{}
+				} else {
+					if err := visibility.Instance(key).Validate(); err != nil {
+						errs = appendErrors(errs, err)
+					} else {
+						exportToMap[key] = struct{}{}
+					}
+				}
+			}
+		}
+
+		// Make sure we have only one of . or *
+		if _, public := exportToMap[string(visibility.Public)]; public {
+			// make sure that there are no other entries in the exportTo
+			// i.e. no point in saying ns1,ns2,*. Might as well say *
+			if len(exportTo) > 1 {
+				errs = appendErrors(errs, fmt.Errorf("cannot have both public (*) and non-public exportTo values for a resource"))
+			}
+		}
+
+		// if this is a service entry, then we need to disallow * and ~ together. Or ~ and other namespaces
+		if _, none := exportToMap[string(visibility.None)]; none {
+			if len(exportTo) > 1 {
+				errs = appendErrors(errs, fmt.Errorf("cannot export service entry to no one (~) and someone"))
+			}
 		}
 	}
 
@@ -2021,7 +2062,7 @@ func validateAuthNPolicyTarget(target *authn.TargetSelector) (errs error) {
 
 // ValidateVirtualService checks that a v1alpha3 route rule is well-formed.
 var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
-	func(_, _ string, msg proto.Message) (errs error) {
+	func(_, namespace string, msg proto.Message) (errs error) {
 		virtualService, ok := msg.(*networking.VirtualService)
 		if !ok {
 			return errors.New("cannot cast to virtual service")
@@ -2111,7 +2152,7 @@ var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
 			errs = appendErrors(errs, validateTCPRoute(tcpRoute))
 		}
 
-		errs = appendErrors(errs, validateExportTo(virtualService.ExportTo))
+		errs = appendErrors(errs, validateExportTo(namespace, virtualService.ExportTo, false))
 		return
 	})
 
@@ -2633,7 +2674,7 @@ var ValidateWorkloadEntry = registerValidateFunc("ValidateWorkloadEntry",
 
 // ValidateServiceEntry validates a service entry.
 var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
-	func(_, _ string, config proto.Message) (errs error) {
+	func(_, namespace string, config proto.Message) (errs error) {
 		serviceEntry, ok := config.(*networking.ServiceEntry)
 		if !ok {
 			return fmt.Errorf("cannot cast to service entry")
@@ -2777,7 +2818,7 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 				ValidatePort(int(port.Number)))
 		}
 
-		errs = appendErrors(errs, validateExportTo(serviceEntry.ExportTo))
+		errs = appendErrors(errs, validateExportTo(namespace, serviceEntry.ExportTo, true))
 		return
 	})
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -6002,3 +6002,101 @@ func TestValidateMeshNetworks(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateExportTo(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		exportTo       []string
+		isServiceEntry bool
+		wantErr        bool
+	}{
+		{
+			name:      "empty exportTo is okay",
+			namespace: "ns5",
+			wantErr:   false,
+		},
+		{
+			name:      "* is allowed",
+			namespace: "ns5",
+			exportTo:  []string{"*"},
+			wantErr:   false,
+		},
+		{
+			name:      ". and ns1 are allowed",
+			namespace: "ns5",
+			exportTo:  []string{".", "ns1"},
+			wantErr:   false,
+		},
+		{
+			name:      "bunch of namespaces in exportTo is okay",
+			namespace: "ns5",
+			exportTo:  []string{"ns1", "ns2", "ns5"},
+			wantErr:   false,
+		},
+		{
+			name:           "~ is allowed for service entry configs",
+			namespace:      "ns5",
+			exportTo:       []string{"~"},
+			isServiceEntry: true,
+			wantErr:        false,
+		},
+		{
+			name:      "~ not allowed for non service entry configs",
+			namespace: "ns5",
+			exportTo:  []string{"~", "ns1"},
+			wantErr:   true,
+		},
+		{
+			name:      ". and * together are not allowed",
+			namespace: "ns5",
+			exportTo:  []string{".", "*"},
+			wantErr:   true,
+		},
+		{
+			name:      "* and ns1 together are not allowed",
+			namespace: "ns5",
+			exportTo:  []string{"*", "ns1"},
+			wantErr:   true,
+		},
+		{
+			name:      ". and same namespace in exportTo is not okay",
+			namespace: "ns5",
+			exportTo:  []string{".", "ns5"},
+			wantErr:   true,
+		},
+		{
+			name:      "duplicate namespaces in exportTo is not okay",
+			namespace: "ns5",
+			exportTo:  []string{"ns1", "ns2", "ns1"},
+			wantErr:   true,
+		},
+		{
+			name:           "duplicate none in service entry exportTo is not okay",
+			namespace:      "ns5",
+			exportTo:       []string{"~", "~", "ns1"},
+			isServiceEntry: true,
+			wantErr:        true,
+		},
+		{
+			name:      "invalid namespace names are not okay",
+			namespace: "ns5",
+			exportTo:  []string{"ns1_"},
+			wantErr:   true,
+		},
+		{
+			name:           "none and other namespaces cannot be combined in service entry exportTo",
+			namespace:      "ns5",
+			exportTo:       []string{"~", "ns1"},
+			isServiceEntry: true,
+			wantErr:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateExportTo(tt.namespace, tt.exportTo, tt.isServiceEntry); (err != nil) != tt.wantErr {
+				t.Errorf("validateExportTo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/config/visibility/visibility.go
+++ b/pkg/config/visibility/visibility.go
@@ -14,9 +14,14 @@
 
 package visibility
 
-import "fmt"
+import (
+	"fmt"
 
-// Instance defines whether a given config or service is exported to local namespace, all namespaces or none
+	"istio.io/istio/pkg/config/labels"
+)
+
+// Instance defines whether a given config or service is exported to local namespace, some set of namespaces, or
+// all namespaces or none
 type Instance string
 
 const (
@@ -24,14 +29,21 @@ const (
 	Private Instance = "."
 	// Public implies config is visible to all
 	Public Instance = "*"
+	// None implies service is visible to no one. Used for services only
+	None Instance = "~"
 )
 
-// Validate a visibility value.
+// Validate a visibility value ( ./*/~/some namespace name which is DNS1123 label)
 func (v Instance) Validate() (errs error) {
 	switch v {
 	case Private, Public:
 		return nil
+	case None:
+		return fmt.Errorf("exportTo ~ (none) is not allowed for Istio configuration objects")
 	default:
-		return fmt.Errorf("only . or * is allowed in the exportTo in the current release")
+		if !labels.IsDNS1123Label(string(v)) {
+			return fmt.Errorf("only .,*,~, or a valid DNS 1123 label is allowed as exportTo entry")
+		}
 	}
+	return nil
 }


### PR DESCRIPTION
This is a cherry-pick of two recent upstream commits that fix private destination rules in root namespace:

  - istio/istio@b1ab306
  - istio/istio@a497e86