### PR TITLE
MAISTRA-2149: Make IOR robust in multiple replicas

### DIFF
--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -15,6 +15,8 @@
 package ior
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -201,7 +203,7 @@ func (r *route) createRoute(metadata config.Meta, gateway *networking.Gateway, o
 
 	nr, err := r.client.Routes(serviceNamespace).Create(context.TODO(), &v1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-%s-", metadata.Namespace, metadata.Name),
+			Name: fmt.Sprintf("%s-%s-%s", metadata.Namespace, metadata.Name, hostHash(actualHost)),
 			Labels: map[string]string{
 				generatedByLabel:            generatedByValue,
 				gatewayNamespaceLabel:       metadata.Namespace,
@@ -297,4 +299,15 @@ func findConfig(list []config.Config, name, namespace, resourceVersion string) (
 		}
 	}
 	return config.Config{}, fmt.Errorf("config not found")
+}
+
+// hostHash applies a sha256 on the host and truncate it to the first 8 bytes
+// This gives enough uniqueness for a given hostname
+func hostHash(name string) string {
+	if name == "" {
+		name = "star"
+	}
+
+	hash := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(hash[:8])
 }

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -36,6 +36,7 @@ const (
 	IngressController = "istio-leader"
 	StatusController  = "istio-status-leader"
 	AnalyzeController = "istio-analyze-leader"
+	IORController     = "ior-leader"
 )
 
 type LeaderElection struct {


### PR DESCRIPTION
In scenarios where multiple replicas of istiod are running,
only one IOR should be in charge of keeping routes in sync
with Istio Gateways. We achieve this by making sure IOR only
runs in the leader replica.

Also, because leader election is not 100% acurate, meaning
that for a small window of time there might be two instances
being the leader - which could lead to duplicated routes
being created if a new gateway is created in that time frame -
we also change the way the Route name is created: Instead of
having a generateName field, we now explicitly pass a name to
the Route object to be created. Being deterministic, it allows
the Route creation to fail when there's already a Route object
with the same name (created by the other leader in that time frame).

Use an exclusive leader ID for IOR

Manual cherrypick of https://github.com/maistra/istio/pull/275