### PR TITLE
MAISTRA-2051: Use MultiNamespaceInformer in galley

### DIFF
--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/galley/pkg/config/processor/transforms"
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/inmemory"
+	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
 	kube_inmemory "istio.io/istio/galley/pkg/config/source/kube/inmemory"
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
@@ -47,7 +48,6 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/snapshots"
-	kubelib "istio.io/istio/pkg/kube"
 )
 
 const (
@@ -267,8 +267,12 @@ func (sa *SourceAnalyzer) AddReaderKubeSource(readers []ReaderSource) error {
 
 // AddRunningKubeSource adds a source based on a running k8s cluster to the current SourceAnalyzer
 // Also tries to get mesh config from the running cluster, if it can
-func (sa *SourceAnalyzer) AddRunningKubeSource(k kubelib.Client) {
-	client := k.Kube()
+func (sa *SourceAnalyzer) AddRunningKubeSource(k kube.Interfaces) {
+	client, err := k.KubeClient()
+	if err != nil {
+		scope.Analysis.Errorf("error getting KubeClient: %v", err)
+		return
+	}
 
 	// Since we're using a running k8s source, try to get meshconfig and meshnetworks from the configmap.
 	if err := sa.addRunningKubeIstioConfigMapSource(client); err != nil {

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -35,10 +35,10 @@ import (
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
 	"istio.io/istio/galley/pkg/config/util/kubeyaml"
+	"istio.io/istio/galley/pkg/testing/mock"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schema/collection"
-	kubelib "istio.io/istio/pkg/kube"
 )
 
 type testAnalyzer struct {
@@ -150,11 +150,11 @@ func TestAddInMemorySource(t *testing.T) {
 func TestAddRunningKubeSource(t *testing.T) {
 	g := NewWithT(t)
 
-	k := kubelib.NewFakeClient()
+	mk := mock.NewKube()
 
 	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false, timeout)
 
-	sa.AddRunningKubeSource(k)
+	sa.AddRunningKubeSource(mk)
 	g.Expect(*sa.meshCfg).To(Equal(*mesh.DefaultMeshConfig())) // Base default meshcfg
 	g.Expect(sa.meshNetworks.Networks).To(HaveLen(0))
 	g.Expect(sa.sources).To(HaveLen(1))
@@ -178,16 +178,18 @@ func TestAddRunningKubeSourceWithIstioMeshConfigMap(t *testing.T) {
 		},
 	}
 
-	k := kubelib.NewFakeClient()
-	client := k.Kube()
-
+	mk := mock.NewKube()
+	client, err := mk.KubeClient()
+	if err != nil {
+		t.Fatalf("Error getting client for mock kube: %v", err)
+	}
 	if _, err := client.CoreV1().ConfigMaps(istioNamespace.String()).Create(context.TODO(), cfg, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error creating mesh config configmap: %v", err)
 	}
 
 	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", istioNamespace, nil, false, timeout)
 
-	sa.AddRunningKubeSource(k)
+	sa.AddRunningKubeSource(mk)
 	g.Expect(sa.meshCfg.RootNamespace).To(Equal(testRootNamespace))
 	g.Expect(sa.meshNetworks.Networks).To(HaveLen(2))
 	g.Expect(sa.sources).To(HaveLen(1))
@@ -272,10 +274,10 @@ func TestResourceFiltering(t *testing.T) {
 		fn:     func(_ analysis.Context) {},
 		inputs: []collection.Name{usedCollection.Name()},
 	}
-	k := kubelib.NewFakeClient()
+	mk := mock.NewKube()
 
 	sa := NewSourceAnalyzer(schema.MustGet(), analysis.Combine("a", a), "", "", nil, true, timeout)
-	sa.AddRunningKubeSource(k)
+	sa.AddRunningKubeSource(mk)
 
 	// All but the used collection should be disabled
 	for _, r := range recordedOptions.Schemas.All() {

--- a/galley/pkg/config/source/kube/apiserver/options.go
+++ b/galley/pkg/config/source/kube/apiserver/options.go
@@ -15,17 +15,23 @@
 package apiserver
 
 import (
+	"time"
+
+	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver/status"
 	"istio.io/istio/pkg/config/schema/collection"
-	kubelib "istio.io/istio/pkg/kube"
 )
 
 // Options for the kube controller
 type Options struct {
 	// The Client interfaces to use for connecting to the API server.
-	Client kubelib.Client
+	Client kube.Interfaces
+
+	ResyncPeriod time.Duration
 
 	Schemas collection.Schemas
 
 	StatusController status.Controller
+
+	WatchedNamespaces string
 }

--- a/galley/pkg/config/source/kube/apiserver/options.go
+++ b/galley/pkg/config/source/kube/apiserver/options.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver/status"
 	"istio.io/istio/pkg/config/schema/collection"
+	memberroll "istio.io/istio/pkg/servicemesh/controller"
 )
 
 // Options for the kube controller
@@ -34,4 +35,8 @@ type Options struct {
 	StatusController status.Controller
 
 	WatchedNamespaces string
+
+	MemberRoll memberroll.MemberRollController
+
+	DisableCRDScan bool
 }

--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -125,7 +125,7 @@ func (s *Source) Start() {
 
 	// Start the CRD listener. When the listener is fully-synced, the listening of actual resources will start.
 	scope.Source.Infof("Beginning CRD Discovery, to figure out resources that are available...")
-	s.provider = rt.NewProvider(s.options.Client)
+	s.provider = rt.NewProvider(s.options.Client, s.options.WatchedNamespaces, s.options.ResyncPeriod)
 	a := s.provider.GetAdapter(crdKubeResource.Resource())
 	s.crdWatcher = newWatcher(crdKubeResource, a, s.statusCtl)
 	s.crdWatcher.dispatch(event.HandlerFromFn(s.onCrdEvent))

--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -123,13 +123,29 @@ func (s *Source) Start() {
 	// Releasing the lock here to avoid deadlock on crdWatcher between the existing one and a newly started one.
 	s.mu.Unlock()
 
-	// Start the CRD listener. When the listener is fully-synced, the listening of actual resources will start.
-	scope.Source.Infof("Beginning CRD Discovery, to figure out resources that are available...")
 	s.provider = rt.NewProvider(s.options.Client, s.options.WatchedNamespaces, s.options.ResyncPeriod)
-	a := s.provider.GetAdapter(crdKubeResource.Resource())
-	s.crdWatcher = newWatcher(crdKubeResource, a, s.statusCtl)
-	s.crdWatcher.dispatch(event.HandlerFromFn(s.onCrdEvent))
-	s.crdWatcher.start()
+
+	if s.options.MemberRoll != nil {
+		s.options.MemberRoll.Register(s.provider)
+	}
+
+	if s.options.DisableCRDScan {
+		scope.Source.Infof("Starting listeners for all known types...")
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		for key := range s.expectedResources {
+			s.foundResources[key] = true
+		}
+		s.startWatchers()
+		s.publishing = true
+	} else {
+		// Start the CRD listener. When the listener is fully-synced, the listening of actual resources will start.
+		scope.Source.Infof("Beginning CRD Discovery, to figure out resources that are available...")
+		a := s.provider.GetAdapter(crdKubeResource.Resource())
+		s.crdWatcher = newWatcher(crdKubeResource, a, s.statusCtl)
+		s.crdWatcher.dispatch(event.HandlerFromFn(s.onCrdEvent))
+		s.crdWatcher.start()
+	}
 }
 
 func (s *Source) onCrdEvent(e event.Event) {

--- a/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
+++ b/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
@@ -1,5 +1,4 @@
 // Copyright Istio Authors
-
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,10 +26,10 @@ import (
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
+	"istio.io/istio/galley/pkg/testing/mock"
 	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/resource"
 	resource2 "istio.io/istio/pkg/config/schema/resource"
-	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -66,8 +65,9 @@ func TestBasic(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := kubelib.NewFakeClient()
-	client := k.Kube()
+	k := mock.NewKube()
+	client, err := k.KubeClient()
+	g.Expect(err).To(BeNil())
 
 	// Start the source.
 	s := newOrFail(t, k, k8smeta.MustGet().KubeCollections(), nil)
@@ -81,7 +81,6 @@ func TestBasic(t *testing.T) {
 
 	acc.Clear()
 
-	var err error
 	node := &corev1.Node{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.NodeSpec{
@@ -107,8 +106,9 @@ func TestNodes(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := kubelib.NewFakeClient()
-	client := k.Kube()
+	k := mock.NewKube()
+	client, err := k.KubeClient()
+	g.Expect(err).To(BeNil())
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -121,7 +121,6 @@ func TestNodes(t *testing.T) {
 	}
 	acc.Clear()
 
-	var err error
 	node := &corev1.Node{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.NodeSpec{
@@ -175,8 +174,9 @@ func TestPods(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := kubelib.NewFakeClient()
-	client := k.Kube()
+	k := mock.NewKube()
+	client, err := k.KubeClient()
+	g.Expect(err).To(BeNil())
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -189,7 +189,6 @@ func TestPods(t *testing.T) {
 	}
 	acc.Clear()
 
-	var err error
 	pod := &corev1.Pod{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.PodSpec{
@@ -253,8 +252,9 @@ func TestServices(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := kubelib.NewFakeClient()
-	client := k.Kube()
+	k := mock.NewKube()
+	client, err := k.KubeClient()
+	g.Expect(err).To(BeNil())
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -267,7 +267,6 @@ func TestServices(t *testing.T) {
 	}
 	acc.Clear()
 
-	var err error
 	svc := &corev1.Service{
 		ObjectMeta: fakeObjectMeta,
 		Spec: corev1.ServiceSpec{
@@ -326,8 +325,9 @@ func TestEndpoints(t *testing.T) {
 	prevLevel := setDebugLogLevel()
 	defer restoreLogLevel(prevLevel)
 
-	k := kubelib.NewFakeClient()
-	client := k.Kube()
+	k := mock.NewKube()
+	client, err := k.KubeClient()
+	g.Expect(err).To(BeNil())
 
 	// Start the source.
 	s := newOrFail(t, k, metadata, nil)
@@ -340,7 +340,6 @@ func TestEndpoints(t *testing.T) {
 	}
 	acc.Clear()
 
-	var err error
 	eps := &corev1.Endpoints{
 		ObjectMeta: fakeObjectMeta,
 		Subsets: []corev1.EndpointSubset{

--- a/galley/pkg/config/source/kube/rt/dynamic.go
+++ b/galley/pkg/config/source/kube/rt/dynamic.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
+	xnsinformers "github.com/maistra/xns-informer/pkg/informers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,7 +29,6 @@ import (
 
 	"istio.io/istio/galley/pkg/config/util/pb"
 	"istio.io/istio/pkg/config/schema/resource"
-	"istio.io/istio/pkg/listwatch"
 )
 
 func (p *Provider) getDynamicAdapter(r resource.Schema) *Adapter {
@@ -61,20 +61,23 @@ func (p *Provider) getDynamicAdapter(r resource.Schema) *Adapter {
 				return nil, err
 			}
 
-			mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces, func(namespace string) cache.ListerWatcher {
-				return &cache.ListWatch{
-					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-						return d.List(context.TODO(), options)
+			newInformer := func(namespace string) cache.SharedIndexInformer {
+				return cache.NewSharedIndexInformer(
+					&cache.ListWatch{
+						ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+							return d.Namespace(namespace).List(context.TODO(), options)
+						},
+						WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+							return d.Namespace(namespace).Watch(context.TODO(), options)
+						},
 					},
-					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-						options.Watch = true
-						return d.Watch(context.TODO(), options)
-					},
-				}
-			})
+					&unstructured.Unstructured{},
+					p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				)
+			}
 
-			informer := cache.NewSharedIndexInformer(mlw, &unstructured.Unstructured{}, p.resyncPeriod,
-				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 			return informer, nil
 		},

--- a/galley/pkg/config/source/kube/rt/dynamic.go
+++ b/galley/pkg/config/source/kube/rt/dynamic.go
@@ -15,17 +15,20 @@
 package rt
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	kubeSchema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/galley/pkg/config/util/pb"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/listwatch"
 )
 
 func (p *Provider) getDynamicAdapter(r resource.Schema) *Adapter {
@@ -53,13 +56,27 @@ func (p *Provider) getDynamicAdapter(r resource.Schema) *Adapter {
 		},
 
 		newInformer: func() (cache.SharedIndexInformer, error) {
-			gvr := kubeSchema.GroupVersionResource{
-				Group:    r.Group(),
-				Version:  r.Version(),
-				Resource: r.Plural(),
+			d, err := p.GetDynamicResourceInterface(r)
+			if err != nil {
+				return nil, err
 			}
 
-			return p.kubeClient.DynamicInformer().ForResource(gvr).Informer(), nil
+			mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces, func(namespace string) cache.ListerWatcher {
+				return &cache.ListWatch{
+					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+						return d.List(context.TODO(), options)
+					},
+					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+						options.Watch = true
+						return d.Watch(context.TODO(), options)
+					},
+				}
+			})
+
+			informer := cache.NewSharedIndexInformer(mlw, &unstructured.Unstructured{}, p.resyncPeriod,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+			return informer, nil
 		},
 
 		parseJSON: func(data []byte) (interface{}, error) {

--- a/galley/pkg/config/source/kube/rt/known.go
+++ b/galley/pkg/config/source/kube/rt/known.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/gogo/protobuf/proto"
+	xnsinformers "github.com/maistra/xns-informer/pkg/informers"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -32,7 +33,6 @@ import (
 
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver/stats"
-	"istio.io/istio/pkg/listwatch"
 )
 
 func (p *Provider) initKnownAdapters() {
@@ -55,20 +55,23 @@ func (p *Provider) initKnownAdapters() {
 					return nil, err
 				}
 
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Services(namespace).List(context.TODO(), opts)
+				newInformer := func(namespace string) cache.SharedIndexInformer {
+					return cache.NewSharedIndexInformer(
+						&cache.ListWatch{
+							ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Services(namespace).List(context.TODO(), options)
 							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Services(namespace).Watch(context.TODO(), opts)
+							WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Services(namespace).Watch(context.TODO(), options)
 							},
-						}
-					})
+						},
+						&v1.Service{},
+						p.resyncPeriod,
+						cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+					)
+				}
 
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Service{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 				return informer, nil
 			},
@@ -160,20 +163,23 @@ func (p *Provider) initKnownAdapters() {
 					return nil, err
 				}
 
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Pods(namespace).List(context.TODO(), opts)
+				newInformer := func(namespace string) cache.SharedIndexInformer {
+					return cache.NewSharedIndexInformer(
+						&cache.ListWatch{
+							ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Pods(namespace).List(context.TODO(), options)
 							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Pods(namespace).Watch(context.TODO(), opts)
+							WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Pods(namespace).Watch(context.TODO(), options)
 							},
-						}
-					})
+						},
+						&v1.Pod{},
+						p.resyncPeriod,
+						cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+					)
+				}
 
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Pod{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 				return informer, nil
 			},
@@ -205,20 +211,23 @@ func (p *Provider) initKnownAdapters() {
 					return nil, err
 				}
 
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Secrets(namespace).List(context.TODO(), opts)
+				newInformer := func(namespace string) cache.SharedIndexInformer {
+					return cache.NewSharedIndexInformer(
+						&cache.ListWatch{
+							ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Secrets(namespace).List(context.TODO(), options)
 							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Secrets(namespace).Watch(context.TODO(), opts)
+							WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Secrets(namespace).Watch(context.TODO(), options)
 							},
-						}
-					})
+						},
+						&v1.Secret{},
+						p.resyncPeriod,
+						cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+					)
+				}
 
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Secret{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 				return informer, nil
 			},
@@ -249,20 +258,23 @@ func (p *Provider) initKnownAdapters() {
 					return nil, err
 				}
 
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().Endpoints(namespace).List(context.TODO(), opts)
+				newInformer := func(namespace string) cache.SharedIndexInformer {
+					return cache.NewSharedIndexInformer(
+						&cache.ListWatch{
+							ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Endpoints(namespace).List(context.TODO(), options)
 							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().Endpoints(namespace).Watch(context.TODO(), opts)
+							WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Endpoints(namespace).Watch(context.TODO(), options)
 							},
-						}
-					})
+						},
+						&v1.Endpoints{},
+						p.resyncPeriod,
+						cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+					)
+				}
 
-				informer := cache.NewSharedIndexInformer(mlw, &v1.Endpoints{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 				return informer, nil
 			},
@@ -305,20 +317,23 @@ func (p *Provider) initKnownAdapters() {
 					return nil, err
 				}
 
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.ExtensionsV1beta1().Ingresses(namespace).List(context.TODO(), opts)
+				newInformer := func(namespace string) cache.SharedIndexInformer {
+					return cache.NewSharedIndexInformer(
+						&cache.ListWatch{
+							ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+								return client.ExtensionsV1beta1().Ingresses(namespace).List(context.TODO(), options)
 							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.ExtensionsV1beta1().Ingresses(namespace).Watch(context.TODO(), opts)
+							WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+								return client.ExtensionsV1beta1().Ingresses(namespace).Watch(context.TODO(), options)
 							},
-						}
-					})
+						},
+						&v1beta1.Ingress{},
+						p.resyncPeriod,
+						cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+					)
+				}
 
-				informer := cache.NewSharedIndexInformer(mlw, &v1beta1.Ingress{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 				return informer, nil
 			},
@@ -388,20 +403,23 @@ func (p *Provider) initKnownAdapters() {
 					return nil, err
 				}
 
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.AppsV1().Deployments(namespace).List(context.TODO(), opts)
+				newInformer := func(namespace string) cache.SharedIndexInformer {
+					return cache.NewSharedIndexInformer(
+						&cache.ListWatch{
+							ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+								return client.AppsV1().Deployments(namespace).List(context.TODO(), options)
 							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.AppsV1().Deployments(namespace).Watch(context.TODO(), opts)
+							WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+								return client.AppsV1().Deployments(namespace).Watch(context.TODO(), options)
 							},
-						}
-					})
+						},
+						&appsv1.Deployment{},
+						p.resyncPeriod,
+						cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+					)
+				}
 
-				informer := cache.NewSharedIndexInformer(mlw, &appsv1.Deployment{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 				return informer, nil
 			},
@@ -431,20 +449,23 @@ func (p *Provider) initKnownAdapters() {
 					return nil, err
 				}
 
-				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
-					func(namespace string) cache.ListerWatcher {
-						return &cache.ListWatch{
-							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-								return client.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
+				newInformer := func(namespace string) cache.SharedIndexInformer {
+					return cache.NewSharedIndexInformer(
+						&cache.ListWatch{
+							ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().ConfigMaps(namespace).List(context.TODO(), options)
 							},
-							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-								return client.CoreV1().ConfigMaps(namespace).Watch(context.TODO(), opts)
+							WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().ConfigMaps(namespace).Watch(context.TODO(), options)
 							},
-						}
-					})
+						},
+						&v1.ConfigMap{},
+						p.resyncPeriod,
+						cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+					)
+				}
 
-				informer := cache.NewSharedIndexInformer(mlw, &v1.ConfigMap{}, p.resyncPeriod,
-					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+				informer := xnsinformers.NewMultiNamespaceInformer(p.namespaces, p.resyncPeriod, newInformer)
 
 				return informer, nil
 			},

--- a/galley/pkg/config/source/kube/rt/known.go
+++ b/galley/pkg/config/source/kube/rt/known.go
@@ -32,6 +32,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver/stats"
+	"istio.io/istio/pkg/listwatch"
 )
 
 func (p *Provider) initKnownAdapters() {
@@ -49,7 +50,27 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Service: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Core().V1().Services().Informer(), nil
+				client, err := p.interfaces.KubeClient()
+				if err != nil {
+					return nil, err
+				}
+
+				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
+					func(namespace string) cache.ListerWatcher {
+						return &cache.ListWatch{
+							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Services(namespace).List(context.TODO(), opts)
+							},
+							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Services(namespace).Watch(context.TODO(), opts)
+							},
+						}
+					})
+
+				informer := cache.NewSharedIndexInformer(mlw, &v1.Service{}, p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+				return informer, nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Service{}
@@ -74,7 +95,12 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Namespace: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Core().V1().Namespaces().Informer(), nil
+				informer, err := p.sharedInformerFactory()
+				if err != nil {
+					return nil, err
+				}
+
+				return informer.Core().V1().Namespaces().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Namespace{}
@@ -99,7 +125,12 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Node: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Core().V1().Nodes().Informer(), nil
+				informer, err := p.sharedInformerFactory()
+				if err != nil {
+					return nil, err
+				}
+
+				return informer.Core().V1().Nodes().Informer(), nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Node{}
@@ -124,7 +155,27 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Pod: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Core().V1().Pods().Informer(), nil
+				client, err := p.interfaces.KubeClient()
+				if err != nil {
+					return nil, err
+				}
+
+				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
+					func(namespace string) cache.ListerWatcher {
+						return &cache.ListWatch{
+							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Pods(namespace).List(context.TODO(), opts)
+							},
+							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Pods(namespace).Watch(context.TODO(), opts)
+							},
+						}
+					})
+
+				informer := cache.NewSharedIndexInformer(mlw, &v1.Pod{}, p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+				return informer, nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Pod{}
@@ -149,7 +200,27 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Secret: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Core().V1().Secrets().Informer(), nil
+				client, err := p.interfaces.KubeClient()
+				if err != nil {
+					return nil, err
+				}
+
+				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
+					func(namespace string) cache.ListerWatcher {
+						return &cache.ListWatch{
+							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Secrets(namespace).List(context.TODO(), opts)
+							},
+							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Secrets(namespace).Watch(context.TODO(), opts)
+							},
+						}
+					})
+
+				informer := cache.NewSharedIndexInformer(mlw, &v1.Secret{}, p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+				return informer, nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Secret{}
@@ -173,7 +244,27 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Endpoints: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Core().V1().Endpoints().Informer(), nil
+				client, err := p.interfaces.KubeClient()
+				if err != nil {
+					return nil, err
+				}
+
+				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
+					func(namespace string) cache.ListerWatcher {
+						return &cache.ListWatch{
+							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().Endpoints(namespace).List(context.TODO(), opts)
+							},
+							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().Endpoints(namespace).Watch(context.TODO(), opts)
+							},
+						}
+					})
+
+				informer := cache.NewSharedIndexInformer(mlw, &v1.Endpoints{}, p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+				return informer, nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Endpoints{}
@@ -209,7 +300,27 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1beta1.Ingress: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Extensions().V1beta1().Ingresses().Informer(), nil
+				client, err := p.interfaces.KubeClient()
+				if err != nil {
+					return nil, err
+				}
+
+				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
+					func(namespace string) cache.ListerWatcher {
+						return &cache.ListWatch{
+							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+								return client.ExtensionsV1beta1().Ingresses(namespace).List(context.TODO(), opts)
+							},
+							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+								return client.ExtensionsV1beta1().Ingresses(namespace).Watch(context.TODO(), opts)
+							},
+						}
+					})
+
+				informer := cache.NewSharedIndexInformer(mlw, &v1beta1.Ingress{}, p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+				return informer, nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1beta1.Ingress{}
@@ -231,8 +342,10 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1beta1.Ingress: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				ext := p.kubeClient.Ext()
-
+				ext, err := p.interfaces.APIExtensionsClientset()
+				if err != nil {
+					return nil, err
+				}
 				inf := cache.NewSharedIndexInformer(
 					&cache.ListWatch{
 						ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -247,6 +360,7 @@ func (p *Provider) initKnownAdapters() {
 					cache.Indexers{})
 
 				return inf, nil
+
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1beta12.CustomResourceDefinition{}
@@ -269,7 +383,27 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.Deployment: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Apps().V1().Deployments().Informer(), nil
+				client, err := p.interfaces.KubeClient()
+				if err != nil {
+					return nil, err
+				}
+
+				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
+					func(namespace string) cache.ListerWatcher {
+						return &cache.ListWatch{
+							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+								return client.AppsV1().Deployments(namespace).List(context.TODO(), opts)
+							},
+							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+								return client.AppsV1().Deployments(namespace).Watch(context.TODO(), opts)
+							},
+						}
+					})
+
+				informer := cache.NewSharedIndexInformer(mlw, &appsv1.Deployment{}, p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+				return informer, nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &appsv1.Deployment{}
@@ -292,7 +426,27 @@ func (p *Provider) initKnownAdapters() {
 				return nil, fmt.Errorf("unable to convert to v1.ConfigMap: %T", o)
 			},
 			newInformer: func() (cache.SharedIndexInformer, error) {
-				return p.kubeClient.KubeInformer().Core().V1().ConfigMaps().Informer(), nil
+				client, err := p.interfaces.KubeClient()
+				if err != nil {
+					return nil, err
+				}
+
+				mlw := listwatch.MultiNamespaceListerWatcher(p.namespaces,
+					func(namespace string) cache.ListerWatcher {
+						return &cache.ListWatch{
+							ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+								return client.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
+							},
+							WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+								return client.CoreV1().ConfigMaps(namespace).Watch(context.TODO(), opts)
+							},
+						}
+					})
+
+				informer := cache.NewSharedIndexInformer(mlw, &v1.ConfigMap{}, p.resyncPeriod,
+					cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+				return informer, nil
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.ConfigMap{}

--- a/galley/pkg/config/source/kube/rt/provider.go
+++ b/galley/pkg/config/source/kube/rt/provider.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	xnsinformers "github.com/maistra/xns-informer/pkg/informers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeSchema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -44,7 +45,7 @@ type Provider struct {
 
 	resyncPeriod time.Duration
 	interfaces   kube.Interfaces
-	namespaces   []string
+	namespaces   xnsinformers.NamespaceSet
 	known        map[string]*Adapter
 
 	informers        informers.SharedInformerFactory
@@ -56,7 +57,7 @@ func NewProvider(interfaces kube.Interfaces, namespaces string, resyncPeriod tim
 	p := &Provider{
 		resyncPeriod: resyncPeriod,
 		interfaces:   interfaces,
-		namespaces:   strings.Split(namespaces, ","),
+		namespaces:   xnsinformers.NewNamespaceSet(strings.Split(namespaces, ",")...),
 	}
 
 	p.initKnownAdapters()

--- a/galley/pkg/config/source/kube/rt/provider.go
+++ b/galley/pkg/config/source/kube/rt/provider.go
@@ -65,6 +65,14 @@ func NewProvider(interfaces kube.Interfaces, namespaces string, resyncPeriod tim
 	return p
 }
 
+// SetNamespaces updates the set of namespaces watched by the provider.
+func (p *Provider) SetNamespaces(namespaces ...string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.namespaces.SetNamespaces(namespaces...)
+}
+
 // GetAdapter returns a type for the group/kind. If the type is a well-known type, then the returned type will have
 // a specialized implementation. Otherwise, it will be using the dynamic conversion logic.
 func (p *Provider) GetAdapter(r resource.Schema) *Adapter {

--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -15,14 +15,13 @@
 package components
 
 import (
-	"fmt"
-
 	"istio.io/istio/galley/pkg/config/analysis/analyzers"
 	"istio.io/istio/galley/pkg/config/processing"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter"
 	"istio.io/istio/galley/pkg/config/processor"
 	"istio.io/istio/galley/pkg/config/processor/groups"
 	"istio.io/istio/galley/pkg/config/processor/transforms"
+	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver/status"
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
@@ -30,7 +29,6 @@ import (
 	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/config/schema/collection"
-	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/mcp/monitoring"
 	"istio.io/istio/pkg/mcp/snapshot"
 	"istio.io/pkg/log"
@@ -43,7 +41,7 @@ type Processing struct {
 
 	mcpCache *snapshot.Cache
 
-	k kubelib.Client
+	k kube.Interfaces
 
 	runtime  *processing.Runtime
 	reporter monitoring.Reporter
@@ -51,10 +49,9 @@ type Processing struct {
 }
 
 // NewProcessing returns a new processing component.
-func NewProcessing(k kubelib.Client, a *settings.Args) *Processing {
+func NewProcessing(a *settings.Args) *Processing {
 	mcpCache := snapshot.New(groups.IndexFunction)
 	return &Processing{
-		k:        k,
 		args:     a,
 		mcpCache: mcpCache,
 	}
@@ -122,11 +119,19 @@ func (p *Processing) Start() (err error) {
 	return nil
 }
 
+func (p *Processing) getKubeInterfaces() (k kube.Interfaces, err error) {
+	if p.k == nil {
+		p.k, err = newInterfaces(p.args.KubeConfig)
+	}
+	k = p.k
+	return
+}
+
 func (p *Processing) createSourceAndStatusUpdater(schemas collection.Schemas) (
 	src event.Source, updater snapshotter.StatusUpdater, err error) {
 
-	if p.k == nil {
-		err = fmt.Errorf("kubernetes client is nil")
+	var k kube.Interfaces
+	if k, err = p.getKubeInterfaces(); err != nil {
 		return
 	}
 
@@ -136,9 +141,11 @@ func (p *Processing) createSourceAndStatusUpdater(schemas collection.Schemas) (
 	}
 
 	o := apiserver.Options{
-		Client:           p.k,
-		Schemas:          schemas,
-		StatusController: statusCtl,
+		Client:            k,
+		WatchedNamespaces: p.args.WatchedNamespaces,
+		ResyncPeriod:      p.args.ResyncPeriod,
+		Schemas:           schemas,
+		StatusController:  statusCtl,
 	}
 	s := apiserver.New(o)
 	src = s

--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -142,10 +142,12 @@ func (p *Processing) createSourceAndStatusUpdater(schemas collection.Schemas) (
 
 	o := apiserver.Options{
 		Client:            k,
+		MemberRoll:        p.args.MemberRoll,
 		WatchedNamespaces: p.args.WatchedNamespaces,
 		ResyncPeriod:      p.args.ResyncPeriod,
 		Schemas:           schemas,
 		StatusController:  statusCtl,
+		DisableCRDScan:    p.args.DisableCRDScan,
 	}
 	s := apiserver.New(o)
 	src = s

--- a/galley/pkg/server/settings/args.go
+++ b/galley/pkg/server/settings/args.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/snapshots"
+	memberroll "istio.io/istio/pkg/servicemesh/controller"
 )
 
 const (
@@ -60,6 +61,14 @@ type Args struct { // nolint:maligned
 
 	Snapshots       []string
 	TriggerSnapshot string
+
+	MemberRoll memberroll.MemberRollController
+
+	// DisableCRDScan determines whether the controller will list all CRDs
+	// present in the cluster, and subsequently only create watches on those
+	// that are. If this is set to false, all CRDs defined in the schema must be
+	// present for istiod to function.
+	DisableCRDScan bool
 }
 
 // DefaultArgs allocates an Args struct initialized with Galley's default configuration.

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/local"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter"
+	cfgKube "istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/pkg/config/resource"
@@ -168,10 +169,11 @@ func Analyze() *cobra.Command {
 			if useKube {
 				// Set up the kube client
 				config := kube.BuildClientCmd(kubeconfig, configContext)
-				k, err := kube.NewClient(config)
+				restConfig, err := config.ClientConfig()
 				if err != nil {
 					return err
 				}
+				k := cfgKube.NewInterfaces(restConfig)
 				sa.AddRunningKubeSource(k)
 			}
 

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -147,6 +147,8 @@ func init() {
 
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.MemberRollName, "memberRollName", "",
 		"The name of the MemberRoll resource")
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableCRDScan, "enableCRDScan", true,
+		"Whether to scan CRDs at startup")
 
 	// using address, so it can be configured as localhost:.. (possibly UDS in future)
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.HTTPAddr, "httpAddr", ":8080",

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -361,6 +361,8 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 	processingArgs.WatchedNamespaces = args.RegistryOptions.KubeOptions.WatchedNamespaces
 	processingArgs.MeshConfigFile = args.MeshConfigFile
 	processingArgs.EnableConfigAnalysis = true
+	processingArgs.MemberRoll = s.kubeClient.GetMemberRoll()
+	processingArgs.DisableCRDScan = !args.RegistryOptions.KubeOptions.EnableCRDScan
 
 	processing := components.NewProcessing(processingArgs)
 

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -362,7 +362,7 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 	processingArgs.MeshConfigFile = args.MeshConfigFile
 	processingArgs.EnableConfigAnalysis = true
 
-	processing := components.NewProcessing(s.kubeClient, processingArgs)
+	processing := components.NewProcessing(processingArgs)
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go leaderelection.

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -145,6 +145,12 @@ type Options struct {
 
 	// Duration to wait for cache syncs
 	SyncInterval time.Duration
+
+	// EnableCRDScan determines whether the controller will list all CRDs
+	// present in the cluster, and subsequently only create watches on those
+	// that are. If this is set to false, all CRDs defined in the schema must be
+	// present for istiod to function.
+	EnableCRDScan bool
 }
 
 func (o Options) GetSyncInterval() time.Duration {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -135,6 +135,9 @@ type Client interface {
 
 	// AddMemberRoll creates a MemberRollController and adds it to the client.
 	AddMemberRoll(namespace, memberRollName string) error
+
+	// GetMemberRoll returns the member roll for the client, which may be nil.
+	GetMemberRoll() memberroll.MemberRollController
 }
 
 // ExtendedClient is an extended client with additional helpers/functionality for Istioctl and testing.
@@ -444,6 +447,10 @@ func (c *client) AddMemberRoll(namespace, memberRollName string) (err error) {
 	c.memberRoll.Register(c.serviceapisInformers)
 
 	return nil
+}
+
+func (c *client) GetMemberRoll() memberroll.MemberRollController {
+	return c.memberRoll
 }
 
 // RunAndWait starts all informers and waits for their caches to sync.

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -39,6 +39,7 @@ import (
 
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	"istio.io/istio/pkg/kube"
+	memberroll "istio.io/istio/pkg/servicemesh/controller"
 	"istio.io/pkg/version"
 )
 
@@ -128,6 +129,10 @@ func (c MockClient) SetNamespaces(namespaces ...string) {
 }
 
 func (c MockClient) AddMemberRoll(namespace, memberRollName string) error {
+	panic("not used in mock")
+}
+
+func (c MockClient) GetMemberRoll() memberroll.MemberRollController {
 	panic("not used in mock")
 }
 

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers"
 	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/galley/pkg/config/analysis/local"
+	cfgKube "istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema"
@@ -214,7 +215,8 @@ func GetAnalyze(p *Params) (map[string]string, error) {
 	sa := local.NewSourceAnalyzer(schema.MustGet(), analyzers.AllCombined(),
 		resource.Namespace(p.Namespace), resource.Namespace(p.IstioNamespace), nil, true, 5*time.Minute)
 
-	sa.AddRunningKubeSource(p.Client)
+	k := cfgKube.NewInterfaces(p.Client.RESTConfig())
+	sa.AddRunningKubeSource(k)
 
 	cancel := make(chan struct{})
 	result, err := sa.Analyze(cancel)


### PR DESCRIPTION
This basically is a rewrite of #241, which updated Galley to use the central Kubernetes client. That turned out to not work because Galley manages stopping and starting individual informers on its own, which doesn't play nicely with shared / cached informers managed by a factory.

This creates individual multi-namepsace informers instead. The diff from upstream is much smaller and all the tests and mocks work as-is.

This also brings in the changes to integrate the MemberRoll controller with Galley.