### PR TITLE
MAISTRA-2010 Fix validation of AuthorizationPolicy fields

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/all-fields-in.yaml
@@ -33,6 +33,8 @@ spec:
         - key: "request.headers[X-header]"
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]
           notValues: ["not-header", "not-header-prefix-*", "*-not-suffix-header", "*"]
+        - key: "request.regex.headers[X-header-regex]"
+          values: ["some.*value"]
         - key: "source.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
           notValues: ["90.10.10.10", "90.168.10.0/24"]

--- a/pilot/pkg/security/authz/builder/testdata/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/all-fields-out.yaml
@@ -481,6 +481,13 @@ typedConfig:
                       presentMatch: true
             - orIds:
                 ids:
+                - header:
+                    name: X-header-regex
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: some.*value
+            - orIds:
+                ids:
                 - sourceIp:
                     addressPrefix: 10.10.10.10
                     prefixLen: 32

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -35,22 +35,23 @@ type JwksInfo struct {
 }
 
 const (
-	attrRequestHeader    = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
-	attrSrcIP            = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrSrcNamespace     = "source.namespace"       // e.g. "default".
-	attrSrcPrincipal     = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
-	attrRequestPrincipal = "request.auth.principal" // authenticated principal of the request.
-	attrRequestAudiences = "request.auth.audiences" // intended audience(s) for this authentication information.
-	attrRequestPresenter = "request.auth.presenter" // authorized presenter of the credential.
-	attrRequestClaims    = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
-	attrDestIP           = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrDestPort         = "destination.port"       // must be in the range [0, 65535].
-	attrDestLabel        = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
-	attrDestName         = "destination.name"       // short service name, e.g. "productpage".
-	attrDestNamespace    = "destination.namespace"  // e.g. "default".
-	attrDestUser         = "destination.user"       // service account, e.g. "bookinfo-productpage".
-	attrConnSNI          = "connection.sni"         // server name indication, e.g. "www.example.com".
-	attrExperimental     = "experimental.envoy.filters."
+	attrRequestHeader      = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
+	attrRequestHeaderRegex = "request.regex.headers"  // header regex is surrounded by brackets, e.g. "request.regex.headers[X-Random-.*]".
+	attrSrcIP              = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrSrcNamespace       = "source.namespace"       // e.g. "default".
+	attrSrcPrincipal       = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
+	attrRequestPrincipal   = "request.auth.principal" // authenticated principal of the request.
+	attrRequestAudiences   = "request.auth.audiences" // intended audience(s) for this authentication information.
+	attrRequestPresenter   = "request.auth.presenter" // authorized presenter of the credential.
+	attrRequestClaims      = "request.auth.claims"    // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
+	attrDestIP             = "destination.ip"         // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrDestPort           = "destination.port"       // must be in the range [0, 65535].
+	attrDestLabel          = "destination.labels"     // label name is surrounded by brackets, e.g. "destination.labels[version]".
+	attrDestName           = "destination.name"       // short service name, e.g. "productpage".
+	attrDestNamespace      = "destination.namespace"  // e.g. "default".
+	attrDestUser           = "destination.user"       // service account, e.g. "bookinfo-productpage".
+	attrConnSNI            = "connection.sni"         // server name indication, e.g. "www.example.com".
+	attrExperimental       = "experimental.envoy.filters."
 )
 
 // ParseJwksURI parses the input URI and returns the corresponding hostname, port, and whether SSL is used.
@@ -105,6 +106,8 @@ func ValidateAttribute(key string, values []string) error {
 	}
 	switch {
 	case hasPrefix(key, attrRequestHeader):
+		return validateMapKey(key)
+	case hasPrefix(key, attrRequestHeaderRegex):
 		return validateMapKey(key)
 	case isEqual(key, attrSrcIP):
 		return ValidateIPs(values)

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -108,6 +108,16 @@ func TestValidateCondition(t *testing.T) {
 			wantError: true,
 		},
 		{
+			key:       "request.regex.headers[]",
+			values:    []string{"some.*value"},
+			wantError: true,
+		},
+		{
+			key:       "request.regex.headers[X-header-regex]",
+			values:    []string{"some.*value"},
+			wantError: false,
+		},
+		{
 			key:    "source.ip",
 			values: []string{"1.2.3.4", "5.6.7.0/24"},
 		},


### PR DESCRIPTION
It would previously detect request.regex.headers as invalid, even though it is supported.

Cherry-pick of MAISTRA-1739 (#157)

We must have missed this during the rebase...