### PR TITLE
Support for HTTP1.1 Only

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -130,6 +130,10 @@ spec:
           - name: TLS_ECDH_CURVES
             value: {{ .Values.global.tls.ecdhCurves }}
 {{- end }}
+{{- if .Values.global.tls.alpnProtocols }}
+          - name: ALPN_PROTOCOLS
+            value: {{ .Values.global.tls.alpnProtocols }}
+{{- end }}
 {{- end }}
           resources:
 {{- if .Values.resources }}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -436,7 +436,7 @@ func buildGatewayListenerTLSContext(
 
 	tls := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
-			AlpnProtocols: util.ALPNHttp,
+			AlpnProtocols: tls_features.ALPNProtocols.Get(),
 			TlsParams: &auth.TlsParameters{
 				TlsMinimumProtocolVersion: convertTLSProtocol(server.Tls.MinProtocolVersion, tls_features.TlsMinProtocolVersion.Get()),
 				TlsMaximumProtocolVersion: convertTLSProtocol(server.Tls.MaxProtocolVersion, tls_features.TlsMaxProtocolVersion.Get()),

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -43,6 +43,123 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 	runTestBuildGatewayListenerTlsContext(t, &auth.TlsParameters{})
 }
 
+func TestALPNHttp11OnlyBuildGatewayListenerTlsContext(t *testing.T) {
+	_ = os.Setenv("TLS_CIPHER_SUITES", strings.Join(tls_features.SupportedGolangCiphers, ", "))
+	tls_features.TlsCipherSuites.Reset()
+	tls_features.ALPNProtocols.Reset()
+	_ = os.Setenv("TLS_MIN_PROTOCOL_VERSION", "TLSv1_2")
+	_ = os.Setenv("TLS_MAX_PROTOCOL_VERSION", "TLSv1_3")
+	_ = os.Setenv("ALPN_PROTOCOLS", util.ALPNH11Only[0])
+
+	defer func() {
+		_ = os.Unsetenv("TLS_CIPHER_SUITES")
+		tls_features.TlsCipherSuites.Reset()
+		tls_features.ALPNProtocols.Reset()
+		_ = os.Unsetenv("TLS_MIN_PROTOCOL_VERSION")
+		_ = os.Unsetenv("TLS_MAX_PROTOCOL_VERSION")
+	}()
+	runTestBuildGatewayListenerTlsContextEx(t, &auth.TlsParameters{
+		TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+		TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
+		CipherSuites: tls_features.SupportedOpenSSLCiphers,
+	}, util.ALPNH11Only)
+}
+
+func TestALPNHttp2OnlyBuildGatewayListenerTlsContext(t *testing.T) {
+	_ = os.Setenv("TLS_CIPHER_SUITES", strings.Join(tls_features.SupportedGolangCiphers, ", "))
+	tls_features.TlsCipherSuites.Reset()
+	tls_features.ALPNProtocols.Reset()
+	_ = os.Setenv("TLS_MIN_PROTOCOL_VERSION", "TLSv1_2")
+	_ = os.Setenv("TLS_MAX_PROTOCOL_VERSION", "TLSv1_3")
+	_ = os.Setenv("ALPN_PROTOCOLS", util.ALPNH2Only[0])
+
+	defer func() {
+		_ = os.Unsetenv("TLS_CIPHER_SUITES")
+		tls_features.TlsCipherSuites.Reset()
+		tls_features.ALPNProtocols.Reset()
+		_ = os.Unsetenv("TLS_MIN_PROTOCOL_VERSION")
+		_ = os.Unsetenv("TLS_MAX_PROTOCOL_VERSION")
+	}()
+	runTestBuildGatewayListenerTlsContextEx(t, &auth.TlsParameters{
+		TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+		TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
+		CipherSuites: tls_features.SupportedOpenSSLCiphers,
+	}, util.ALPNH2Only)
+}
+
+func TestALPNHttpBuildGatewayListenerTlsContext(t *testing.T) {
+	_ = os.Setenv("TLS_CIPHER_SUITES", strings.Join(tls_features.SupportedGolangCiphers, ", "))
+	tls_features.TlsCipherSuites.Reset()
+	tls_features.ALPNProtocols.Reset()
+	_ = os.Setenv("TLS_MIN_PROTOCOL_VERSION", "TLSv1_2")
+	_ = os.Setenv("TLS_MAX_PROTOCOL_VERSION", "TLSv1_3")
+	_ = os.Setenv("ALPN_PROTOCOLS", strings.Join(util.ALPNHttp, ","))
+
+	defer func() {
+		_ = os.Unsetenv("TLS_CIPHER_SUITES")
+		tls_features.TlsCipherSuites.Reset()
+		tls_features.ALPNProtocols.Reset()
+		_ = os.Unsetenv("TLS_MIN_PROTOCOL_VERSION")
+		_ = os.Unsetenv("TLS_MAX_PROTOCOL_VERSION")
+	}()
+	runTestBuildGatewayListenerTlsContextEx(t, &auth.TlsParameters{
+		TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+		TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
+		CipherSuites: tls_features.SupportedOpenSSLCiphers,
+	}, util.ALPNHttp)
+}
+
+func TestALPNHttp11OnlyCreateGatewayHTTPFilterChainOpts(t *testing.T) {
+	_ = os.Setenv("TLS_CIPHER_SUITES", strings.Join(tls_features.SupportedGolangCiphers, ", "))
+	_ = os.Setenv("ALPN_PROTOCOLS", util.ALPNH11Only[0])
+	tls_features.TlsCipherSuites.Reset()
+	tls_features.ALPNProtocols.Reset()
+
+	defer func() {
+		_ = os.Unsetenv("TLS_CIPHER_SUITES")
+		tls_features.TlsCipherSuites.Reset()
+		tls_features.ALPNProtocols.Reset()
+	}()
+
+	runTestCreateGatewayHTTPFilterChainOptsEx(t, &auth.TlsParameters{
+		CipherSuites: tls_features.SupportedOpenSSLCiphers,
+	}, util.ALPNH11Only)
+}
+
+func TestALPNHttp2OnlyCreateGatewayHTTPFilterChainOpts(t *testing.T) {
+	_ = os.Setenv("TLS_CIPHER_SUITES", strings.Join(tls_features.SupportedGolangCiphers, ", "))
+	_ = os.Setenv("ALPN_PROTOCOLS", util.ALPNH2Only[0])
+	tls_features.TlsCipherSuites.Reset()
+	tls_features.ALPNProtocols.Reset()
+
+	defer func() {
+		_ = os.Unsetenv("TLS_CIPHER_SUITES")
+		tls_features.TlsCipherSuites.Reset()
+		tls_features.ALPNProtocols.Reset()
+	}()
+
+	runTestCreateGatewayHTTPFilterChainOptsEx(t, &auth.TlsParameters{
+		CipherSuites: tls_features.SupportedOpenSSLCiphers,
+	}, util.ALPNH2Only)
+}
+
+func TestALPNHttpCreateGatewayHTTPFilterChainOpts(t *testing.T) {
+	_ = os.Setenv("TLS_CIPHER_SUITES", strings.Join(tls_features.SupportedGolangCiphers, ", "))
+	_ = os.Setenv("ALPN_PROTOCOLS",  strings.Join(util.ALPNHttp, ","))
+	tls_features.TlsCipherSuites.Reset()
+	tls_features.ALPNProtocols.Reset()
+
+	defer func() {
+		_ = os.Unsetenv("TLS_CIPHER_SUITES")
+		tls_features.TlsCipherSuites.Reset()
+		tls_features.ALPNProtocols.Reset()
+	}()
+
+	runTestCreateGatewayHTTPFilterChainOptsEx(t, &auth.TlsParameters{
+		CipherSuites: tls_features.SupportedOpenSSLCiphers,
+	}, util.ALPNHttp)
+}
+
 func TestTlsProtocolVersionBuildGatewayListenerTlsContext(t *testing.T) {
 	_ = os.Setenv("TLS_MIN_PROTOCOL_VERSION", "TLSv1_2")
 	_ = os.Setenv("TLS_MAX_PROTOCOL_VERSION", "TLSv1_3")
@@ -107,7 +224,12 @@ func TestTlsCipherSuitesEcdhCurvesBuildGatewayListenerTlsContext(t *testing.T) {
 	})
 }
 
+// Wrapper to handle alpn_protocol addition
 func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParameters) {
+	runTestBuildGatewayListenerTlsContextEx(t, tlsParam, util.ALPNHttp)
+}
+
+func runTestBuildGatewayListenerTlsContextEx(t *testing.T, tlsParam *auth.TlsParameters, alpn_protocol []string) {
 	testCases := []struct {
 		name                  string
 		server                *networking.Server
@@ -127,7 +249,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -168,7 +290,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "default",
@@ -248,7 +370,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -280,7 +402,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -323,7 +445,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -370,7 +492,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -403,7 +525,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -439,7 +561,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -510,7 +632,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -581,7 +703,7 @@ func runTestBuildGatewayListenerTlsContext(t *testing.T, tlsParam *auth.TlsParam
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsParams: tlsParam,
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: alpn_protocol,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -728,7 +850,12 @@ func TestTlsCipherSuitesEcdhCurvesCreateGatewayHTTPFilterChainOpts(t *testing.T)
 	})
 }
 
+// Wrapper to handle alpn_protocol addition
 func runTestCreateGatewayHTTPFilterChainOpts(t *testing.T, tlsParam *auth.TlsParameters) {
+	runTestCreateGatewayHTTPFilterChainOptsEx(t, tlsParam, util.ALPNHttp);
+}
+
+func runTestCreateGatewayHTTPFilterChainOptsEx(t *testing.T, tlsParam *auth.TlsParameters, alpn_protocol []string) {
 	testCases := []struct {
 		name      string
 		node      *pilot_model.Proxy
@@ -810,7 +937,7 @@ func runTestCreateGatewayHTTPFilterChainOpts(t *testing.T, tlsParam *auth.TlsPar
 								},
 							},
 						},
-						AlpnProtocols: []string{"h2", "http/1.1"},
+						AlpnProtocols: alpn_protocol,
 					},
 				},
 				httpOpts: &httpListenerOpts{
@@ -873,7 +1000,7 @@ func runTestCreateGatewayHTTPFilterChainOpts(t *testing.T, tlsParam *auth.TlsPar
 								},
 							},
 						},
-						AlpnProtocols: []string{"h2", "http/1.1"},
+						AlpnProtocols: alpn_protocol,
 					},
 				},
 				httpOpts: &httpListenerOpts{
@@ -936,7 +1063,7 @@ func runTestCreateGatewayHTTPFilterChainOpts(t *testing.T, tlsParam *auth.TlsPar
 								},
 							},
 						},
-						AlpnProtocols: []string{"h2", "http/1.1"},
+						AlpnProtocols: alpn_protocol,
 					},
 				},
 				httpOpts: &httpListenerOpts{

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -87,6 +87,9 @@ const (
 // ALPNH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
 var ALPNH2Only = []string{"h2"}
 
+// ALPNH11Only advertises that Proxy is going to use HTTP/1.1 when talking to the cluster.
+var ALPNH11Only = []string{"http/1.1"}
+
 // ALPNInMeshH2 advertises that Proxy is going to use HTTP/2 when talking to the in-mesh cluster.
 // The custom "istio" value indicates in-mesh traffic and it's going to be used for routing decisions.
 // Once Envoy supports client-side ALPN negotiation, this should be {"istio", "h2", "http/1.1"}.

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -335,7 +335,7 @@ func (a v1alpha1PolicyApplier) InboundFilterChain(sdsUdsPath string, meta *model
 			// include "istio" for the secure traffic, but its TLSContext.ALPN must not
 			// include "istio", which would interfere with negotiation of the underlying
 			// protocol, e.g. HTTP/2.
-			AlpnProtocols: util.ALPNHttp,
+      AlpnProtocols: tls_features.ALPNProtocols.Get(),
 			TlsParams: &auth.TlsParameters{
 				TlsMinimumProtocolVersion: tls_features.TlsMinProtocolVersion.Get(),
 				TlsMaximumProtocolVersion: tls_features.TlsMaxProtocolVersion.Get(),

--- a/pkg/features/alpn_protocols.go
+++ b/pkg/features/alpn_protocols.go
@@ -1,0 +1,70 @@
+package features
+
+import (
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/pkg/env"
+	"istio.io/pkg/log"
+	"strings"
+
+	//"strings"
+	"sync"
+)
+
+var (
+	ALPNProtocols = RegisterALPNProtocolsVar(
+		"ALPN_PROTOCOLS",
+		"",
+		"The supported ALPN Protocols",
+	)
+	elock = &sync.Mutex{}
+)
+
+type ALPNProtocolsVar struct {
+	env.StringVar
+	protocols []string
+}
+
+func RegisterALPNProtocolsVar(name string, defaultValue string, description string) ALPNProtocolsVar {
+	v := env.RegisterStringVar(name, defaultValue, description)
+	return ALPNProtocolsVar{v, nil }
+}
+
+func (v *ALPNProtocolsVar) initAlpnProtocols() {
+	lock.Lock()
+	defer lock.Unlock()
+	if v.protocols == nil {
+		protocols := []string{}
+		protocolsParam, _ := v.Lookup()
+		if protocolsParam != "" {
+			protocolsParamSlice := strings.Split(protocolsParam, ",")
+			for _, protocolsParam := range protocolsParamSlice {
+				trimmed := strings.Trim(protocolsParam, " ")
+				// ensure only supported values are accepted
+				if trimmed == util.ALPNH11Only[0] || trimmed == util.ALPNH2Only[0] {
+					protocols = append(protocols, trimmed)
+				} else {
+					log.Warnf("ALPN Protocol %v is not supported, this entry will be ignored", trimmed)
+				}
+			}
+		}
+		if len(protocols) == 0 {
+			v.protocols = util.ALPNHttp
+		} else {
+			v.protocols = protocols
+		}
+		log.Infof("ALPN Protocol is %v", v.protocols)
+	}
+}
+
+func (v *ALPNProtocolsVar) Reset() {
+	elock.Lock()
+	defer elock.Unlock()
+	v.protocols = nil
+}
+
+func (v *ALPNProtocolsVar) Get() []string {
+	if v.protocols == nil {
+		v.initAlpnProtocols()
+	}
+	return v.protocols
+}

--- a/pkg/features/alpn_protocols.go
+++ b/pkg/features/alpn_protocols.go
@@ -1,12 +1,12 @@
 package features
 
 import (
+	"strings"
+
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
-	"strings"
 
-	//"strings"
 	"sync"
 )
 
@@ -16,22 +16,22 @@ var (
 		"",
 		"The supported ALPN Protocols",
 	)
-	elock = &sync.Mutex{}
 )
 
 type ALPNProtocolsVar struct {
 	env.StringVar
-	protocols []string
+	protocols        []string
+	alpnProtocolLock *sync.Mutex
 }
 
 func RegisterALPNProtocolsVar(name string, defaultValue string, description string) ALPNProtocolsVar {
 	v := env.RegisterStringVar(name, defaultValue, description)
-	return ALPNProtocolsVar{v, nil }
+	return ALPNProtocolsVar{v, nil, &sync.Mutex{}}
 }
 
 func (v *ALPNProtocolsVar) initAlpnProtocols() {
-	lock.Lock()
-	defer lock.Unlock()
+	v.alpnProtocolLock.Lock()
+	defer v.alpnProtocolLock.Unlock()
 	if v.protocols == nil {
 		protocols := []string{}
 		protocolsParam, _ := v.Lookup()
@@ -57,8 +57,8 @@ func (v *ALPNProtocolsVar) initAlpnProtocols() {
 }
 
 func (v *ALPNProtocolsVar) Reset() {
-	elock.Lock()
-	defer elock.Unlock()
+	v.alpnProtocolLock.Lock()
+	defer v.alpnProtocolLock.Unlock()
 	v.protocols = nil
 }
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

Issue raised by https://github.com/istio/istio/issues/14708

"Is it possible to disable http2 and always use http 1.1"

This change allows for istio to configure envoy to use "h2" only, "http/1.1" only or default to the "h2,http/1.1" and relates to problems encountered with the use of wildcard certificates for multiple backend services.  Including the problem with sticky sessions when using h2 and browsers for example with the OCP Console.  

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
Change to deployment template.
[x] Docs
      tls_context:
         common_tls_context:
           tls_certificates:
            certificate_chain: { filename: „/etc/example-com.crt“ }
             private_key: { filename: „/etc/example-com.key“ }
           alpn_protocols: [ "http/1.1" ]
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
