### PR TITLE
MAISTRA-2166 incorrect lock used in test Reset for tls_ecdh_curves

### DIFF
--- a/pkg/features/tls_ecdh_curves.go
+++ b/pkg/features/tls_ecdh_curves.go
@@ -119,8 +119,8 @@ func (v *TLSECDHCurvesVar) initECDHCurves() {
 }
 
 func (v *TLSECDHCurvesVar) Reset() {
-	lock.Lock()
-	defer lock.Unlock()
+	eclock.Lock()
+	defer eclock.Unlock()
 	v.ecdhCurves = nil
 	v.goECDHCurves = nil
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
