### PR TITLE
MAISTRA-2194 && MAISTRA-2195 Federation Service Discovery v1 (incl. /watch endpoint)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/miekg/dns v1.1.34
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/hashstructure/v2 v2.0.1
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v0.0.0-20200929171550-c99a4deebbe5
 	github.com/openshift/client-go v0.0.0-20200929181438-91d71ef2122c

--- a/go.sum
+++ b/go.sum
@@ -702,6 +702,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure/v2 v2.0.1 h1:L60q1+q7cXE4JeEJJKMnh2brFIe3rZxCihYAB61ypAY=
+github.com/mitchellh/hashstructure/v2 v2.0.1/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=

--- a/licenses/github.com/mitchellh/hashstructure/v2/LICENSE
+++ b/licenses/github.com/mitchellh/hashstructure/v2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -168,6 +168,8 @@ func init() {
 		"Discovery service secured gRPC address")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.MonitoringAddr, "monitoringAddr", ":15014",
 		"HTTP address to use for pilot's self-monitoring information")
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.FederationAddr, "federationAddr", ":8188",
+		"Federation Service Discovery HTTP address")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.ServerOptions.EnableProfiling, "profile", true,
 		"Enable profiling via web interface host:port/debug/pprof")
 

--- a/pilot/pkg/bootstrap/multicluster.go
+++ b/pilot/pkg/bootstrap/multicluster.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/pkg/log"
 )
@@ -35,7 +36,9 @@ func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 			log.Info("Unable to create new Multicluster object")
 			return err
 		}
-
+		if features.FederationDiscoveryEndpoint != "" {
+			_ = mc.AddFederatedCluster("remote", features.FederationDiscoveryEndpoint)
+		}
 		s.multicluster = mc
 	}
 	return nil

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -55,6 +55,7 @@ type PilotArgs struct {
 	Namespace          string
 	Revision           string
 	MeshConfigFile     string
+	Network            string
 	NetworksConfigFile string
 	RegistryOptions    RegistryOptions
 	CtrlZOptions       *ctrlz.Options
@@ -93,6 +94,10 @@ type DiscoveryServerOptions struct {
 	// The listening address for secured gRPC. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
 	// a port number is automatically chosen.
 	SecureGRPCAddr string
+
+	// The listening address for federation service discovery. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
+	// a port number is automatically chosen.
+	FederationAddr string
 }
 
 type InjectionOptions struct {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -66,6 +66,7 @@ import (
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/servicemesh/controller/extension"
+	"istio.io/istio/pkg/servicemesh/federation"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/k8s/chiron"
 	"istio.io/istio/security/pkg/pki/ca"
@@ -135,6 +136,8 @@ type Server struct {
 	httpsServer      *http.Server // webhooks HTTPS Server.
 	httpsReadyClient *http.Client
 
+	federationServer *federation.Server
+
 	grpcServer       *grpc.Server
 	secureGrpcServer *grpc.Server
 
@@ -152,9 +155,10 @@ type Server struct {
 	// If the address os empty, the webhooks will be set on the default httpPort.
 	httpsMux *http.ServeMux // webhooks
 
-	HTTPListener       net.Listener
-	GRPCListener       net.Listener
-	SecureGrpcListener net.Listener
+	HTTPListener           net.Listener
+	GRPCListener           net.Listener
+	SecureGrpcListener     net.Listener
+	FederationHTTPListener net.Listener
 
 	// fileWatcher used to watch mesh config, networks and certificates.
 	fileWatcher filewatcher.FileWatcher
@@ -204,6 +208,14 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		httpMux:         http.NewServeMux(),
 		monitoringMux:   http.NewServeMux(),
 		readinessProbes: make(map[string]readinessProbe),
+	}
+
+	if features.EnableFederationDiscoveryServer {
+		var err error
+		s.federationServer, err = federation.NewServer(args.ServerOptions.FederationAddr, e, s.clusterID, features.NetworkName)
+		if err != nil {
+			return nil, fmt.Errorf("error initializing federation server: %v", err)
+		}
 	}
 
 	if args.ShutdownDuration == 0 {
@@ -428,6 +440,10 @@ func (s *Server) Start(stop <-chan struct{}) error {
 				log.Warna(err)
 			}
 		}()
+	}
+
+	if s.federationServer != nil {
+		go s.federationServer.Run(stop)
 	}
 
 	s.waitForShutdown(stop)
@@ -858,6 +874,12 @@ func (s *Server) initRegistryEventHandlers() error {
 	}
 	if err := s.ServiceController().AppendServiceHandler(serviceHandler); err != nil {
 		return fmt.Errorf("append service handler failed: %v", err)
+	}
+
+	if s.federationServer != nil {
+		if err := s.ServiceController().AppendServiceHandler(s.federationServer.UpdateService); err != nil {
+			return fmt.Errorf("append service handler for federation service discovery failed: %v", err)
+		}
 	}
 
 	if s.configController != nil {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -297,6 +297,9 @@ var (
 	ClusterName = env.RegisterStringVar("CLUSTER_ID", "Kubernetes",
 		"Defines the cluster and service registry that this Istiod instance is belongs to").Get()
 
+	NetworkName = env.RegisterStringVar("NETWORK_NAME", "Kubernetes",
+		"Defines the network that this Istiod instance belongs to").Get()
+
 	EnableIncrementalMCP = env.RegisterBoolVar(
 		"PILOT_ENABLE_INCREMENTAL_MCP",
 		false,
@@ -392,4 +395,8 @@ var (
 
 	EnableIOR = env.RegisterBoolVar("ENABLE_IOR", false,
 		"Whether to enable IOR component, which provides integration between Istio Gateways and OpenShift Routes").Get()
+
+	EnableFederationDiscoveryServer = env.RegisterBoolVar("PILOT_ENABLE_FEDERATION_DISCOVERY_SERVER", true, "").Get()
+
+	FederationDiscoveryEndpoint = env.RegisterStringVar("PILOT_REMOTE_FEDERATION_DISCOVERY", "", "").Get()
 )

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/servicemesh/federation"
 	"istio.io/istio/pkg/util/gogo"
 	"istio.io/pkg/log"
 )
@@ -238,6 +239,10 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 				continue
 			}
 			subsetClusters := cb.applyDestinationRule(defaultCluster, SniDnatClusterMode, service, port, networkView)
+			if service.Attributes.Labels[federation.ExportLabel] != "" {
+				defaultCluster.Name = model.BuildDNSSrvSubsetKey(
+					model.TrafficDirectionOutbound, "", host.Name(service.Attributes.Labels[federation.ExportLabel]), port.Port)
+			}
 			clusters = cp.conditionallyAppend(clusters, defaultCluster)
 			clusters = cp.conditionallyAppend(clusters, subsetClusters...)
 		}

--- a/pilot/pkg/serviceregistry/federation/controller.go
+++ b/pilot/pkg/serviceregistry/federation/controller.go
@@ -1,0 +1,316 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package federation
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/servicemesh/federation"
+	"istio.io/pkg/log"
+)
+
+var _ model.ServiceDiscovery = &Controller{}
+var _ model.Controller = &Controller{}
+var _ serviceregistry.Instance = &Controller{}
+
+// Controller aggregates data across different registries and monitors for changes
+type Controller struct {
+	meshHolder        mesh.Holder
+	discoveryEndpoint string
+	networkName       string
+	clusterID         string
+	resyncPeriod      time.Duration
+
+	xdsUpdater model.XDSUpdater
+
+	storeLock     sync.RWMutex
+	serviceStore  []*model.Service
+	instanceStore map[host.Name][]*model.ServiceInstance
+	gatewayStore  []*model.Gateway
+}
+
+type Options struct {
+	MeshHolder        mesh.Holder
+	DiscoveryEndpoint string
+	NetworkName       string
+	ClusterID         string
+	XDSUpdater        model.XDSUpdater
+	ResyncPeriod      time.Duration
+}
+
+// NewController creates a new Aggregate controller
+func NewController(opt Options) *Controller {
+	return &Controller{
+		meshHolder:        opt.MeshHolder,
+		discoveryEndpoint: opt.DiscoveryEndpoint,
+		networkName:       opt.NetworkName,
+		clusterID:         opt.ClusterID,
+		xdsUpdater:        opt.XDSUpdater,
+		resyncPeriod:      opt.ResyncPeriod,
+	}
+}
+
+func (c *Controller) Cluster() string {
+	return c.clusterID
+}
+
+func (c *Controller) Provider() serviceregistry.ProviderID {
+	return serviceregistry.Federation
+}
+
+func (c *Controller) pollServices() *federation.ServiceListMessage {
+	url := c.discoveryEndpoint + "/services/"
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Errorf("Failed to GET URL: '%s': %s", url, err)
+		return nil
+	}
+
+	respBytes := []byte{}
+	_, err = resp.Body.Read(respBytes)
+	if err != nil {
+		log.Errorf("Failed to read response body from URL '%s': %s", url, err)
+		return nil
+	}
+
+	var serviceList federation.ServiceListMessage
+	err = json.NewDecoder(resp.Body).Decode(&serviceList)
+	if err != nil {
+		log.Errorf("Failed to unmarshal response bytes: %s", err)
+		return nil
+	}
+	return &serviceList
+}
+
+func getNameAndNamespaceFromHostname(hostname string) (string, string) {
+	fragments := strings.Split(hostname, ".")
+	if len(fragments) != 5 {
+		log.Warnf("Can't parse hostname: %s", hostname)
+		return hostname, ""
+	}
+	return fragments[0], fragments[1]
+}
+
+func (c *Controller) convertServices(serviceList *federation.ServiceListMessage) {
+	services := []*model.Service{}
+	instances := make(map[host.Name][]*model.ServiceInstance)
+	for _, s := range serviceList.Services {
+		name, namespace := getNameAndNamespaceFromHostname(s.Name)
+		svc := &model.Service{
+			Attributes: model.ServiceAttributes{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Resolution:      model.ClientSideLB,
+			Address:         constants.UnspecifiedIP,
+			Hostname:        host.Name(s.Name),
+			Ports:           model.PortList{},
+			ServiceAccounts: []string{},
+		}
+		for _, port := range s.ServicePorts {
+			svc.Ports = append(svc.Ports, &model.Port{
+				Name:     port.Name,
+				Port:     port.Port,
+				Protocol: protocol.Instance(port.Protocol),
+			})
+		}
+
+		services = append(services, svc)
+		for _, port := range svc.Ports {
+			for _, networkGateway := range serviceList.NetworkGatewayEndpoints {
+				if list, ok := instances[svc.Hostname]; !ok || list == nil {
+					instances[svc.Hostname] = []*model.ServiceInstance{}
+				}
+				instances[svc.Hostname] = append(instances[svc.Hostname], &model.ServiceInstance{
+					Service:     svc,
+					ServicePort: port,
+					Endpoint: &model.IstioEndpoint{
+						Address:      networkGateway.Hostname,
+						EndpointPort: uint32(port.Port),
+						Network:      c.networkName,
+						Locality: model.Locality{
+							ClusterID: c.clusterID,
+						},
+						ServicePortName: port.Name,
+					},
+				})
+			}
+		}
+	}
+	gateways := []*model.Gateway{}
+	for _, gateway := range serviceList.NetworkGatewayEndpoints {
+		gateways = append(gateways, &model.Gateway{
+			Addr: gateway.Hostname,
+			Port: uint32(gateway.Port),
+		})
+	}
+	autoAllocateIPs(services)
+	c.storeLock.Lock()
+	c.serviceStore = services
+	c.instanceStore = instances
+	c.gatewayStore = gateways
+	c.storeLock.Unlock()
+}
+
+func autoAllocateIPs(services []*model.Service) []*model.Service {
+	// i is everything from 240.240.0.(j) to 240.240.255.(j)
+	// j is everything from 240.240.(i).1 to 240.240.(i).254
+	// we can capture this in one integer variable.
+	// given X, we can compute i by X/255, and j is X%255
+	// To avoid allocating 240.240.(i).255, if X % 255 is 0, increment X.
+	// For example, when X=510, the resulting IP would be 240.240.2.0 (invalid)
+	// So we bump X to 511, so that the resulting IP is 240.240.2.1
+	maxIPs := 255 * 255 // are we going to exceeed this limit by processing 64K services?
+	x := 0
+	for _, svc := range services {
+		// we can allocate IPs only if
+		// 1. the service has resolution set to static/dns. We cannot allocate
+		//   for NONE because we will not know the original DST IP that the application requested.
+		// 2. the address is not set (0.0.0.0)
+		// 3. the hostname is not a wildcard
+		if svc.Address == constants.UnspecifiedIP && !svc.Hostname.IsWildCarded() &&
+			svc.Resolution != model.Passthrough {
+			x++
+			if x%255 == 0 {
+				x++
+			}
+			if x >= maxIPs {
+				log.Errorf("out of IPs to allocate for service entries")
+				return services
+			}
+			thirdOctet := x / 255
+			fourthOctet := x % 255
+			svc.AutoAllocatedAddress = fmt.Sprintf("240.241.%d.%d", thirdOctet, fourthOctet)
+		}
+	}
+	return services
+}
+
+// Services lists services
+func (c *Controller) Services() ([]*model.Service, error) {
+	c.storeLock.RLock()
+	defer c.storeLock.RUnlock()
+	return c.serviceStore, nil
+}
+
+// GetService retrieves a service by hostname if exists
+func (c *Controller) GetService(hostname host.Name) (*model.Service, error) {
+	var errs error
+	var out *model.Service
+	return out, errs
+}
+
+// NetworkGateways merges the service-based cross-network gateways from each registry.
+func (c *Controller) NetworkGateways() map[string][]*model.Gateway {
+	c.storeLock.RLock()
+	defer c.storeLock.RUnlock()
+	gws := map[string][]*model.Gateway{}
+	gws[c.networkName] = c.gatewayStore
+	return gws
+}
+
+// InstancesByPort retrieves instances for a service on a given port that match
+// any of the supplied labels. All instances match an empty label list.
+func (c *Controller) InstancesByPort(svc *model.Service, port int, labels labels.Collection) []*model.ServiceInstance {
+	instances := []*model.ServiceInstance{}
+	c.storeLock.RLock()
+	for _, instanceList := range c.instanceStore {
+		for _, instance := range instanceList {
+			if instance.Service == svc && instance.ServicePort.Port == port {
+				instances = append(instances, instance.DeepCopy())
+			}
+		}
+	}
+	c.storeLock.RUnlock()
+	return instances
+}
+
+// GetProxyServiceInstances lists service instances co-located with a given proxy
+func (c *Controller) GetProxyServiceInstances(node *model.Proxy) []*model.ServiceInstance {
+	return make([]*model.ServiceInstance, 0)
+}
+
+func (c *Controller) GetProxyWorkloadLabels(proxy *model.Proxy) labels.Collection {
+	return labels.Collection{}
+}
+
+// Run starts all the controllers
+func (c *Controller) Run(stop <-chan struct{}) {
+	for {
+		select {
+		case <-stop:
+			log.Info("Federation Controller terminated")
+			break
+		default:
+		}
+		svcList := c.pollServices()
+		if svcList != nil {
+			c.convertServices(svcList)
+			c.storeLock.RLock()
+			for hostname, instanceList := range c.instanceStore {
+				endpoints := []*model.IstioEndpoint{}
+				for _, instance := range instanceList {
+					endpoints = append(endpoints, instance.Endpoint)
+				}
+				c.xdsUpdater.SvcUpdate(c.clusterID, string(hostname), instanceList[0].Service.Attributes.Namespace, model.EventUpdate)
+				c.xdsUpdater.EDSUpdate(c.clusterID, string(hostname), instanceList[0].Service.Attributes.Namespace, endpoints)
+			}
+			c.storeLock.RUnlock()
+		}
+		<-time.After(c.resyncPeriod)
+	}
+}
+
+// HasSynced returns true when all registries have synced
+func (c *Controller) HasSynced() bool {
+	return true
+}
+
+// AppendServiceHandler implements a service catalog operation
+func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) error {
+	// TODO
+	return nil
+}
+
+func (c *Controller) AppendWorkloadHandler(f func(*model.WorkloadInstance, model.Event)) error {
+	// TODO
+	return nil
+}
+
+// GetIstioServiceAccounts implements model.ServiceAccounts operation.
+// The returned list contains all SPIFFE based identities that backs the service.
+// This method also expand the results from different registries based on the mesh config trust domain aliases.
+// To retain such trust domain expansion behavior, the xDS server implementation should wrap any (even if single)
+// service registry by this aggreated one.
+// For example,
+// - { "spiffe://cluster.local/bar@iam.gserviceaccount.com"}; when annotation is used on corresponding workloads.
+// - { "spiffe://cluster.local/ns/default/sa/foo" }; normal kubernetes cases
+// - { "spiffe://cluster.local/ns/default/sa/foo", "spiffe://trust-domain-alias/ns/default/sa/foo" };
+//   if the trust domain alias is configured.
+func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []string {
+	return []string{}
+}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -43,6 +43,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
+	"istio.io/istio/pkg/servicemesh/federation"
 	"istio.io/pkg/log"
 	"istio.io/pkg/monitoring"
 )
@@ -446,10 +447,16 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 
 		if len(endpoints) > 0 {
 			c.xdsUpdater.EDSCacheUpdate(c.clusterID, string(svcConv.Hostname), svc.Namespace, endpoints)
+			if svcConv.Attributes.Labels[federation.ExportLabel] != "" {
+				c.xdsUpdater.EDSCacheUpdate(c.clusterID, svcConv.Attributes.Labels[federation.ExportLabel], svc.Namespace, endpoints)
+			}
 		}
 	}
 
 	c.xdsUpdater.SvcUpdate(c.clusterID, string(svcConv.Hostname), svc.Namespace, event)
+	if svcConv.Attributes.Labels[federation.ExportLabel] != "" {
+		c.xdsUpdater.SvcUpdate(c.clusterID, svcConv.Attributes.Labels[federation.ExportLabel], svc.Namespace, event)
+	}
 	// Notify service handlers.
 	for _, f := range c.serviceHandlers {
 		f(svcConv, event)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	"istio.io/istio/pilot/pkg/serviceregistry/federation"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/gvk"
 	kubelib "istio.io/istio/pkg/kube"
@@ -152,6 +153,29 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 	}
 
 	clients.RunAndWait(stopCh)
+	return nil
+}
+
+func (m *Multicluster) AddFederatedCluster(clusterID string, discoveryEndpoint string) error {
+	// stopCh to stop controller created here when cluster removed.
+	stopCh := make(chan struct{})
+	m.m.Lock()
+	options := federation.Options{
+		DiscoveryEndpoint: discoveryEndpoint,
+		ClusterID:         clusterID,
+		XDSUpdater:        m.XDSUpdater,
+		ResyncPeriod:      time.Second * 30,
+	}
+	log.Infof("Initializing Federation service registry %q at %s", options.ClusterID, options.DiscoveryEndpoint)
+	kubectl := federation.NewController(options)
+	m.serviceController.AddRegistry(kubectl)
+	m.m.Unlock()
+
+	// Only need to add service handler for kubernetes registry as `initRegistryEventHandlers`,
+	// because when endpoints update `XDSUpdater.EDSUpdate` has already been called.
+	_ = kubectl.AppendServiceHandler(func(svc *model.Service, ev model.Event) { m.updateHandler(svc) })
+	go kubectl.Run(stopCh)
+
 	return nil
 }
 

--- a/pilot/pkg/serviceregistry/providers.go
+++ b/pilot/pkg/serviceregistry/providers.go
@@ -24,6 +24,8 @@ const (
 	Kubernetes ProviderID = "Kubernetes"
 	// MCP is a service registry backed by MCP ServiceEntries
 	MCP ProviderID = "MCP"
+	// Federation is a service registry backed by Federation
+	Federation ProviderID = "Federation"
 	// External is a service registry for externally provided ServiceEntries
 	External = "External"
 )

--- a/pkg/servicemesh/federation/model.go
+++ b/pkg/servicemesh/federation/model.go
@@ -14,10 +14,12 @@
 
 package federation
 
+import hashstructure "github.com/mitchellh/hashstructure/v2"
+
 type ServiceListMessage struct {
 	Checksum                uint64             `json:"checksum" hash:"ignore"`
-	NetworkGatewayEndpoints []*ServiceEndpoint `json:"networkGatewayEndpoints"`
-	Services                []*ServiceMessage  `json:"services"`
+	NetworkGatewayEndpoints []*ServiceEndpoint `json:"networkGatewayEndpoints" hash:"set"`
+	Services                []*ServiceMessage  `json:"services" hash:"set"`
 }
 
 type ServiceMessage struct {
@@ -34,4 +36,24 @@ type ServicePort struct {
 type ServiceEndpoint struct {
 	Port     int    `json:"port"`
 	Hostname string `json:"hostname"`
+}
+
+type WatchEvent struct {
+	Action   string          `json:"action"`
+	Service  *ServiceMessage `json:"service"`
+	Checksum uint64          `json:"checksum"`
+}
+
+var (
+	ActionAdd    = "add"
+	ActionUpdate = "update"
+	ActionDelete = "delete"
+)
+
+func (s *ServiceListMessage) GenerateChecksum() uint64 {
+	checksum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	if err != nil {
+		return 0
+	}
+	return checksum
 }

--- a/pkg/servicemesh/federation/model.go
+++ b/pkg/servicemesh/federation/model.go
@@ -1,0 +1,37 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package federation
+
+type ServiceListMessage struct {
+	Checksum                uint64             `json:"checksum" hash:"ignore"`
+	NetworkGatewayEndpoints []*ServiceEndpoint `json:"networkGatewayEndpoints"`
+	Services                []*ServiceMessage  `json:"services"`
+}
+
+type ServiceMessage struct {
+	Name         string         `json:"name"`
+	ServicePorts []*ServicePort `json:"servicePorts"`
+}
+
+type ServicePort struct {
+	Name     string `json:"name"`
+	Port     int    `json:"port"`
+	Protocol string `json:"protocol"`
+}
+
+type ServiceEndpoint struct {
+	Port     int    `json:"port"`
+	Hostname string `json:"hostname"`
+}

--- a/pkg/servicemesh/federation/server.go
+++ b/pkg/servicemesh/federation/server.go
@@ -1,0 +1,202 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package federation
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+	hashstructure "github.com/mitchellh/hashstructure/v2"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/pkg/log"
+)
+
+const (
+	ExportLabel = "maistra.io/exportAs"
+)
+
+var (
+	logger = log.RegisterScope("federation-server", "federation-server", 0)
+)
+
+type Server struct {
+	sync.RWMutex
+
+	Env        *model.Environment
+	listener   net.Listener
+	httpServer *http.Server
+	Network    string
+	clusterID  string
+
+	currentServices         map[string]*ServiceMessage
+	currentGatewayEndpoints []*ServiceEndpoint
+}
+
+func NewServer(addr string, env *model.Environment, clusterID, network string) (*Server, error) {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	fed := &Server{
+		Env: env,
+		httpServer: &http.Server{
+			ReadTimeout:    10 * time.Second,
+			MaxHeaderBytes: 1 << 20,
+		},
+		clusterID:       clusterID,
+		Network:         network,
+		currentServices: make(map[string]*ServiceMessage),
+		listener:        listener,
+	}
+	mux := mux.NewRouter()
+	mux.HandleFunc("/services/", fed.handleServiceList)
+	fed.httpServer.Handler = mux
+	return fed, nil
+}
+
+func (s *Server) Addr() string {
+	return s.listener.Addr().String()
+}
+
+func (s *Server) getServiceMessage(svc *model.Service) *ServiceMessage {
+	if svc == nil || svc.Attributes.Labels[ExportLabel] == "" {
+		return nil
+	}
+	ret := &ServiceMessage{
+		Name:         svc.Attributes.Labels[ExportLabel],
+		ServicePorts: make([]*ServicePort, 0),
+	}
+	for _, port := range svc.Ports {
+		ret.ServicePorts = append(ret.ServicePorts, &ServicePort{
+			Name:     port.Name,
+			Port:     port.Port,
+			Protocol: string(port.Protocol),
+		})
+	}
+	return ret
+}
+
+func (s *Server) handleServiceList(response http.ResponseWriter, request *http.Request) {
+	s.RLock()
+	defer s.RUnlock()
+	ret := ServiceListMessage{
+		NetworkGatewayEndpoints: s.currentGatewayEndpoints,
+	}
+	ret.Services = []*ServiceMessage{}
+	for _, svcMessage := range s.currentServices {
+		ret.Services = append(ret.Services, svcMessage)
+	}
+	checksum, err := hashstructure.Hash(ret, hashstructure.FormatV2, nil)
+	if err != nil {
+		logger.Errorf("failed to generate checksum: %s", err)
+		response.WriteHeader(500)
+		return
+	}
+	ret.Checksum = checksum
+	respBytes, err := json.Marshal(ret)
+	if err != nil {
+		logger.Errorf("failed to marshal to json: %s", err)
+		response.WriteHeader(500)
+		return
+	}
+	_, err = response.Write(respBytes)
+	if err != nil {
+		logger.Errorf("failed to send response: %s", err)
+		response.WriteHeader(500)
+		return
+	}
+}
+
+func (s *Server) resync() {
+	s.resyncNetworkGateways()
+
+	s.Lock()
+	defer s.Unlock()
+
+	services, err := s.Env.Services()
+	if err != nil {
+		logger.Errorf("failed to call env.Services(): %s", err)
+		return
+	}
+	serviceMap := make(map[string]*ServiceMessage)
+	for _, svc := range services {
+		svcMessage := s.getServiceMessage(svc)
+		if svcMessage != nil {
+			serviceMap[string(svc.Hostname)] = svcMessage
+		}
+	}
+
+	s.currentServices = serviceMap
+}
+
+func (s *Server) resyncNetworkGateways() {
+	s.Lock()
+	defer s.Unlock()
+
+	gatewayEndpoints := []*ServiceEndpoint{}
+	for _, gateway := range s.Env.NetworkGateways()[s.Network] {
+		gatewayEndpoints = append(gatewayEndpoints, &ServiceEndpoint{
+			Port:     int(gateway.Port),
+			Hostname: gateway.Addr,
+		})
+	}
+	s.currentGatewayEndpoints = gatewayEndpoints
+}
+
+func (s *Server) Run(stopCh <-chan struct{}) {
+	log.Infof("starting federation service discovery at %s", s.Addr())
+	go func() {
+		_ = s.httpServer.Serve(s.listener)
+	}()
+	<-stopCh
+	_ = s.httpServer.Shutdown(context.TODO())
+}
+
+func (s *Server) UpdateService(svc *model.Service, event model.Event) {
+	// this might be a NetworkGateway
+	if svc != nil && svc.Attributes.ClusterExternalAddresses != nil {
+		s.resyncNetworkGateways()
+	}
+
+	var svcMessage *ServiceMessage
+	switch event {
+	case model.EventAdd:
+		svcMessage = s.getServiceMessage(svc)
+		if svcMessage != nil {
+			s.Lock()
+			defer s.Unlock()
+			s.currentServices[string(svc.Hostname)] = svcMessage
+		}
+	case model.EventUpdate:
+		svcMessage = s.getServiceMessage(svc)
+		s.Lock()
+		defer s.Unlock()
+		if svcMessage != nil {
+			s.currentServices[string(svc.Hostname)] = svcMessage
+		} else {
+			delete(s.currentServices, string(svc.Hostname))
+		}
+	case model.EventDelete:
+		s.Lock()
+		defer s.Unlock()
+		delete(s.currentServices, string(svc.Hostname))
+	}
+}

--- a/pkg/servicemesh/federation/server_test.go
+++ b/pkg/servicemesh/federation/server_test.go
@@ -16,6 +16,7 @@ package federation
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -25,6 +26,10 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pkg/config/protocol"
+)
+
+var (
+	ignoreChecksum = cmp.FilterPath(func(p cmp.Path) bool { return p.String() == "Checksum" }, cmp.Ignore())
 )
 
 func TestServiceList(t *testing.T) {
@@ -42,8 +47,7 @@ func TestServiceList(t *testing.T) {
 			name:     "empty serviceList",
 			services: []*model.Service{},
 			expectedMessage: ServiceListMessage{
-				NetworkGatewayEndpoints: []*ServiceEndpoint{},
-				Services:                []*ServiceMessage{},
+				Services: []*ServiceMessage{},
 			},
 		},
 		{
@@ -66,7 +70,6 @@ func TestServiceList(t *testing.T) {
 				},
 			},
 			expectedMessage: ServiceListMessage{
-				NetworkGatewayEndpoints: []*ServiceEndpoint{},
 				Services: []*ServiceMessage{
 					{
 						Name: "service.federation.local",
@@ -233,24 +236,296 @@ func TestServiceList(t *testing.T) {
 			for _, e := range tc.serviceEvents {
 				s.UpdateService(e.svc, e.event)
 			}
-			resp, err := http.Get("http://" + s.Addr() + "/services/")
-			if err != nil {
-				t.Fatal(err)
-			}
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			serviceList := ServiceListMessage{}
-			err = json.Unmarshal(body, &serviceList)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			ignoreChecksum := cmp.FilterPath(func(p cmp.Path) bool { return p.String() == "Checksum" }, cmp.Ignore())
-
-			if diff := cmp.Diff(serviceList, tc.expectedMessage, ignoreChecksum); diff != "" {
+			serviceList := getServiceList(t, s.Addr())
+			tc.expectedMessage.Checksum = serviceList.GenerateChecksum()
+			if diff := cmp.Diff(serviceList, tc.expectedMessage); diff != "" {
 				t.Fatalf("comparison failed, -got +want:\n%s", diff)
+			}
+		})
+	}
+}
+
+func getServiceList(t *testing.T, addr string) ServiceListMessage {
+	resp, err := http.Get("http://" + addr + "/services/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceList := ServiceListMessage{}
+	err = json.Unmarshal(body, &serviceList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return serviceList
+}
+
+func TestWatch(t *testing.T) {
+	testCases := []struct {
+		name          string
+		services      []*model.Service
+		serviceEvents []struct {
+			event model.Event
+			svc   *model.Service
+		}
+		gateways      []*model.Gateway
+		gatewayEvents []struct {
+			newGateways []*model.Gateway
+		}
+		expectedWatchEvents []*WatchEvent
+	}{
+		{
+			name:     "no gateways, service added + removed",
+			services: []*model.Service{},
+			serviceEvents: []struct {
+				event model.Event
+				svc   *model.Service
+			}{
+				{
+					event: model.EventAdd,
+					svc: &model.Service{
+						Hostname: "productpage.bookinfo.svc.cluster.local",
+						Attributes: model.ServiceAttributes{
+							Labels: map[string]string{
+								ExportLabel: "service.federation.local",
+							},
+						},
+						Ports: model.PortList{
+							&model.Port{
+								Name:     "https",
+								Protocol: protocol.HTTPS,
+								Port:     443,
+							},
+						},
+					},
+				},
+				{
+					event: model.EventDelete,
+					svc: &model.Service{
+						Hostname: "productpage.bookinfo.svc.cluster.local",
+					},
+				},
+			},
+			expectedWatchEvents: []*WatchEvent{
+				{
+					Action: ActionAdd,
+					Service: &ServiceMessage{
+						Name: "service.federation.local",
+						ServicePorts: []*ServicePort{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: "HTTPS",
+							},
+						},
+					},
+				},
+				{
+					Action: ActionDelete,
+					Service: &ServiceMessage{
+						Name: "service.federation.local",
+						ServicePorts: []*ServicePort{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: "HTTPS",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no gateways, service exported name changes",
+			services: []*model.Service{
+				{
+					Hostname: "productpage.bookinfo.svc.cluster.local",
+					Attributes: model.ServiceAttributes{
+						Labels: map[string]string{
+							ExportLabel: "service.federation.local",
+						},
+					},
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "https",
+							Protocol: protocol.HTTPS,
+							Port:     443,
+						},
+					},
+				},
+			},
+			serviceEvents: []struct {
+				event model.Event
+				svc   *model.Service
+			}{
+				{
+					event: model.EventUpdate,
+					svc: &model.Service{
+						Hostname: "productpage.bookinfo.svc.cluster.local",
+						Attributes: model.ServiceAttributes{
+							Labels: map[string]string{
+								ExportLabel: "service.cluster.local",
+							},
+						},
+						Ports: model.PortList{
+							&model.Port{
+								Name:     "https",
+								Protocol: protocol.HTTPS,
+								Port:     443,
+							},
+						},
+					},
+				},
+			},
+			expectedWatchEvents: []*WatchEvent{
+				{
+					Action: ActionDelete,
+					Service: &ServiceMessage{
+						Name: "service.federation.local",
+						ServicePorts: []*ServicePort{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: "HTTPS",
+							},
+						},
+					},
+				},
+				{
+					Action: ActionAdd,
+					Service: &ServiceMessage{
+						Name: "service.cluster.local",
+						ServicePorts: []*ServicePort{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: "HTTPS",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single gateway, public IP changed",
+			services: []*model.Service{
+				{
+					Hostname: "productpage.bookinfo.svc.cluster.local",
+					Attributes: model.ServiceAttributes{
+						Labels: map[string]string{
+							ExportLabel: "service.federation.local",
+						},
+					},
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "https",
+							Protocol: protocol.HTTPS,
+							Port:     443,
+						},
+					},
+				},
+			},
+			gateways: []*model.Gateway{
+				{
+					Addr: "127.0.0.1",
+					Port: 443,
+				},
+			},
+			gatewayEvents: []struct{ newGateways []*model.Gateway }{
+				{
+					newGateways: []*model.Gateway{
+						{
+							Addr: "127.0.0.2",
+							Port: 443,
+						},
+					},
+				},
+			},
+			expectedWatchEvents: []*WatchEvent{
+				{
+					Action:  ActionUpdate,
+					Service: nil,
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceDiscovery := memory.NewServiceDiscovery(tc.services)
+			serviceDiscovery.SetGatewaysForNetwork("cluster1", tc.gateways...)
+			env := &model.Environment{
+				ServiceDiscovery: serviceDiscovery,
+			}
+
+			s, _ := NewServer("127.0.0.1:0", env, "cluster1", "cluster1")
+			stopCh := make(chan struct{})
+			go s.Run(stopCh)
+			defer close(stopCh)
+			s.resync()
+			req, err := http.NewRequest("GET", "http://"+s.Addr()+"/watch", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("Status code is not OK: %v (%s)", resp.StatusCode, resp.Status)
+			}
+			for _, e := range tc.serviceEvents {
+				s.UpdateService(e.svc, e.event)
+			}
+			for _, e := range tc.gatewayEvents {
+				serviceDiscovery.SetGatewaysForNetwork("cluster1", e.newGateways...)
+				// trigger a gateway resync
+				s.UpdateService(&model.Service{
+					Attributes: model.ServiceAttributes{
+						ClusterExternalAddresses: map[string][]string{
+							"cluster1": {"a"},
+						},
+					},
+				}, model.EventUpdate)
+			}
+			svcList := ServiceListMessage{}
+			dec := json.NewDecoder(resp.Body)
+			for i := 0; i < len(tc.expectedWatchEvents); i++ {
+				var e WatchEvent
+				err := dec.Decode(&e)
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					t.Fatal(err)
+				}
+				if diff := cmp.Diff(&e, tc.expectedWatchEvents[i], ignoreChecksum); diff != "" {
+					t.Fatalf("comparison failed, -got +want:\n%s", diff)
+				}
+
+				if e.Service == nil {
+					svcList = getServiceList(t, s.Addr())
+				} else if e.Action == ActionAdd {
+					svcList.Services = append(svcList.Services, e.Service)
+				} else if e.Action == ActionUpdate {
+					for i, svc := range svcList.Services {
+						if svc.Name == e.Service.Name {
+							svcList.Services[i] = e.Service
+							break
+						}
+					}
+				} else if e.Action == ActionDelete {
+					for i, svc := range svcList.Services {
+						if svc.Name == e.Service.Name {
+							svcList.Services = append(svcList.Services[:i], svcList.Services[i+1:]...)
+							break
+						}
+					}
+				}
+				if e.Checksum != svcList.GenerateChecksum() {
+					t.Fatalf("checksum mismatch, expected %d but got %d", svcList.GenerateChecksum(), e.Checksum)
+				}
 			}
 		})
 	}

--- a/pkg/servicemesh/federation/server_test.go
+++ b/pkg/servicemesh/federation/server_test.go
@@ -1,0 +1,257 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package federation
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pkg/config/protocol"
+)
+
+func TestServiceList(t *testing.T) {
+	testCases := []struct {
+		name          string
+		services      []*model.Service
+		serviceEvents []struct {
+			event model.Event
+			svc   *model.Service
+		}
+		gateways        []*model.Gateway
+		expectedMessage ServiceListMessage
+	}{
+		{
+			name:     "empty serviceList",
+			services: []*model.Service{},
+			expectedMessage: ServiceListMessage{
+				NetworkGatewayEndpoints: []*ServiceEndpoint{},
+				Services:                []*ServiceMessage{},
+			},
+		},
+		{
+			name: "exported service, no gateway",
+			services: []*model.Service{
+				{
+					Hostname: "productpage.bookinfo.svc.cluster.local",
+					Attributes: model.ServiceAttributes{
+						Labels: map[string]string{
+							ExportLabel: "service.federation.local",
+						},
+					},
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "https",
+							Protocol: protocol.HTTPS,
+							Port:     443,
+						},
+					},
+				},
+			},
+			expectedMessage: ServiceListMessage{
+				NetworkGatewayEndpoints: []*ServiceEndpoint{},
+				Services: []*ServiceMessage{
+					{
+						Name: "service.federation.local",
+						ServicePorts: []*ServicePort{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: "HTTPS",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "exported service + gateway",
+			services: []*model.Service{
+				{
+					Hostname: "productpage.bookinfo.svc.cluster.local",
+					Attributes: model.ServiceAttributes{
+						Labels: map[string]string{
+							ExportLabel: "service.federation.local",
+						},
+					},
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "https",
+							Protocol: protocol.HTTPS,
+							Port:     443,
+						},
+					},
+				},
+				{
+					Hostname: "ratings.bookinfo.svc.cluster.local",
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "https",
+							Protocol: protocol.HTTPS,
+							Port:     443,
+						},
+					},
+				},
+			},
+			gateways: []*model.Gateway{
+				{
+					Addr: "127.0.0.1",
+					Port: 8080,
+				},
+			},
+			expectedMessage: ServiceListMessage{
+				NetworkGatewayEndpoints: []*ServiceEndpoint{
+					{
+						Port:     8080,
+						Hostname: "127.0.0.1",
+					},
+				},
+				Services: []*ServiceMessage{
+					{
+						Name: "service.federation.local",
+						ServicePorts: []*ServicePort{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: "HTTPS",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "exported service + gateway, updated",
+			services: []*model.Service{
+				{
+					Hostname: "productpage.bookinfo.svc.cluster.local",
+					Attributes: model.ServiceAttributes{
+						Labels: map[string]string{
+							ExportLabel: "service.federation.local",
+						},
+					},
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "https",
+							Protocol: protocol.HTTPS,
+							Port:     443,
+						},
+					},
+				},
+				{
+					Hostname: "ratings.bookinfo.svc.cluster.local",
+					Ports: model.PortList{
+						&model.Port{
+							Name:     "https",
+							Protocol: protocol.HTTPS,
+							Port:     443,
+						},
+					},
+				},
+			},
+			gateways: []*model.Gateway{
+				{
+					Addr: "127.0.0.1",
+					Port: 8080,
+				},
+			},
+			serviceEvents: []struct {
+				event model.Event
+				svc   *model.Service
+			}{
+				{
+					event: model.EventUpdate,
+					svc: &model.Service{
+						Hostname: "productpage.bookinfo.svc.cluster.local",
+						Attributes: model.ServiceAttributes{
+							Labels: map[string]string{
+								ExportLabel: "service2.federation.local",
+							},
+						},
+						Ports: model.PortList{
+							&model.Port{
+								Name:     "https",
+								Protocol: protocol.HTTPS,
+								Port:     443,
+							},
+						},
+					},
+				},
+			},
+			expectedMessage: ServiceListMessage{
+				NetworkGatewayEndpoints: []*ServiceEndpoint{
+					{
+						Port:     8080,
+						Hostname: "127.0.0.1",
+					},
+				},
+				Services: []*ServiceMessage{
+					{
+						Name: "service2.federation.local",
+						ServicePorts: []*ServicePort{
+							{
+								Name:     "https",
+								Port:     443,
+								Protocol: "HTTPS",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceDiscovery := memory.NewServiceDiscovery(tc.services)
+			serviceDiscovery.SetGatewaysForNetwork("cluster1", tc.gateways...)
+			env := &model.Environment{
+				ServiceDiscovery: serviceDiscovery,
+			}
+
+			s, _ := NewServer("127.0.0.1:0", env, "cluster1", "cluster1")
+			stopCh := make(chan struct{})
+			go s.Run(stopCh)
+			defer close(stopCh)
+			s.resync()
+			for _, e := range tc.serviceEvents {
+				s.UpdateService(e.svc, e.event)
+			}
+			resp, err := http.Get("http://" + s.Addr() + "/services/")
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			serviceList := ServiceListMessage{}
+			err = json.Unmarshal(body, &serviceList)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ignoreChecksum := cmp.FilterPath(func(p cmp.Path) bool { return p.String() == "Checksum" }, cmp.Ignore())
+
+			if diff := cmp.Diff(serviceList, tc.expectedMessage, ignoreChecksum); diff != "" {
+				t.Fatalf("comparison failed, -got +want:\n%s", diff)
+			}
+		})
+	}
+}

--- a/vendor/github.com/mitchellh/hashstructure/v2/LICENSE
+++ b/vendor/github.com/mitchellh/hashstructure/v2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/hashstructure/v2/README.md
+++ b/vendor/github.com/mitchellh/hashstructure/v2/README.md
@@ -1,0 +1,76 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally, specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+
+  * Optionally, hash the output of `.String()` on structs that implement fmt.Stringer,
+    allowing effective hashing of time.Time
+
+  * Optionally, override the hashing process by implementing `Hashable`.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure/v2
+```
+
+**Note on v2:** It is highly recommended you use the "v2" release since this
+fixes some significant hash collisions issues from v1. In practice, we used
+v1 for many years in real projects at HashiCorp and never had issues, but it
+is highly dependent on the shape of the data you're hashing and how you use
+those hashes.
+
+When using v2+, you can still generate weaker v1 hashes by using the
+`FormatV1` format when calling `Hash`.
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/vendor/github.com/mitchellh/hashstructure/v2/errors.go
+++ b/vendor/github.com/mitchellh/hashstructure/v2/errors.go
@@ -1,0 +1,22 @@
+package hashstructure
+
+import (
+	"fmt"
+)
+
+// ErrNotStringer is returned when there's an error with hash:"string"
+type ErrNotStringer struct {
+	Field string
+}
+
+// Error implements error for ErrNotStringer
+func (ens *ErrNotStringer) Error() string {
+	return fmt.Sprintf("hashstructure: %s has hash:\"string\" set, but does not implement fmt.Stringer", ens.Field)
+}
+
+// ErrFormat is returned when an invalid format is given to the Hash function.
+type ErrFormat struct{}
+
+func (*ErrFormat) Error() string {
+	return "format must be one of the defined Format values in the hashstructure library"
+}

--- a/vendor/github.com/mitchellh/hashstructure/v2/go.mod
+++ b/vendor/github.com/mitchellh/hashstructure/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/mitchellh/hashstructure/v2
+
+go 1.14

--- a/vendor/github.com/mitchellh/hashstructure/v2/hashstructure.go
+++ b/vendor/github.com/mitchellh/hashstructure/v2/hashstructure.go
@@ -1,0 +1,483 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+	"time"
+)
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+
+	// IgnoreZeroValue is determining if zero value fields should be
+	// ignored for hash calculation.
+	IgnoreZeroValue bool
+
+	// SlicesAsSets assumes that a `set` tag is always present for slices.
+	// Default is false (in which case the tag is used instead)
+	SlicesAsSets bool
+
+	// UseStringer will attempt to use fmt.Stringer aways. If the struct
+	// doesn't implement fmt.Stringer, it'll fall back to trying usual tricks.
+	// If this is true, and the "string" tag is also set, the tag takes
+	// precedense (meaning that if the type doesn't implement fmt.Stringer, we
+	// panic)
+	UseStringer bool
+}
+
+// Format specifies the hashing process used. Different formats typically
+// generate different hashes for the same value and have different properties.
+type Format uint
+
+const (
+	// To disallow the zero value
+	formatInvalid Format = iota
+
+	// FormatV1 is the format used in v1.x of this library. This has the
+	// downsides noted in issue #18 but allows simultaneous v1/v2 usage.
+	FormatV1
+
+	// FormatV2 is the current recommended format and fixes the issues
+	// noted in FormatV1.
+	FormatV2
+
+	formatMax // so we can easily find the end
+)
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values. The same *HashOptions value cannot be used
+// concurrently. None of the values within a *HashOptions struct are
+// safe to read/write while hashing is being done.
+//
+// The "format" is required and must be one of the format values defined
+// by this library. You should probably just use "FormatV2". This allows
+// generated hashes uses alternate logic to maintain compatibility with
+// older versions.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+//   * "string" - The field will be hashed as a string, only works when the
+//                field implements fmt.Stringer
+//
+func Hash(v interface{}, format Format, opts *HashOptions) (uint64, error) {
+	// Validate our format
+	if format <= formatInvalid || format >= formatMax {
+		return 0, &ErrFormat{}
+	}
+
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		format:          format,
+		h:               opts.Hasher,
+		tag:             opts.TagName,
+		zeronil:         opts.ZeroNil,
+		ignorezerovalue: opts.IgnoreZeroValue,
+		sets:            opts.SlicesAsSets,
+		stringer:        opts.UseStringer,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	format          Format
+	h               hash.Hash64
+	tag             string
+	zeronil         bool
+	ignorezerovalue bool
+	sets            bool
+	stringer        bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+var timeType = reflect.TypeOf(time.Time{})
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch v.Type() {
+	case timeType:
+		w.h.Reset()
+		b, err := v.Interface().(time.Time).MarshalBinary()
+		if err != nil {
+			return 0, err
+		}
+
+		err = binary.Write(w.h, binary.LittleEndian, b)
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		if w.format != FormatV1 {
+			// Important: read the docs for hashFinishUnordered
+			h = hashFinishUnordered(w.h, h)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		parent := v.Interface()
+		var include Includable
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		if impl, ok := parent.(Hashable); ok {
+			return impl.Hash()
+		}
+
+		// If we can address this value, check if the pointer value
+		// implements our interfaces and use that if so.
+		if v.CanAddr() {
+			vptr := v.Addr()
+			parentptr := vptr.Interface()
+			if impl, ok := parentptr.(Includable); ok {
+				include = impl
+			}
+
+			if impl, ok := parentptr.(Hashable); ok {
+				return impl.Hash()
+			}
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if innerV := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				if w.ignorezerovalue {
+					zeroVal := reflect.Zero(reflect.TypeOf(innerV.Interface())).Interface()
+					if innerV.Interface() == zeroVal {
+						continue
+					}
+				}
+
+				// if string is set, use the string value
+				if tag == "string" || w.stringer {
+					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
+						innerV = reflect.ValueOf(impl.String())
+					} else if tag == "string" {
+						// We only show this error if the tag explicitly
+						// requests a stringer.
+						return 0, &ErrNotStringer{
+							Field: v.Type().Field(i).Name,
+						}
+					}
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, innerV)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(innerV, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+
+			if w.format != FormatV1 {
+				// Important: read the docs for hashFinishUnordered
+				h = hashFinishUnordered(w.h, h)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set || w.sets {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		if set && w.format != FormatV1 {
+			// Important: read the docs for hashFinishUnordered
+			h = hashFinishUnordered(w.h, h)
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// After mixing a group of unique hashes with hashUpdateUnordered, it's always
+// necessary to call hashFinishUnordered. Why? Because hashUpdateUnordered
+// is a simple XOR, and calling hashUpdateUnordered on hashes produced by
+// hashUpdateUnordered can effectively cancel out a previous change to the hash
+// result if the same hash value appears later on. For example, consider:
+//
+//   hashUpdateUnordered(hashUpdateUnordered("A", "B"), hashUpdateUnordered("A", "C")) =
+//   H("A") ^ H("B")) ^ (H("A") ^ H("C")) =
+//   (H("A") ^ H("A")) ^ (H("B") ^ H(C)) =
+//   H(B) ^ H(C) =
+//   hashUpdateUnordered(hashUpdateUnordered("Z", "B"), hashUpdateUnordered("Z", "C"))
+//
+// hashFinishUnordered "hardens" the result, so that encountering partially
+// overlapping input data later on in a different context won't cancel out.
+func hashFinishUnordered(h hash.Hash64, a uint64) uint64 {
+	h.Reset()
+
+	// We just panic if the writes fail
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	if e1 != nil {
+		panic(e1)
+	}
+
+	return h.Sum64()
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/vendor/github.com/mitchellh/hashstructure/v2/include.go
+++ b/vendor/github.com/mitchellh/hashstructure/v2/include.go
@@ -1,0 +1,22 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}
+
+// Hashable is an interface that can optionally be implemented by a struct
+// to override the hash value. This value will override the hash value for
+// the entire struct. Entries in the struct will not be hashed.
+type Hashable interface {
+	Hash() (uint64, error)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -775,6 +775,9 @@ github.com/mitchellh/copystructure
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
+# github.com/mitchellh/hashstructure/v2 v2.0.1
+## explicit
+github.com/mitchellh/hashstructure/v2
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0


### PR DESCRIPTION
This does not yet use CRDs to configure exports, and it doesn't yet offer the option to change service names on import (this depends on the routing part, and also CRDs). Instead, it currently uses a service label (`maistra.io/exportAs`) to determine what the service will be exported as.

The routing is also not final. Instead of mTLS termination at egress/ingress, this was tested using the eastwest-gateway arch that upstream uses for multi-primary deployments.

Now also includes /watch endpoint and client code (in the ServiceRegistry)

If you want to test this, you can do the following:
- check out the `federation` branch of https://github.com/dgn/istio-multicluster
- run `./setup.sh install` - this will setup two kind clusters (you'll need a 1.8.x istioctl)
- mark a service in one of the clusters as exported, e.g. by doing `kubectl --context kind-cluster2 -n sample edit svc helloworld` and adding a `maistra.io/exportAs: helloworld.sample.svc.cluster2.local` label
- check the logs of the other istiod instance to see that it has received the exported service
- try connecting from cluster1's sleep pod to cluster2's now-exported helloworld service: `kubectl --context kind-cluster1 exec -it -n sample <SLEEP_POD_NAME> -- curl -v helloworld.sample.svc.cluster2.local:5000/hello`



Next steps:
- use mTLS termination routing (Rob has been working on this part)
- add CRDs (we should also investigate MCS serviceexport/import here)
- add integration tests