### PR TITLE
MAISTRA-2165 incorrect lock used in test Reset for tls_ecdh_curves

### DIFF
--- a/pkg/features/tls_ecdh_curves.go
+++ b/pkg/features/tls_ecdh_curves.go
@@ -104,8 +104,8 @@ func (v *TlsEcdhCurvesVar) initEcdhCurves() {
 }
 
 func (v *TlsEcdhCurvesVar) Reset() {
-	lock.Lock()
-	defer lock.Unlock()
+	eclock.Lock()
+	defer eclock.Unlock()
 	v.ecdhCurves = nil
 	v.goEcdhCurves = nil
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
