### PR TITLE
MAISTRA-1980: Fix private destination rules in root namespace

### DIFF
--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Istio Authors
+// Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,15 +18,24 @@ import (
 	"fmt"
 
 	networking "istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/pkg/config/visibility"
 )
 
 // This function merges one or more destination rules for a given host string
 // into a single destination rule. Note that it does not perform inheritance style merging.
 // IOW, given three dest rules (*.foo.com, *.foo.com, *.com), calling this function for
 // each config will result in a final dest rule set (*.foo.com, and *.com).
-func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig Config) {
+//
+// The following is the merge logic:
+// 1. Unique subsets (based on subset name) are concatenated to the original rule's list of subsets
+// 2. If the original rule did not have any top level traffic policy, traffic policies from the new rule will be
+// used.
+// 3. If the original rule did not have any exportTo, exportTo settings from the new rule will be used.
+func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig Config, exportToMap map[visibility.Instance]bool) {
 	rule := destRuleConfig.Spec.(*networking.DestinationRule)
 	resolvedHost := ResolveShortnameToFQDN(rule.Host, destRuleConfig.ConfigMeta)
+
 	if mdr, exists := p.destRule[resolvedHost]; exists {
 		// Deep copy destination rule, to prevent mutate it later when merge with a new one.
 		// This can happen when there are more than one destination rule of same host in one namespace.
@@ -39,6 +48,8 @@ func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfi
 		}
 		// we have an another destination rule for same host.
 		// concatenate both of them -- essentially add subsets from one to other.
+		// Note: we only add the subsets and do not overwrite anything else like exportTo or top level
+		// traffic policies if they already exist
 		for _, subset := range rule.Subsets {
 			if _, ok := existingSubset[subset.Name]; !ok {
 				// if not duplicated, append
@@ -56,10 +67,18 @@ func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfi
 		if mergedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
 			mergedRule.TrafficPolicy = rule.TrafficPolicy
 		}
+
+		// If there is no exportTo in the existing rule and
+		// the incoming rule has an explicit exportTo, use the
+		// one from the incoming rule.
+		if len(p.exportTo[resolvedHost]) == 0 && len(exportToMap) > 0 {
+			p.exportTo[resolvedHost] = exportToMap
+		}
 		return
 	}
 
 	// DestinationRule does not exist for the resolved host so add it
 	p.hosts = append(p.hosts, resolvedHost)
 	p.destRule[resolvedHost] = &destRuleConfig
+	p.exportTo[resolvedHost] = exportToMap
 }

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -18,51 +18,48 @@ import (
 	"fmt"
 
 	networking "istio.io/api/networking/v1alpha3"
-
-	"istio.io/istio/pkg/config/host"
 )
 
 // This function merges one or more destination rules for a given host string
 // into a single destination rule. Note that it does not perform inheritance style merging.
 // IOW, given three dest rules (*.foo.com, *.foo.com, *.com), calling this function for
 // each config will result in a final dest rule set (*.foo.com, and *.com).
-func (ps *PushContext) combineSingleDestinationRule(
-	combinedDestRuleHosts []host.Name,
-	combinedDestRuleMap map[host.Name]*combinedDestinationRule,
-	destRuleConfig Config) []host.Name {
+func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig Config) {
 	rule := destRuleConfig.Spec.(*networking.DestinationRule)
 	resolvedHost := ResolveShortnameToFQDN(rule.Host, destRuleConfig.ConfigMeta)
-
-	if mdr, exists := combinedDestRuleMap[resolvedHost]; exists {
-		combinedRule := mdr.config.Spec.(*networking.DestinationRule)
+	if mdr, exists := p.destRule[resolvedHost]; exists {
+		// Deep copy destination rule, to prevent mutate it later when merge with a new one.
+		// This can happen when there are more than one destination rule of same host in one namespace.
+		copied := mdr.DeepCopy()
+		p.destRule[resolvedHost] = &copied
+		mergedRule := copied.Spec.(*networking.DestinationRule)
+		existingSubset := map[string]struct{}{}
+		for _, subset := range mergedRule.Subsets {
+			existingSubset[subset.Name] = struct{}{}
+		}
 		// we have an another destination rule for same host.
 		// concatenate both of them -- essentially add subsets from one to other.
 		for _, subset := range rule.Subsets {
-			if _, subsetExists := mdr.subsets[subset.Name]; !subsetExists {
-				mdr.subsets[subset.Name] = struct{}{}
-				combinedRule.Subsets = append(combinedRule.Subsets, subset)
+			if _, ok := existingSubset[subset.Name]; !ok {
+				// if not duplicated, append
+				mergedRule.Subsets = append(mergedRule.Subsets, subset)
 			} else {
+				// duplicate subset
 				ps.Add(DuplicatedSubsets, string(resolvedHost), nil,
 					fmt.Sprintf("Duplicate subset %s found while merging destination rules for %s",
 						subset.Name, string(resolvedHost)))
 			}
 		}
+
 		// If there is no top level policy and the incoming rule has top level
 		// traffic policy, use the one from the incoming rule.
-		if combinedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
-			combinedRule.TrafficPolicy = rule.TrafficPolicy
+		if mergedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
+			mergedRule.TrafficPolicy = rule.TrafficPolicy
 		}
-		return combinedDestRuleHosts
+		return
 	}
 
-	combinedDestRuleMap[resolvedHost] = &combinedDestinationRule{
-		subsets: make(map[string]struct{}),
-		config:  &destRuleConfig,
-	}
-	for _, subset := range rule.Subsets {
-		combinedDestRuleMap[resolvedHost].subsets[subset.Name] = struct{}{}
-	}
-	combinedDestRuleHosts = append(combinedDestRuleHosts, resolvedHost)
-
-	return combinedDestRuleHosts
+	// DestinationRule does not exist for the resolved host so add it
+	p.hosts = append(p.hosts, resolvedHost)
+	p.destRule[resolvedHost] = &destRuleConfig
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -70,15 +70,11 @@ type PushContext struct {
 	privateVirtualServicesByNamespace map[string][]Config
 	publicVirtualServices             []Config
 
-	// destination rules are of three types:
+	// destination rules are of two types:
 	//  namespaceLocalDestRules: all public/private dest rules pertaining to a service defined in a given namespace
 	//  namespaceExportedDestRules: all public dest rules pertaining to a service defined in a namespace
-	//  allExportedDestRules: all (public) dest rules across all namespaces
-	// We need the allExportedDestRules in addition to namespaceExportedDestRules because we select
-	// the dest rule based on the most specific host match, and not just any destination rule
 	namespaceLocalDestRules    map[string]*processedDestRules
 	namespaceExportedDestRules map[string]*processedDestRules
-	allExportedDestRules       *processedDestRules
 
 	// sidecars for each namespace
 	sidecarsByNamespace map[string][]*SidecarScope
@@ -429,17 +425,13 @@ func NewPushContext() *PushContext {
 		privateVirtualServicesByNamespace: map[string][]Config{},
 		namespaceLocalDestRules:           map[string]*processedDestRules{},
 		namespaceExportedDestRules:        map[string]*processedDestRules{},
-		allExportedDestRules: &processedDestRules{
-			hosts:    make([]host.Name, 0),
-			destRule: map[host.Name]*combinedDestinationRule{},
-		},
-		sidecarsByNamespace:           map[string][]*SidecarScope{},
-		envoyFiltersByNamespace:       map[string][]*EnvoyFilterWrapper{},
-		gatewaysByNamespace:           map[string][]Config{},
-		allGateways:                   []Config{},
-		ServiceByHostnameAndNamespace: map[host.Name]map[string]*Service{},
-		ProxyStatus:                   map[string]map[string]ProxyPushStatus{},
-		ServiceAccounts:               map[host.Name]map[int][]string{},
+		sidecarsByNamespace:               map[string][]*SidecarScope{},
+		envoyFiltersByNamespace:           map[string][]*EnvoyFilterWrapper{},
+		gatewaysByNamespace:               map[string][]Config{},
+		allGateways:                       []Config{},
+		ServiceByHostnameAndNamespace:     map[host.Name]map[string]*Service{},
+		ProxyStatus:                       map[string]map[string]ProxyPushStatus{},
+		ServiceAccounts:                   map[host.Name]map[int][]string{},
 		AuthnPolicies: processedAuthnPolicies{
 			policies: map[host.Name][]*authnPolicyByPort{},
 		},
@@ -606,14 +598,6 @@ func (ps *PushContext) GetAllSidecarScopes() map[string][]*SidecarScope {
 
 // DestinationRule returns a destination rule for a service name in a given domain.
 func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
-	// FIXME: this code should be removed once the EDS issue is fixed
-	if proxy == nil {
-		if hostname, ok := MostSpecificHostMatch(service.Hostname, ps.allExportedDestRules.hosts); ok {
-			return ps.allExportedDestRules.destRule[hostname].config
-		}
-		return nil
-	}
-
 	// If proxy has a sidecar scope that is user supplied, then get the destination rules from the sidecar scope
 	// sidecarScope.config is nil if there is no sidecar scope for the namespace
 	if proxy.SidecarScope != nil && proxy.Type == SidecarProxy {
@@ -827,7 +811,6 @@ func (ps *PushContext) updateContext(
 	} else {
 		ps.namespaceLocalDestRules = oldPushContext.namespaceLocalDestRules
 		ps.namespaceExportedDestRules = oldPushContext.namespaceExportedDestRules
-		ps.allExportedDestRules = oldPushContext.allExportedDestRules
 	}
 
 	if authnChanged {
@@ -1274,10 +1257,6 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 	sortConfigByCreationTime(configs)
 	namespaceLocalDestRules := make(map[string]*processedDestRules)
 	namespaceExportedDestRules := make(map[string]*processedDestRules)
-	allExportedDestRules := &processedDestRules{
-		hosts:    make([]host.Name, 0),
-		destRule: map[host.Name]*combinedDestinationRule{},
-	}
 
 	for i := range configs {
 		rule := configs[i].Spec.(*networking.DestinationRule)
@@ -1330,11 +1309,6 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 				namespaceExportedDestRules[configs[i].Namespace].hosts,
 				namespaceExportedDestRules[configs[i].Namespace].destRule,
 				configs[i])
-
-			// Merge this destination rule with any public dest rule for the same host
-			// across all namespaces. If there are no duplicates, the dest rule will be added to the list
-			allExportedDestRules.hosts = ps.combineSingleDestinationRule(
-				allExportedDestRules.hosts, allExportedDestRules.destRule, configs[i])
 		}
 	}
 
@@ -1346,11 +1320,9 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 	for ns := range namespaceExportedDestRules {
 		sort.Sort(host.Names(namespaceExportedDestRules[ns].hosts))
 	}
-	sort.Sort(host.Names(allExportedDestRules.hosts))
 
 	ps.namespaceLocalDestRules = namespaceLocalDestRules
 	ps.namespaceExportedDestRules = namespaceExportedDestRules
-	ps.allExportedDestRules = allExportedDestRules
 }
 
 func (ps *PushContext) initAuthorizationPolicies(env *Environment) error {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -107,7 +107,7 @@ type processedDestRules struct {
 	// List of dest rule hosts. We match with the most specific host first
 	hosts []host.Name
 	// Map of dest rule host and the merged destination rules for that host
-	destRule map[host.Name]*combinedDestinationRule
+	destRule map[host.Name]*Config
 }
 
 type processedAuthnPolicies struct {
@@ -264,10 +264,9 @@ type ProxyPushStatus struct {
 	Message string `json:"message,omitempty"`
 }
 
-type combinedDestinationRule struct {
-	subsets map[string]struct{} // list of subsets seen so far
-	// We are not doing ports
-	config *Config
+// IsMixerEnabled returns true if mixer is enabled in the Mesh config.
+func (ps *PushContext) IsMixerEnabled() bool {
+	return ps != nil && ps.Env.Mesh != nil && (ps.Env.Mesh.MixerCheckServer != "" || ps.Env.Mesh.MixerReportServer != "")
 }
 
 // Add will add an case to the metric.
@@ -614,16 +613,19 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 	// proxies like the istio-ingressgateway or istio-egressgateway.
 	// If there are no service specific dest rules, we will end up picking up the same
 	// rules anyway, later in the code
+
+	// 1. select destination rule from proxy config namespace
 	if proxy.ConfigNamespace != ps.Env.Mesh.RootNamespace {
 		// search through the DestinationRules in proxy's namespace first
 		if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
 			if hostname, ok := MostSpecificHostMatch(service.Hostname,
 				ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
-				return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[hostname].config
+				return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[hostname]
 			}
 		}
 	}
 
+	// 2. select destination rule from service namespace
 	svcNs := service.Attributes.Namespace
 
 	// This can happen when finding the subset labels for a proxy in root namespace.
@@ -638,22 +640,22 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		}
 	}
 
-	// if no private/public rule matched in the calling proxy's namespace,
+	// 3. if no private/public rule matched in the calling proxy's namespace,
 	// check the target service's namespace for public rules
 	if svcNs != "" && ps.namespaceExportedDestRules[svcNs] != nil {
 		if hostname, ok := MostSpecificHostMatch(service.Hostname,
 			ps.namespaceExportedDestRules[svcNs].hosts); ok {
-			return ps.namespaceExportedDestRules[svcNs].destRule[hostname].config
+			return ps.namespaceExportedDestRules[svcNs].destRule[hostname]
 		}
 	}
 
-	// if no public/private rule in calling proxy's namespace matched, and no public rule in the
+	// 4. if no public/private rule in calling proxy's namespace matched, and no public rule in the
 	// target service's namespace matched, search for any public destination rule in the config root namespace
 	// NOTE: This does mean that we are effectively ignoring private dest rules in the config root namespace
 	if ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace] != nil {
 		if hostname, ok := MostSpecificHostMatch(service.Hostname,
 			ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace].hosts); ok {
-			return ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace].destRule[hostname].config
+			return ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace].destRule[hostname]
 		}
 	}
 
@@ -1269,16 +1271,12 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 		if _, exist := namespaceLocalDestRules[configs[i].Namespace]; !exist {
 			namespaceLocalDestRules[configs[i].Namespace] = &processedDestRules{
 				hosts:    make([]host.Name, 0),
-				destRule: map[host.Name]*combinedDestinationRule{},
+				destRule: map[host.Name]*Config{},
 			}
 		}
 		// Merge this destination rule with any public/private dest rules for same host in the same namespace
 		// If there are no duplicates, the dest rule will be added to the list
-		namespaceLocalDestRules[configs[i].Namespace].hosts = ps.combineSingleDestinationRule(
-			namespaceLocalDestRules[configs[i].Namespace].hosts,
-			namespaceLocalDestRules[configs[i].Namespace].destRule,
-			configs[i])
-
+		ps.mergeDestinationRule(namespaceLocalDestRules[configs[i].Namespace], configs[i])
 		isPubliclyExported := false
 		if len(rule.ExportTo) == 0 {
 			// No exportTo in destinationRule. Use the global default
@@ -1300,15 +1298,12 @@ func (ps *PushContext) SetDestinationRules(configs []Config) {
 			if _, exist := namespaceExportedDestRules[configs[i].Namespace]; !exist {
 				namespaceExportedDestRules[configs[i].Namespace] = &processedDestRules{
 					hosts:    make([]host.Name, 0),
-					destRule: map[host.Name]*combinedDestinationRule{},
+					destRule: map[host.Name]*Config{},
 				}
 			}
 			// Merge this destination rule with any public dest rule for the same host in the same namespace
 			// If there are no duplicates, the dest rule will be added to the list
-			namespaceExportedDestRules[configs[i].Namespace].hosts = ps.combineSingleDestinationRule(
-				namespaceExportedDestRules[configs[i].Namespace].hosts,
-				namespaceExportedDestRules[configs[i].Namespace].destRule,
-				configs[i])
+			ps.mergeDestinationRule(namespaceExportedDestRules[configs[i].Namespace], configs[i])
 		}
 	}
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -643,11 +643,11 @@ func (*fakeStore) GetResourceAtVersion(version string, key string) (resourceVers
 func TestSetDestinationRule(t *testing.T) {
 	ps := NewPushContext()
 	ps.defaultDestinationRuleExportTo = map[visibility.Instance]bool{visibility.Public: true}
-	testhost := "test.test-namespace1.svc.cluster.local"
+	testhost := "httpbin.org"
 	destinationRuleNamespace1 := Config{
 		ConfigMeta: ConfigMeta{
 			Name:      "rule1",
-			Namespace: "test-namespace1",
+			Namespace: "test",
 		},
 		Spec: &networking.DestinationRule{
 			Host: testhost,
@@ -664,7 +664,7 @@ func TestSetDestinationRule(t *testing.T) {
 	destinationRuleNamespace2 := Config{
 		ConfigMeta: ConfigMeta{
 			Name:      "rule2",
-			Namespace: "istio-system",
+			Namespace: "test",
 		},
 		Spec: &networking.DestinationRule{
 			Host: testhost,
@@ -679,12 +679,13 @@ func TestSetDestinationRule(t *testing.T) {
 		},
 	}
 	ps.SetDestinationRules([]Config{destinationRuleNamespace1, destinationRuleNamespace2})
-	subsetsLocal := len(ps.namespaceLocalDestRules["test-namespace1"].destRule[host.Name(testhost)].config.Spec.(*networking.DestinationRule).Subsets)
-	subsetsExport := len(ps.namespaceExportedDestRules["test-namespace1"].destRule[host.Name(testhost)].config.Spec.(*networking.DestinationRule).Subsets)
-	if subsetsLocal != 2 {
-		t.Fatalf("want %d, but got %d", 2, subsetsLocal)
+	subsetsLocal := ps.namespaceLocalDestRules["test"].destRule[host.Name(testhost)].Spec.(*networking.DestinationRule).Subsets
+	subsetsExport := ps.namespaceExportedDestRules["test"].destRule[host.Name(testhost)].Spec.(*networking.DestinationRule).Subsets
+	if len(subsetsLocal) != 4 {
+		t.Errorf("want %d, but got %d", 4, len(subsetsLocal))
 	}
-	if subsetsExport != 2 {
-		t.Fatalf("want %d, but got %d", 2, subsetsExport)
+
+	if len(subsetsExport) != 4 {
+		t.Errorf("want %d, but got %d", 4, len(subsetsExport))
 	}
 }


### PR DESCRIPTION
This is cherry-picks or partially cherry-picks a few upstream commits to try to fix private destination rules in the root namespace for the maistra-1.1 branch.

This seems to fix the issue for me, but I'm actually not convinced we should merge this. It's a fairly big change, and it wasn't possible to fully bring over the changes to this stuff from 1.6 and above without making the diff huge. So, it's hard to say whether this has other side effects. There's also a workaround, which is to simply run the gateway in a namespace that is not the root config namespace. In any case, I wanted to put this PR up so we can decide one way or the other.