### PR TITLE
[MAISTRA-2067] [MAISTRA-1528] Fix bookinfo versions to pick up latest version and CVE fixes

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -634,7 +634,7 @@ $(HELM): $(ISTIO_OUT)
 	bin/init_helm.sh
 
 $(HOME)/.helm:
-	$(HELM) init --client-only
+	$(HELM) init --stable-repo-url https://charts.helm.sh/stable --client-only
 
 # create istio-init.yaml
 istio-init.yaml: $(HELM) $(HOME)/.helm

--- a/pkg/test/deployment/helm.go
+++ b/pkg/test/deployment/helm.go
@@ -141,7 +141,7 @@ func HelmTemplate(deploymentName, namespace, chartDir, workDir, valuesFile strin
 	}
 
 	// Initialize the helm (but do not install tiller).
-	if _, err := exec(fmt.Sprintf("helm --home %s init --client-only", helmRepoDir)); err != nil {
+	if _, err := exec(fmt.Sprintf("helm --home %s init --stable-repo-url https://charts.helm.sh/stable --client-only", helmRepoDir)); err != nil {
 		return "", err
 	}
 

--- a/pkg/test/helm/helm.go
+++ b/pkg/test/helm/helm.go
@@ -29,7 +29,7 @@ func Init(homeDir string, clientOnly bool) error {
 		clientSuffix = " --client-only"
 	}
 
-	out, err := shell.Execute(true, "helm --home %s init %s", homeDir, clientSuffix)
+	out, err := shell.Execute(true, "helm --home %s init %s --stable-repo-url https://charts.helm.sh/stable", homeDir, clientSuffix)
 	if err != nil {
 		scopes.Framework.Errorf("helm init: %v, out:%q", err, out)
 	} else {

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -14,6 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+function setup_gcloud_credentials() {
+  if [[ $(command -v gcloud) ]]; then
+    gcloud auth configure-docker -q
+  elif [[ $(command -v docker-credential-gcr) ]]; then
+    docker-credential-gcr configure-docker
+  else
+    echo "No credential helpers found, push to docker may not function properly"
+  fi
+}
+
 function setup_and_export_git_sha() {
   if [[ -n "${CI:-}" ]]; then
 
@@ -35,7 +45,7 @@ function setup_and_export_git_sha() {
   fi
   GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
   export GIT_BRANCH
-  gcloud auth configure-docker -q
+  setup_gcloud_credentials
 }
 
 # Download and unpack istio release artifacts.

--- a/samples/bookinfo/platform/consul/bookinfo.yaml
+++ b/samples/bookinfo/platform/consul/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: maistra/examples-bookinfo-details-v1:1.1.0
+    image: maistra/examples-bookinfo-details-v1:1.1.12
     networks:
       istiomesh:
     dns:
@@ -33,7 +33,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: maistra/examples-bookinfo-ratings-v1:1.1.0
+    image: maistra/examples-bookinfo-ratings-v1:1.1.12
     networks:
       istiomesh:
     dns:
@@ -50,7 +50,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: maistra/examples-bookinfo-reviews-v1:1.1.0
+    image: maistra/examples-bookinfo-reviews-v1:1.1.12
     networks:
       istiomesh:
     dns:
@@ -68,7 +68,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: maistra/examples-bookinfo-reviews-v2:1.1.0
+    image: maistra/examples-bookinfo-reviews-v2:1.1.12
     networks:
       istiomesh:
     dns:
@@ -86,7 +86,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: maistra/examples-bookinfo-reviews-v3:1.1.0
+    image: maistra/examples-bookinfo-reviews-v3:1.1.12
     networks:
       istiomesh:
     dns:
@@ -104,7 +104,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: maistra/examples-bookinfo-productpage-v1:1.1.0
+    image: maistra/examples-bookinfo-productpage-v1:1.1.12
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14

--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: mongodb
-        image: maistra/examples-bookinfo-mongodb:1.1.1
+        image: maistra/examples-bookinfo-mongodb:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: maistra/examples-bookinfo-details-v2:1.1.1
+        image: maistra/examples-bookinfo-details-v2:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: maistra/examples-bookinfo-details-v1:1.1.1
+        image: maistra/examples-bookinfo-details-v1:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: maistra/examples-bookinfo-mysqldb:1.1.1
+        image: maistra/examples-bookinfo-mysqldb:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: maistra/examples-bookinfo-ratings-v2:1.1.1
+        image: maistra/examples-bookinfo-ratings-v2:1.1.12
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: maistra/examples-bookinfo-ratings-v2:1.1.1
+        image: maistra/examples-bookinfo-ratings-v2:1.1.12
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: bookinfo-ratings-v2
       containers:
       - name: ratings
-        image: maistra/examples-bookinfo-ratings-v2:1.1.1
+        image: maistra/examples-bookinfo-ratings-v2:1.1.12
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: maistra/examples-bookinfo-ratings-v1:1.1.1
+        image: maistra/examples-bookinfo-ratings-v1:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: maistra/examples-bookinfo-reviews-v2:1.1.1
+        image: maistra/examples-bookinfo-reviews-v2:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: maistra/examples-bookinfo-details-v1:1.1.1
+        image: maistra/examples-bookinfo-details-v1:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: maistra/examples-bookinfo-ratings-v1:1.1.1
+        image: maistra/examples-bookinfo-ratings-v1:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -180,7 +180,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: maistra/examples-bookinfo-reviews-v1:1.1.1
+        image: maistra/examples-bookinfo-reviews-v1:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -209,7 +209,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: maistra/examples-bookinfo-reviews-v2:1.1.1
+        image: maistra/examples-bookinfo-reviews-v2:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -238,7 +238,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: maistra/examples-bookinfo-reviews-v3:1.1.1
+        image: maistra/examples-bookinfo-reviews-v3:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -291,7 +291,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: maistra/examples-bookinfo-productpage-v1:1.1.1
+        image: maistra/examples-bookinfo-productpage-v1:1.1.12
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -255,7 +255,7 @@ dumpsys: out_dir
 # Run once for each cluster, to install helm on the cluster
 helm/init: ${HELM}
 	kubectl apply -n kube-system -f install/kubernetes/helm/helm-service-account.yaml
-	helm init --upgrade --service-account tiller
+	helm init --stable-repo-url https://charts.helm.sh/stable --upgrade --service-account tiller
 
 # Install istio for the first time
 helm/install:

--- a/tests/util/helm_utils.go
+++ b/tests/util/helm_utils.go
@@ -23,7 +23,7 @@ import (
 
 // HelmInit init helm with a service account
 func HelmInit(serviceAccount string) error {
-	_, err := Shell("helm init --upgrade --service-account %s", serviceAccount)
+	_, err := Shell("helm init --upgrade --stable-repo-url https://charts.helm.sh/stable --service-account %s", serviceAccount)
 	return err
 }
 


### PR DESCRIPTION
Please provide a description for what this PR is for.
This updates our Bookinfo examples to fix several CVEs. This also fixes tests due to the fact that Helm charts were moved as well as disables reliance in gcloud in tests.