### PR TITLE
MAISTRA-2051: Cherry-picks for Maistra 2.1 / Istio 1.8 rebase

### DIFF
--- a/galley/pkg/config/source/kube/apiserver/source.go
+++ b/galley/pkg/config/source/kube/apiserver/source.go
@@ -126,7 +126,7 @@ func (s *Source) Start() {
 	s.provider = rt.NewProvider(s.options.Client, s.options.WatchedNamespaces, s.options.ResyncPeriod)
 
 	if s.options.MemberRoll != nil {
-		s.options.MemberRoll.Register(s.provider)
+		s.options.MemberRoll.Register(s.provider, "galley")
 	}
 
 	if s.options.DisableCRDScan {

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -174,7 +174,7 @@ func (e *endpointsController) onEvent(curr interface{}, event model.Event) error
 		}
 	}
 
-	return processEndpointEvent(e.c, e, ep.Name, ep.Namespace, event, curr)
+	return processEndpointEvent(e.c, e, ep.Name, ep.Namespace, event, ep)
 }
 
 func (e *endpointsController) forgetEndpoint(endpoint interface{}) {

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -73,7 +73,7 @@ func (esc *endpointSliceController) onEvent(curr interface{}, event model.Event)
 		}
 	}
 
-	return processEndpointEvent(esc.c, esc, ep.Labels[discovery.LabelServiceName], ep.Namespace, event, curr)
+	return processEndpointEvent(esc.c, esc, ep.Labels[discovery.LabelServiceName], ep.Namespace, event, ep)
 }
 
 // GetProxyServiceInstances returns service instances co-located with a given proxy

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -126,7 +126,7 @@ func NewNamespaceController(data func() map[string]string, kubeClient kube.Clien
 			},
 		})
 
-		mrc.Register(c.namespaces)
+		mrc.Register(c.namespaces, "namespace-controller")
 		return c
 	}
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -440,11 +440,11 @@ func (c *client) AddMemberRoll(namespace, memberRollName string) (err error) {
 		return err
 	}
 
-	c.memberRoll.Register(c.kubeInformer)
-	c.memberRoll.Register(c.istioInformer)
-	c.memberRoll.Register(c.dynamicInformer)
-	c.memberRoll.Register(c.metadataInformer)
-	c.memberRoll.Register(c.serviceapisInformers)
+	c.memberRoll.Register(c.kubeInformer, "kubernetes-informers")
+	c.memberRoll.Register(c.istioInformer, "istio-infomrers")
+	c.memberRoll.Register(c.dynamicInformer, "dynamic-informers")
+	c.memberRoll.Register(c.metadataInformer, "metadata-informers")
+	c.memberRoll.Register(c.serviceapisInformers, "service-apis-informers")
 
 	return nil
 }


### PR DESCRIPTION
Cherry-picks of the following for the Maistra 2.1 / Istio 1.8 rebase:

MAISTRA-1724: Better hanlde deletion in NamespaceController
MAISTRA-1908: Fix tombstone handling in endpoints controller
MAISTRA-1755: invoke UpdateNamespaces() as part of MemberRollController.Register()