### PR TITLE
MAISTRA-2149: Make IOR robust in multiple replicas

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -144,7 +144,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 	if features.EnableIOR {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			go leaderelection.
-				NewLeaderElection(args.Namespace, args.PodName, leaderelection.StatusController, s.kubeClient).
+				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IORController, s.kubeClient).
 				AddRunFunction(func(stop <-chan struct{}) {
 					ior.Register(s.kubeClient, s.configController, args.Namespace, s.mrc, stop)
 				}).Run(stop)

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -142,7 +142,14 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 	s.environment.IstioConfigStore = model.MakeIstioStore(s.configController)
 
 	if features.EnableIOR {
-		ior.Register(s.kubeClient, s.configController, args.Namespace, s.mrc)
+		s.addStartFunc(func(stop <-chan struct{}) error {
+			go leaderelection.
+				NewLeaderElection(args.Namespace, args.PodName, leaderelection.StatusController, s.kubeClient).
+				AddRunFunction(func(stop <-chan struct{}) {
+					ior.Register(s.kubeClient, s.configController, args.Namespace, s.mrc, stop)
+				}).Run(stop)
+			return nil
+		})
 	}
 
 	// Defer starting the controller until after the service is created.

--- a/pilot/pkg/config/kube/ior/ior.go
+++ b/pilot/pkg/config/kube/ior/ior.go
@@ -29,7 +29,7 @@ import (
 var iorLog = log.RegisterScope("ior", "IOR logging", 0)
 
 // Register configures IOR component to respond to Gateway creations and removals
-func Register(client kubernetes.Interface, store model.ConfigStoreCache, pilotNamespace string, mrc memberroll.Controller) {
+func Register(client kubernetes.Interface, store model.ConfigStoreCache, pilotNamespace string, mrc memberroll.Controller, stop <-chan struct{}) {
 	iorLog.Info("Registering IOR component")
 
 	if !isRouteSupported(client) {
@@ -43,8 +43,23 @@ func Register(client kubernetes.Interface, store model.ConfigStoreCache, pilotNa
 		return
 	}
 
+	alive := true
+	go func(stop <-chan struct{}) {
+		// Stop responding to events when we are no longer a leader.
+		// Two notes here:
+		// (1) There's no such method "UnregisterEventHandler()"
+		// (2) It might take a few seconds to this channel to be closed. So, both pods might be leader for a few seconds.
+		<-stop
+		iorLog.Info("This pod is no longer a leader. IOR stopped responding")
+		alive = false
+	}(stop)
+
 	kind := collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
 	store.RegisterEventHandler(kind, func(_, curr model.Config, event model.Event) {
+		if !alive {
+			return
+		}
+
 		// encapsulate in goroutine to not slow down processing because of waiting for mutex
 		go func() {
 			_, ok := curr.Spec.(*networking.Gateway)

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -35,6 +35,7 @@ const (
 	// doing the ingress syncing.
 	IngressController = "istio-leader"
 	StatusController  = "istio-status-leader"
+	IORController     = "ior-leader"
 )
 
 type LeaderElection struct {


### PR DESCRIPTION
In scenarios where multiple replicas of istiod are running,
only one IOR should be in charge of keeping routes in sync
with Istio Gateways. We achieve this by making sure IOR only
runs in the leader replica.

Also, because leader election is not 100% acurate, meaning
that for a small window of time there might be two instances
being the leader - which could lead to duplicated routes
being created if a new gateway is created in that time frame -
we also change the way the Route name is created: Instead of
having a generateName field, we now explicitly pass a name to
the Route object to be created. Being deterministic, it allows
the Route creation to fail when there's already a Route object
with the same name (created by the other leader in that time frame).
