### PR TITLE
MAISTRA-1897: Allow disabling IngressClass support

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -151,6 +151,8 @@ func init() {
 		"Whether to scan CRDs at startup")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.DisableNodeAccess, "disableNodeAccess", false,
 		"Whether to prevent istiod watching Node objects")
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableIngressClassName, "enableIngressClassName",
+		true, "Whether support processing Ingress resources that use the new ingressClassName field in their spec")
 
 	// using address, so it can be configured as localhost:.. (possibly UDS in future)
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.HTTPAddr, "httpAddr", ":8080",

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -137,7 +137,7 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 	serviceInformer := client.KubeInformer().Core().V1().Services()
 
 	var classes v1beta1.IngressClassInformer
-	if NetworkingIngressAvailable(client) {
+	if options.EnableIngressClassName && NetworkingIngressAvailable(client) {
 		classes = client.KubeInformer().Networking().V1beta1().IngressClasses()
 		// Register the informer now, so it will be properly started
 		_ = classes.Informer()

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -157,6 +157,12 @@ type Options struct {
 	// be available, e.g. NodePort gateways and determining locality information
 	// based on Nodes.
 	DisableNodeAccess bool
+
+	// EnableIngressClassName determines whether the controller will support
+	// processing Kubernetes Ingress resources that use the new (as of 1.18)
+	// `ingressClassName` in their spec, or if it will only check the deprecated
+	// `kubernetes.io/ingress.class` annotation.
+	EnableIngressClassName bool
 }
 
 func (o Options) GetSyncInterval() time.Duration {


### PR DESCRIPTION
This adds an option to istiod that allows disabling reading
IngressClass resources, which are cluster-scoped.  When this is
disabled, processing of Ingress resources that use the new (as of
Kubernetes v1.18) `ingressClassName` field in their spec is not
supported.  Only resources that use the deprecated annotation will be
processed.

Cherry-pick of abb958783e for Maistra 2.1 / Istio 1.8 rebase.