### PR TITLE
MAISTRA-2140: Don't use pre-compiled WASM extensions

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -40,10 +40,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -75,10 +75,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -234,10 +234,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -289,10 +289,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -405,10 +405,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -458,10 +458,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -40,10 +40,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -75,10 +75,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -110,10 +110,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -241,10 +241,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -295,10 +295,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -408,10 +408,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -460,10 +460,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -40,10 +40,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -75,10 +75,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -234,10 +234,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -289,10 +289,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -405,10 +405,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -458,10 +458,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -40,10 +40,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -75,10 +75,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -110,10 +110,10 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -241,10 +241,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -295,10 +295,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -408,10 +408,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -460,10 +460,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
+                  allow_precompiled: false
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:


### PR DESCRIPTION
We are not going to use them for 2.1, because they are built
on x86 architecture, hence they will not work on other arches.

So, let's use normal, arch-independent wasm files.
