### PR TITLE
MAISTRA-2152: Get namespaces from MemberRoll in gateway controller

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -79,7 +79,7 @@ func TestListInvalidGroupVersionKind(t *testing.T) {
 	g := NewWithT(t)
 	clientSet := fake.NewSimpleClientset()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller2.Options{})
+	controller := NewController(clientSet, store, nil, controller2.Options{})
 
 	typ := config.GroupVersionKind{Kind: "wrong-kind"}
 	c, err := controller.List(typ, "ns1")
@@ -92,7 +92,7 @@ func TestListGatewayResourceType(t *testing.T) {
 
 	clientSet := fake.NewSimpleClientset()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller2.Options{})
+	controller := NewController(clientSet, store, nil, controller2.Options{})
 
 	gwClassType := collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource()
 	gwSpecType := collections.K8SServiceApisV1Alpha1Gateways.Resource()
@@ -141,7 +141,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 
 	clientSet := fake.NewSimpleClientset()
 	store := memory.NewController(memory.Make(collections.All))
-	controller := NewController(clientSet, store, controller2.Options{})
+	controller := NewController(clientSet, store, nil, controller2.Options{})
 
 	gwClassType := collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource()
 	gwSpecType := collections.K8SServiceApisV1Alpha1Gateways.Resource()


### PR DESCRIPTION
This avoids listing namespaces in the gateway controller, which
Maistra can't do, by having the controller take an optional
NamespaceSet argument that is registered with the MemberRoll
controller.  If that is present, the list of namespaces is taken from
it rather than from the API server.

Note that the NamespaceSet will only have access to namespace names
and no other metadata, so this may not work correctly for anything
needing things like annotations, labels, etc. from namespaces.