### PR TITLE
MAISTRA-2137 Make network namespace setup executable name configurable

### DIFF
--- a/cni/cmd/istio-cni/main.go
+++ b/cni/cmd/istio-cni/main.go
@@ -53,6 +53,7 @@ type Kubernetes struct {
 	NodeName             string   `json:"node_name"`
 	ExcludeNamespaces    []string `json:"exclude_namespaces"`
 	CNIBinDir            string   `json:"cni_bin_dir"`
+	NetnsSetupExecutable string   `json:"netns_setup_executable"`
 }
 
 // PluginConf is whatever you expect your configuration json to be. This is whatever
@@ -147,6 +148,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	if conf.Kubernetes.InterceptRuleMgrType != "" {
 		interceptRuleMgrType = conf.Kubernetes.InterceptRuleMgrType
+	}
+	if conf.Kubernetes.NetnsSetupExecutable != "" {
+		nsSetupProg = conf.Kubernetes.NetnsSetupExecutable
 	}
 
 	log.WithLabels("ContainerID", args.ContainerID, "Pod", string(k8sArgs.K8S_POD_NAME),


### PR DESCRIPTION
To support the deployment of multiple CNI plugin versions, the name of the
executable that is invoked to set up the network namespace must be configurable.