### PR TITLE
MAISTRA-2153: Disable namespace informer if MemberRoll is used

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -307,7 +307,8 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		syncInterval:                options.GetSyncInterval(),
 	}
 
-	if options.SystemNamespace != "" {
+	// Don't start the namespace informer if Maistra's MemberRoll is in use.
+	if options.SystemNamespace != "" && options.MemberRollName == "" {
 		c.nsInformer = informers.NewSharedInformerFactoryWithOptions(c.client, options.ResyncPeriod,
 			informers.WithTweakListOptions(func(listOpts *metav1.ListOptions) {
 				listOpts.FieldSelector = fields.OneTermEqualSelector("metadata.name", options.SystemNamespace).String()


### PR DESCRIPTION
This causes istiod to skip creating the namespace informer in the
Kubernetes service registry controller if a MemberRoll is specified,
because Maistra cannot read namespace objects.  This will affect the
behavior of multi-network deployments that do not use mesh networks
for configuration, i.e. a namespace cannot be labeled with a default
network now.