### PR TITLE
MAISTRA-2197: Push first update when cache is warm

### DIFF
--- a/pkg/servicemesh/controller/memberroll/controller.go
+++ b/pkg/servicemesh/controller/memberroll/controller.go
@@ -15,7 +15,6 @@
 package memberroll
 
 import (
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -31,12 +30,15 @@ import (
 	"istio.io/pkg/log"
 )
 
+var smmrLog = log.RegisterScope("smmr", "SMMR controller", 0)
+
 type serviceMeshMemberRollController struct {
 	informer       cache.SharedIndexInformer
 	namespace      string
 	memberRollName string
 	started        bool
 	lock           sync.Mutex
+	cacheWarmed    bool
 }
 
 type Listener interface {
@@ -51,12 +53,10 @@ type Controller interface {
 func NewControllerFromConfigFile(kubeConfig string, namespace string, memberRollName string, resync time.Duration) (Controller, error) {
 	config, err := kube.BuildClientConfig(kubeConfig, "")
 	if err != nil {
-		fmt.Printf("Could not create k8s config: %v", err)
 		return nil, err
 	}
 	cs, err := versioned_v1.NewForConfig(config)
 	if err != nil {
-		fmt.Printf("Could not create k8s clientset: %v", err)
 		return nil, err
 	}
 
@@ -82,6 +82,19 @@ func (smmrc *serviceMeshMemberRollController) Start(stop chan struct{}) {
 	if !smmrc.started {
 		go smmrc.informer.Run(stop)
 		smmrc.started = true
+
+		smmrLog.Debug("Controller started, waiting for cache to warm up")
+		go func() {
+			for {
+				if cache.WaitForNamedCacheSync("SMMR", stop, smmrc.informer.HasSynced) {
+					smmrLog.Debug("Cache warmed up. From now on will send the initial update to listeners")
+					smmrc.cacheWarmed = true
+					return
+				}
+				smmrLog.Debug("Cache not synced, trying again")
+				time.Sleep(time.Second)
+			}
+		}()
 	}
 }
 
@@ -112,7 +125,21 @@ func (smmrc *serviceMeshMemberRollController) newserviceMeshMemberRollListener(l
 		currentNamespaces: nil,
 		name:              name,
 	}
-	handler.updateNamespaces("add", smmrc.memberRollName, smmrc.getNamespaces(nil))
+
+	if smmrc.cacheWarmed {
+		smmrLog.Debugf("Listener for %q created. Ready to send an initial update", name)
+
+		var members []string
+		for _, item := range smmrc.informer.GetIndexer().List() {
+			smmr := item.(*v1.ServiceMeshMemberRoll)
+			members = smmr.Status.ConfiguredMembers
+		}
+		members = smmrc.getNamespaces(members)
+		handler.updateNamespaces("added", smmrc.memberRollName, members)
+	} else {
+		smmrLog.Debugf("Listener for %q created. Not sending an initial update", name)
+	}
+
 	return handler
 }
 
@@ -140,13 +167,13 @@ func (smmrl *serviceMeshMemberRollListener) checkEquality(lhs, rhs []string) boo
 
 func (smmrl *serviceMeshMemberRollListener) updateNamespaces(operation string, memberRollName string, members []string) {
 	if smmrl.smmrc.memberRollName != memberRollName {
-		log.Infof("ServiceMeshMemberRoll using incorrect name %v, ignoring", memberRollName)
+		smmrLog.Errorf("ServiceMeshMemberRoll using incorrect name %v, ignoring", memberRollName)
 	} else {
 		namespaces := smmrl.smmrc.getNamespaces(members)
 		sort.Strings(namespaces)
 		if !smmrl.checkEquality(smmrl.currentNamespaces, namespaces) {
 			smmrl.currentNamespaces = namespaces
-			log.Infof("ServiceMeshMemberRoll %v %s, namespaces for listener %s now %q", memberRollName, operation, smmrl.name, smmrl.currentNamespaces)
+			smmrLog.Debugf("Sending [%s] update to listener %q with %d member(s): %v", operation, smmrl.name, len(namespaces), namespaces)
 			smmrl.listener.UpdateNamespaces(smmrl.currentNamespaces)
 		}
 	}
@@ -167,12 +194,12 @@ func (smmrl *serviceMeshMemberRollListener) OnDelete(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			log.Errorf("Couldn't get object from tombstone %#v", obj)
+			smmrLog.Errorf("Couldn't get object from tombstone %#v", obj)
 			return
 		}
 		serviceMeshMemberRoll, ok = tombstone.Obj.(*v1.ServiceMeshMemberRoll)
 		if !ok {
-			log.Errorf("Tombstone contained object that is not a service mesh member roll %#v", obj)
+			smmrLog.Errorf("Tombstone contained object that is not a service mesh member roll %#v", obj)
 			return
 		}
 	}


### PR DESCRIPTION
Change SMMR Controller behavior to only send the first update to
listeners when it has a list of members ready. In other words, when
cache is synced.

Before this, the first update was sent with only one hardcoded member:
The control plane namespace. Now it is sent with the full list of SMMR
members.

While on that, switch to our own log scope, to facilitate debugging.