### PR TITLE
MAISTRA-2151: ensure locks are released using defer

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "edb3bbc7c086b21ecd45138a6f17d268b316e8a5"
+    "lastStableSHA": "93ebcf5f6e58c7db2e78c4b36a31cf9e7491372f"
   },
   {
     "_comment": "",


### PR DESCRIPTION
Note the underlying issue which caused MAISTRA-2101 has already been fixed in the 2.0 branch (getResourceVersion not handling a nonce of "") so the reproducer from that issue is not valid.  This cherry picks the same changes with regards to unlocking. 