### PR TITLE
Make `make docker` work again

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -121,7 +121,7 @@ endif
 
 # Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
 
-export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/istio-build/proxy
+export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/maistra-prow-testing/proxy
 
 # Use envoy as the sidecar by default
 export SIDECAR ?= envoy

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -123,6 +123,7 @@ fi
 
 # Download and extract the Envoy linux release binary.
 download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH"
+download_envoy_if_necessary "${ISTIO_ENVOY_CENTOS_RELEASE_URL}" "$ISTIO_ENVOY_CENTOS_LINUX_RELEASE_PATH"
 
 if [[ "$GOOS_LOCAL" == "darwin" ]]; then
   # Download and extract the Envoy macOS release binary
@@ -145,6 +146,10 @@ done
 # Copy native envoy binary to ISTIO_OUT
 echo "Copying ${ISTIO_ENVOY_NATIVE_PATH} to ${ISTIO_OUT}/${SIDECAR}"
 cp -f "${ISTIO_ENVOY_NATIVE_PATH}" "${ISTIO_OUT}/${SIDECAR}"
+
+# Copy CentOS binary
+echo "Copying ${ISTIO_ENVOY_CENTOS_LINUX_RELEASE_PATH} to ${ISTIO_OUT_LINUX}/${SIDECAR}-centos"
+cp -f "${ISTIO_ENVOY_CENTOS_LINUX_RELEASE_PATH}" "${ISTIO_OUT_LINUX}/${SIDECAR}-centos"
 
 # Copy the envoy binary to ISTIO_OUT_LINUX if the local OS is not Linux
 if [[ "$GOOS_LOCAL" != "linux" ]]; then

--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "24fe377d72d148cf912bacf4b841f0fc76ec752d"
+    "lastStableSHA": "64885886d9fd133750466325fcde5170bfc35b37"
   }
 ]


### PR DESCRIPTION
- Point the Base URL to ours instead of upstream
- Download envoy-centos binary (Reverts
  https://github.com/maistra/istio/pull/234/commits/bb004bd823640ea15e747e21bbb7c0d706a6f9e3)
- Bump proxy SHA