### PR TITLE
MAISTRA-2051: Use shared Kubernetes client in galley

### DIFF
--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/istio/galley/pkg/config/processor/transforms"
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/inmemory"
-	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
 	kube_inmemory "istio.io/istio/galley/pkg/config/source/kube/inmemory"
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
@@ -48,6 +47,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/snapshots"
+	kubelib "istio.io/istio/pkg/kube"
 )
 
 const (
@@ -267,12 +267,8 @@ func (sa *SourceAnalyzer) AddReaderKubeSource(readers []ReaderSource) error {
 
 // AddRunningKubeSource adds a source based on a running k8s cluster to the current SourceAnalyzer
 // Also tries to get mesh config from the running cluster, if it can
-func (sa *SourceAnalyzer) AddRunningKubeSource(k kube.Interfaces) {
-	client, err := k.KubeClient()
-	if err != nil {
-		scope.Analysis.Errorf("error getting KubeClient: %v", err)
-		return
-	}
+func (sa *SourceAnalyzer) AddRunningKubeSource(k kubelib.Client) {
+	client := k.Kube()
 
 	// Since we're using a running k8s source, try to get meshconfig and meshnetworks from the configmap.
 	if err := sa.addRunningKubeIstioConfigMapSource(client); err != nil {

--- a/galley/pkg/config/source/kube/apiserver/options.go
+++ b/galley/pkg/config/source/kube/apiserver/options.go
@@ -15,23 +15,17 @@
 package apiserver
 
 import (
-	"time"
-
-	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver/status"
 	"istio.io/istio/pkg/config/schema/collection"
+	kubelib "istio.io/istio/pkg/kube"
 )
 
 // Options for the kube controller
 type Options struct {
 	// The Client interfaces to use for connecting to the API server.
-	Client kube.Interfaces
-
-	ResyncPeriod time.Duration
+	Client kubelib.Client
 
 	Schemas collection.Schemas
 
 	StatusController status.Controller
-
-	WatchedNamespaces string
 }

--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -125,7 +125,7 @@ func (s *Source) Start() {
 
 	// Start the CRD listener. When the listener is fully-synced, the listening of actual resources will start.
 	scope.Source.Infof("Beginning CRD Discovery, to figure out resources that are available...")
-	s.provider = rt.NewProvider(s.options.Client, s.options.WatchedNamespaces, s.options.ResyncPeriod)
+	s.provider = rt.NewProvider(s.options.Client)
 	a := s.provider.GetAdapter(crdKubeResource.Resource())
 	s.crdWatcher = newWatcher(crdKubeResource, a, s.statusCtl)
 	s.crdWatcher.dispatch(event.HandlerFromFn(s.onCrdEvent))

--- a/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
+++ b/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
@@ -1,4 +1,5 @@
 // Copyright Istio Authors
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,10 +27,10 @@ import (
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
-	"istio.io/istio/galley/pkg/testing/mock"
 	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/resource"
 	resource2 "istio.io/istio/pkg/config/schema/resource"
+	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -65,9 +66,8 @@ func TestBasic(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := mock.NewKube()
-	client, err := k.KubeClient()
-	g.Expect(err).To(BeNil())
+	k := kubelib.NewFakeClient()
+	client := k.Kube()
 
 	// Start the source.
 	s := newOrFail(t, k, k8smeta.MustGet().KubeCollections(), nil)
@@ -81,6 +81,7 @@ func TestBasic(t *testing.T) {
 
 	acc.Clear()
 
+	var err error
 	node := &corev1.Node{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.NodeSpec{
@@ -106,9 +107,8 @@ func TestNodes(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := mock.NewKube()
-	client, err := k.KubeClient()
-	g.Expect(err).To(BeNil())
+	k := kubelib.NewFakeClient()
+	client := k.Kube()
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -121,6 +121,7 @@ func TestNodes(t *testing.T) {
 	}
 	acc.Clear()
 
+	var err error
 	node := &corev1.Node{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.NodeSpec{
@@ -174,9 +175,8 @@ func TestPods(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := mock.NewKube()
-	client, err := k.KubeClient()
-	g.Expect(err).To(BeNil())
+	k := kubelib.NewFakeClient()
+	client := k.Kube()
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -189,6 +189,7 @@ func TestPods(t *testing.T) {
 	}
 	acc.Clear()
 
+	var err error
 	pod := &corev1.Pod{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.PodSpec{
@@ -252,9 +253,8 @@ func TestServices(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := mock.NewKube()
-	client, err := k.KubeClient()
-	g.Expect(err).To(BeNil())
+	k := kubelib.NewFakeClient()
+	client := k.Kube()
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -267,6 +267,7 @@ func TestServices(t *testing.T) {
 	}
 	acc.Clear()
 
+	var err error
 	svc := &corev1.Service{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.ServiceSpec{
@@ -325,9 +326,8 @@ func TestEndpoints(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := mock.NewKube()
-	client, err := k.KubeClient()
-	g.Expect(err).To(BeNil())
+	k := kubelib.NewFakeClient()
+	client := k.Kube()
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -340,6 +340,7 @@ func TestEndpoints(t *testing.T) {
 	}
 	acc.Clear()
 
+	var err error
 	eps := &corev1.Endpoints{
 		ObjectMeta: fakeObjectMeta,
 		Subsets: []corev1.EndpointSubset{

--- a/galley/pkg/config/source/kube/rt/known.go
+++ b/galley/pkg/config/source/kube/rt/known.go
@@ -32,7 +32,6 @@ import (
 
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver/stats"
-	"istio.io/istio/pkg/listwatch"
 )
 
 func (p *Provider) initKnownAdapters() {
@@ -50,27 +49,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Service: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				client, err := p.interfaces.KubeClient()
-				if err != nil {
-					return nil, err
-				}
-
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Services(namespace).List(context.TODO(), opts)
-							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Services(namespace).Watch(context.TODO(), opts)
-							},
-						}
-					})
-
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Service{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-				return informer, nil
+				return p.kubeClient.KubeInformer().Core().V1().Services().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Service{}
@@ -95,12 +74,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Namespace: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				informer, err := p.sharedInformerFactory()
-				if err != nil {
-					return nil, err
-				}
-
-				return informer.Core().V1().Namespaces().Informer(), nil
+				return p.kubeClient.KubeInformer().Core().V1().Namespaces().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Namespace{}
@@ -125,12 +99,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Node: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				informer, err := p.sharedInformerFactory()
-				if err != nil {
-					return nil, err
-				}
-
-				return informer.Core().V1().Nodes().Informer(), nil
+				return p.kubeClient.KubeInformer().Core().V1().Nodes().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Node{}
@@ -155,27 +124,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Pod: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				client, err := p.interfaces.KubeClient()
-				if err != nil {
-					return nil, err
-				}
-
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Pods(namespace).List(context.TODO(), opts)
-							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Pods(namespace).Watch(context.TODO(), opts)
-							},
-						}
-					})
-
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Pod{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-				return informer, nil
+				return p.kubeClient.KubeInformer().Core().V1().Pods().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Pod{}
@@ -200,27 +149,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Secret: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				client, err := p.interfaces.KubeClient()
-				if err != nil {
-					return nil, err
-				}
-
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Secrets(namespace).List(context.TODO(), opts)
-							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Secrets(namespace).Watch(context.TODO(), opts)
-							},
-						}
-					})
-
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Secret{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-				return informer, nil
+				return p.kubeClient.KubeInformer().Core().V1().Secrets().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Secret{}
@@ -244,27 +173,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Endpoints: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				client, err := p.interfaces.KubeClient()
-				if err != nil {
-					return nil, err
-				}
-
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Endpoints(namespace).List(context.TODO(), opts)
-							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Endpoints(namespace).Watch(context.TODO(), opts)
-							},
-						}
-					})
-
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Endpoints{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-				return informer, nil
+				return p.kubeClient.KubeInformer().Core().V1().Endpoints().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Endpoints{}
@@ -300,27 +209,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1beta1.Ingress: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				client, err := p.interfaces.KubeClient()
-				if err != nil {
-					return nil, err
-				}
-
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.ExtensionsV1beta1().Ingresses(namespace).List(context.TODO(), opts)
-							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.ExtensionsV1beta1().Ingresses(namespace).Watch(context.TODO(), opts)
-							},
-						}
-					})
-
-				informer := cache.NewSharedIndexInformer(mlw, &v1beta1.Ingress{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-				return informer, nil
+				return p.kubeClient.KubeInformer().Extensions().V1beta1().Ingresses().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1beta1.Ingress{}
@@ -342,10 +231,8 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1beta1.Ingress: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				ext, err := p.interfaces.APIExtensionsClientset()
-				if err != nil {
-					return nil, err
-				}
+				ext := p.kubeClient.Ext()
+
 				inf := cache.NewSharedIndexInformer(
 					&cache.ListWatch{
 						ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -360,7 +247,6 @@ func (p *Provider) initKnownAdapters() {
 					cache.Indexers{})
 
 				return inf, nil
-
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1beta12.CustomResourceDefinition{}
@@ -383,27 +269,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Deployment: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				client, err := p.interfaces.KubeClient()
-				if err != nil {
-					return nil, err
-				}
-
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.AppsV1().Deployments(namespace).List(context.TODO(), opts)
-							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.AppsV1().Deployments(namespace).Watch(context.TODO(), opts)
-							},
-						}
-					})
-
-				informer := cache.NewSharedIndexInformer(mlw, &appsv1.Deployment{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-				return informer, nil
+				return p.kubeClient.KubeInformer().Apps().V1().Deployments().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &appsv1.Deployment{}
@@ -426,27 +292,7 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.ConfigMap: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				client, err := p.interfaces.KubeClient()
-				if err != nil {
-					return nil, err
-				}
-
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
-							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().ConfigMaps(namespace).Watch(context.TODO(), opts)
-							},
-						}
-					})
-
-				informer := cache.NewSharedIndexInformer(mlw, &v1.ConfigMap{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-				return informer, nil
+				return p.kubeClient.KubeInformer().Core().V1().ConfigMaps().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.ConfigMap{}

--- a/galley/pkg/config/source/kube/rt/provider.go
+++ b/galley/pkg/config/source/kube/rt/provider.go
@@ -16,21 +16,16 @@ package rt
 
 import (
 	"errors"
-	"strings"
-	"sync"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeSchema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/informers"
 
-	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/pkg/config/schema/resource"
+	kubelib "istio.io/istio/pkg/kube"
 )
 
 var (
-	defaultProvider = NewProvider(nil, metav1.NamespaceAll, 0)
+	defaultProvider = NewProvider(nil)
 )
 
 // DefaultProvider returns a default provider that has no K8s connectivity enabled.
@@ -40,25 +35,13 @@ func DefaultProvider() *Provider {
 
 // Provider for adapters. It closes over K8s connection-related infrastructure.
 type Provider struct {
-	mu sync.Mutex
-
-	resyncPeriod time.Duration
-	interfaces   kube.Interfaces
-	namespaces   []string
-	known        map[string]*Adapter
-
-	informers        informers.SharedInformerFactory
-	dynamicInterface dynamic.Interface
+	kubeClient kubelib.Client
+	known      map[string]*Adapter
 }
 
 // NewProvider returns a new instance of Provider.
-func NewProvider(interfaces kube.Interfaces, namespaces string, resyncPeriod time.Duration) *Provider {
-	p := &Provider{
-		resyncPeriod: resyncPeriod,
-		interfaces:   interfaces,
-		namespaces:   strings.Split(namespaces, ","),
-	}
-
+func NewProvider(kubeClient kubelib.Client) *Provider {
+	p := &Provider{kubeClient: kubeClient}
 	p.initKnownAdapters()
 
 	return p
@@ -74,41 +57,13 @@ func (p *Provider) GetAdapter(r resource.Schema) *Adapter {
 	return p.getDynamicAdapter(r)
 }
 
-func (p *Provider) sharedInformerFactory() (informers.SharedInformerFactory, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if p.informers == nil {
-		if p.interfaces == nil {
-			return nil, errors.New("client interfaces was not initialized")
-		}
-		cl, err := p.interfaces.KubeClient()
-		if err != nil {
-			return nil, err
-		}
-		p.informers = informers.NewSharedInformerFactory(cl, p.resyncPeriod)
-	}
-
-	return p.informers, nil
-}
-
 // GetDynamicResourceInterface returns a dynamic.NamespaceableResourceInterface for the given resource.
 func (p *Provider) GetDynamicResourceInterface(r resource.Schema) (dynamic.NamespaceableResourceInterface, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if p.dynamicInterface == nil {
-		if p.interfaces == nil {
-			return nil, errors.New("client interfaces was not initialized")
-		}
-		d, err := p.interfaces.DynamicInterface()
-		if err != nil {
-			return nil, err
-		}
-		p.dynamicInterface = d
+	if p.kubeClient == nil {
+		return nil, errors.New("client interfaces was not initialized")
 	}
 
-	return p.dynamicInterface.Resource(kubeSchema.GroupVersionResource{
+	return p.kubeClient.Dynamic().Resource(kubeSchema.GroupVersionResource{
 		Group:    r.Group(),
 		Version:  r.Version(),
 		Resource: r.Plural(),

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -32,7 +32,6 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/local"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter"
-	cfgKube "istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/pkg/config/resource"
@@ -169,11 +168,10 @@ func Analyze() *cobra.Command {
 			if useKube {
 				// Set up the kube client
 				config := kube.BuildClientCmd(kubeconfig, configContext)
-				restConfig, err := config.ClientConfig()
+				k, err := kube.NewClient(config)
 				if err != nil {
 					return err
 				}
-				k := cfgKube.NewInterfaces(restConfig)
 				sa.AddRunningKubeSource(k)
 			}
 

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -362,7 +362,7 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 	processingArgs.MeshConfigFile = args.MeshConfigFile
 	processingArgs.EnableConfigAnalysis = true
 
-	processing := components.NewProcessing(processingArgs)
+	processing := components.NewProcessing(s.kubeClient, processingArgs)
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go leaderelection.

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -22,7 +22,6 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers"
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/analysis/local"
-	cfgKube "istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema"
@@ -215,8 +214,7 @@ func GetAnalyze(p *Params) (map[string]string, error) {
 	sa := local.NewSourceAnalyzer(schema.MustGet(), analyzers.AllCombined(),
 		resource.Namespace(p.Namespace), resource.Namespace(p.IstioNamespace), nil, true, 5*time.Minute)
 
-	k := cfgKube.NewInterfaces(p.Client.RESTConfig())
-	sa.AddRunningKubeSource(k)
+	sa.AddRunningKubeSource(p.Client)
 
 	cancel := make(chan struct{})
 	result, err := sa.Analyze(cancel)


### PR DESCRIPTION
This moves galley to the shared Kubernetes client, which will let it
use xns-informers for multi-namespace support like everything else.
