### PR TITLE
MAISTRA-2128: Fix flaky TestClientNoCRDs

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -48,7 +48,7 @@ func makeClient(t *testing.T, schemas collection.Schemas) model.ConfigStoreCache
 		}, metav1.CreateOptions{})
 	}
 	stop := make(chan struct{})
-	config, err := New(fake, "", controller.Options{})
+	config, err := New(fake, "", controller.Options{EnableCRDScan: true})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Introduced by MAISTRA-1895: https://github.com/maistra/istio/pull/260

That test did not exist when we introduced the original change in Istio
1.6. In Istio 1.8 it does, and the default behavior changed with our change.

Thus, we should keep the default behavior that the test expects, i.e.,
having access to all CRD's, aka `options.EnableCRDScan = true`.

Note that `true` is its default value, we explicitly pass the value
`false` in our operator.