### PR TITLE
[MAISTRA-1451][MAISTRA-1612] Add tests for pod redirect annotation

### DIFF
--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_podRedirectAnnot.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_podRedirectAnnot.patch
@@ -1,0 +1,103 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/initContainers/-",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/-",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {},
+      "securityContext": {
+        "runAsUser": 1337
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-envoy",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/securityContext",
+    "value": {
+      "fsGroup": 1337
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/prometheus.io~1port",
+    "value": "15020"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/prometheus.io~1scrape",
+    "value": "true"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/sidecar.istio.io~1status",
+    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels",
+    "value": {
+      "istio.io/rev": ""
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-name",
+    "value": "something"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/service.istio.io~1canonical-revision",
+    "value": "latest"
+  }
+]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_podRedirectAnnot.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_podRedirectAnnot.yaml
@@ -1,0 +1,12 @@
+metadata:
+  name: something
+spec:
+  initContainers:
+  - name: c0
+  - name: injected0
+  containers:
+  - name: c1
+  - name: injected1
+  volumes:
+  - name: v0
+  - name: injected2

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_podRedirectAnnot_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_podRedirectAnnot_template.yaml
@@ -1,0 +1,25 @@
+policy: enabled
+alwaysInjectSelector: []
+neverInjectSelector: []
+template: |-
+  initContainers:
+  - name: istio-init
+    image: example.com/init:latest
+  containers:
+  - name: istio-proxy
+    image: example.com/proxy:latest
+  imagePullSecrets:
+  - name: istio-image-pull-secrets
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-certs
+    secret:
+      {{ if eq .Spec.ServiceAccountName "" -}}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+      {{- end}}
+  podRedirectAnnot:
+    sidecar.istio.io/interceptionMode: "injected-via-podRedirectAnnot"

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -576,6 +576,11 @@ func TestWebhookInject(t *testing.T) {
 			templateFile: "TestWebhookInject_injectorAnnotations_template.yaml",
 		},
 		{
+			inputFile:    "TestWebhookInject_podRedirectAnnot.yaml",
+			wantFile:     "TestWebhookInject_podRedirectAnnot.patch",
+			templateFile: "TestWebhookInject_podRedirectAnnot_template.yaml",
+		},
+		{
 			inputFile: "TestWebhookInject_mtls_not_ready.yaml",
 			wantFile:  "TestWebhookInject_mtls_not_ready.patch",
 		},


### PR DESCRIPTION
Maistra-1451 added pod redirect annotation. Maistra-1612 removed reverted most of that code. In the mean time, that code greatly changed in Istio. This is a manual merge of the two. 