### PR TITLE
MAISTRA-2051: Allow istiod to run without Node access

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -149,6 +149,8 @@ func init() {
 		"The name of the MemberRoll resource")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableCRDScan, "enableCRDScan", true,
 		"Whether to scan CRDs at startup")
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.DisableNodeAccess, "disableNodeAccess", false,
+		"Whether to prevent istiod watching Node objects")
 
 	// using address, so it can be configured as localhost:.. (possibly UDS in future)
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.HTTPAddr, "httpAddr", ":8080",

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -97,7 +97,8 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 			leaderelection.
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, s.kubeClient.Kube()).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
-					ingressSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient)
+					ingressSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient,
+						args.RegistryOptions.KubeOptions.DisableNodeAccess)
 					// Start informers again. This fixes the case where informers for namespace do not start,
 					// as we create them only after acquiring the leader lock
 					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -129,7 +129,7 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
-	sync := NewStatusSyncer(&m, client)
+	sync := NewStatusSyncer(&m, client, false)
 	stop := make(chan struct{})
 	client.RunAndWait(stop)
 	t.Cleanup(func() {


### PR DESCRIPTION
This is a reimplementation of the following for the Maistra 2.1 /
Istio 1.8 rebase:

 - MAISTRA-1723: Allow disabling NodePort gateway support (#180)
 - Ensure Pilot can run without privileges for reading nodes (#125)

A new istiod flag is added, `disableNodeAccess`, that will disable any
feature relying on access to Node objects.