### PR TITLE
OSSM-357 Use the correct port when updating ServiceEntry endpoints

### DIFF
--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -464,7 +464,7 @@ func (d *ServiceEntryStore) edsUpdate(instances []*model.ServiceInstance) {
 		endpoints[key] = append(endpoints[key],
 			&model.IstioEndpoint{
 				Address:         instance.Endpoint.Address,
-				EndpointPort:    uint32(port.Port),
+				EndpointPort:    instance.Endpoint.EndpointPort,
 				ServicePortName: port.Name,
 				Labels:          instance.Endpoint.Labels,
 				UID:             instance.Endpoint.UID,


### PR DESCRIPTION
Cherry-pick of https://github.com/istio/istio/pull/25356

Initial reads of a ServiceEntry detect the correct endpoint port, but subsequent updates using edsUpdate() use the service port instead of endpoint port