### PR TITLE
MAISTRA-681: Rewrite multi-namespace listwatcher to address performan…

### DIFF
--- a/galley/pkg/source/kube/builtin/source_test.go
+++ b/galley/pkg/source/kube/builtin/source_test.go
@@ -263,10 +263,7 @@ func TestPods(t *testing.T) {
 		if pod, err = client.CoreV1().Pods(namespace).Create(pod); err != nil {
 			t.Fatalf("failed creating pod: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedPod := pod.DeepCopy()
-		expectedPod.ResourceVersion = namespace + "=" + pod.ResourceVersion
-		expected := toEvent(resource.Added, spec, expectedPod, expectedPod)
+		expected := toEvent(resource.Added, spec, pod, pod)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -279,10 +276,7 @@ func TestPods(t *testing.T) {
 		if _, err := client.CoreV1().Pods(namespace).Update(pod); err != nil {
 			t.Fatalf("failed updating pod: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedPod := pod.DeepCopy()
-		expectedPod.ResourceVersion = namespace + "=" + pod.ResourceVersion
-		expected := toEvent(resource.Updated, spec, expectedPod, expectedPod)
+		expected := toEvent(resource.Updated, spec, pod, pod)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -301,10 +295,7 @@ func TestPods(t *testing.T) {
 		if err := client.CoreV1().Pods(namespace).Delete(pod.Name, nil); err != nil {
 			t.Fatalf("failed deleting pod: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedPod := pod.DeepCopy()
-		expectedPod.ResourceVersion = namespace + "=" + pod.ResourceVersion
-		expected := toEvent(resource.Deleted, spec, expectedPod, expectedPod)
+		expected := toEvent(resource.Deleted, spec, pod, pod)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -347,10 +338,7 @@ func TestServices(t *testing.T) {
 		if svc, err = client.CoreV1().Services(namespace).Create(svc); err != nil {
 			t.Fatalf("failed creating service: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedSvc := svc.DeepCopy()
-		expectedSvc.ResourceVersion = namespace + "=" + svc.ResourceVersion
-		expected := toEvent(resource.Added, spec, expectedSvc, &svc.Spec)
+		expected := toEvent(resource.Added, spec, svc, &svc.Spec)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -363,10 +351,7 @@ func TestServices(t *testing.T) {
 		if _, err := client.CoreV1().Services(namespace).Update(svc); err != nil {
 			t.Fatalf("failed updating service: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedSvc := svc.DeepCopy()
-		expectedSvc.ResourceVersion = namespace + "=" + svc.ResourceVersion
-		expected := toEvent(resource.Updated, spec, expectedSvc, &svc.Spec)
+		expected := toEvent(resource.Updated, spec, svc, &svc.Spec)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -385,10 +370,7 @@ func TestServices(t *testing.T) {
 		if err := client.CoreV1().Services(namespace).Delete(svc.Name, nil); err != nil {
 			t.Fatalf("failed deleting service: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedSvc := svc.DeepCopy()
-		expectedSvc.ResourceVersion = namespace + "=" + svc.ResourceVersion
-		expected := toEvent(resource.Deleted, spec, expectedSvc, &expectedSvc.Spec)
+		expected := toEvent(resource.Deleted, spec, svc, &svc.Spec)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -438,10 +420,7 @@ func TestEndpoints(t *testing.T) {
 		if eps, err = client.CoreV1().Endpoints(namespace).Create(eps); err != nil {
 			t.Fatalf("failed creating endpoints: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedEps := eps.DeepCopy()
-		expectedEps.ResourceVersion = namespace + "=" + eps.ResourceVersion
-		expected := toEvent(resource.Added, spec, expectedEps, expectedEps)
+		expected := toEvent(resource.Added, spec, eps, eps)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -454,10 +433,7 @@ func TestEndpoints(t *testing.T) {
 		if _, err := client.CoreV1().Endpoints(namespace).Update(eps); err != nil {
 			t.Fatalf("failed updating endpoints: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedEps := eps.DeepCopy()
-		expectedEps.ResourceVersion = namespace + "=" + eps.ResourceVersion
-		expected := toEvent(resource.Updated, spec, expectedEps, expectedEps)
+		expected := toEvent(resource.Updated, spec, eps, eps)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -478,10 +454,7 @@ func TestEndpoints(t *testing.T) {
 		if err := client.CoreV1().Endpoints(namespace).Delete(eps.Name, nil); err != nil {
 			t.Fatalf("failed deleting endpoints: %v", err)
 		}
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		expectedEps := eps.DeepCopy()
-		expectedEps.ResourceVersion = namespace + "=" + eps.ResourceVersion
-		expected := toEvent(resource.Deleted, spec, expectedEps, expectedEps)
+		expected := toEvent(resource.Deleted, spec, eps, eps)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})

--- a/galley/pkg/source/kube/builtin/types.go
+++ b/galley/pkg/source/kube/builtin/types.go
@@ -68,11 +68,11 @@ var (
 							return cl.CoreV1().Services(namespace).Watch(opts)
 						},
 					}
-				})
+				}, &v1.Service{}, resyncPeriod)
 				if mrc != nil {
 					mrc.Register(mlw)
 				}
-				return cache.NewSharedIndexInformer(mlw, &v1.Service{}, resyncPeriod, cache.Indexers{})
+				return cache.NewSharedIndexInformer(mlw, &v1.Service{}, 0, cache.Indexers{})
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Service{}
@@ -140,11 +140,11 @@ var (
 							return cl.CoreV1().Pods(namespace).Watch(opts)
 						},
 					}
-				})
+				}, &v1.Pod{}, resyncPeriod)
 				if mrc != nil {
 					mrc.Register(mlw)
 				}
-				return cache.NewSharedIndexInformer(mlw, &v1.Pod{}, resyncPeriod, cache.Indexers{})
+				return cache.NewSharedIndexInformer(mlw, &v1.Pod{}, 0, cache.Indexers{})
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Pod{}
@@ -193,11 +193,11 @@ var (
 							return cl.CoreV1().Endpoints(namespace).Watch(opts)
 						},
 					}
-				})
+				}, &v1.Endpoints{}, resyncPeriod)
 				if mrc != nil {
 					mrc.Register(mlw)
 				}
-				return cache.NewSharedIndexInformer(mlw, &v1.Endpoints{}, resyncPeriod, cache.Indexers{})
+				return cache.NewSharedIndexInformer(mlw, &v1.Endpoints{}, 0, cache.Indexers{})
 			},
 			parseJSON: func(input []byte) (interface{}, error) {
 				out := &v1.Endpoints{}

--- a/galley/pkg/source/kube/dynamic/source.go
+++ b/galley/pkg/source/kube/dynamic/source.go
@@ -103,7 +103,7 @@ func (s *source) Start(handler resource.EventHandler) error {
 					return s.resourceClient.Namespace(namespace).Watch(options)
 				},
 			}
-		})
+		}, &unstructured.Unstructured{}, s.resyncPeriod)
 
 		if s.mrc != nil {
 			s.mrc.Register(mlw)
@@ -113,7 +113,7 @@ func (s *source) Start(handler resource.EventHandler) error {
 		s.informer = cache.NewSharedIndexInformer(
 			mlw,
 			&unstructured.Unstructured{},
-			s.resyncPeriod,
+			0,
 			cache.Indexers{})
 
 		s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/galley/pkg/source/kube/dynamic/source_test.go
+++ b/galley/pkg/source/kube/dynamic/source_test.go
@@ -317,8 +317,7 @@ func TestSource_MangledNames(t *testing.T) {
 					Collection: emptyInfo.Collection,
 					FullName:   resource.FullNameFromNamespaceAndName("foo/"+obj.GetNamespace(), obj.GetName()),
 				},
-				// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-				Version: resource.Version(listerWatcherNamespace + "=" + obj.GetResourceVersion()),
+				Version: resource.Version(obj.GetResourceVersion()),
 			},
 			Metadata: resource.Metadata{
 				Labels:      obj.GetLabels(),
@@ -396,8 +395,7 @@ func getID(obj *unstructured.Unstructured) resource.VersionedKey {
 			Collection: emptyInfo.Collection,
 			FullName:   resource.FullNameFromNamespaceAndName(obj.GetNamespace(), obj.GetName()),
 		},
-		// multi namespace lister watcher prepends the namespace used on its creation to the original resource version
-		Version: resource.Version(listerWatcherNamespace + "=" + obj.GetResourceVersion()),
+		Version: resource.Version(obj.GetResourceVersion()),
 	}
 }
 

--- a/mixer/pkg/adapter/test/env.go
+++ b/mixer/pkg/adapter/test/env.go
@@ -127,6 +127,6 @@ func (e *Env) GetDoneChan() chan struct{} {
 
 func (e *Env) NewInformer(clientset kubernetes.Interface, objType runtime.Object, duration time.Duration, listerWatcher func(namespace string) cache.ListerWatcher,
 	indexers cache.Indexers) cache.SharedIndexInformer {
-	mlw := listwatch.MultiNamespaceListerWatcher([]string{""}, listerWatcher)
-	return cache.NewSharedIndexInformer(mlw, objType, duration, indexers)
+	mlw := listwatch.MultiNamespaceListerWatcher([]string{""}, listerWatcher, objType, duration)
+	return cache.NewSharedIndexInformer(mlw, objType, 0, indexers)
 }

--- a/mixer/pkg/runtime/handler/env.go
+++ b/mixer/pkg/runtime/handler/env.go
@@ -147,9 +147,9 @@ func (e env) reportStrayWorkers() {
 
 func (e env) NewInformer(clientset kubernetes.Interface, objType runtime.Object, duration time.Duration, listerWatcher func(namespace string) cache.ListerWatcher,
 	indexers cache.Indexers) cache.SharedIndexInformer {
-	mlw := listwatch.MultiNamespaceListerWatcher(*e.namespaces, listerWatcher)
+	mlw := listwatch.MultiNamespaceListerWatcher(*e.namespaces, listerWatcher, objType, duration)
 	if e.mrc != nil {
 		e.mrc.Register(mlw)
 	}
-	return cache.NewSharedIndexInformer(mlw, objType, duration, indexers)
+	return cache.NewSharedIndexInformer(mlw, objType, 0, indexers)
 }

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -199,14 +199,14 @@ func (c *controller) createInformer(
 	handler.Append(c.notify)
 
 	// TODO: finer-grained index (perf)
-	mlw := listwatch.MultiNamespaceListerWatcher(namespaces, lwf)
+	mlw := listwatch.MultiNamespaceListerWatcher(namespaces, lwf, o, resyncPeriod)
 	if mrc != nil {
 		mrc.Register(mlw)
 	}
 
 	informer := cache.NewSharedIndexInformer(
 		mlw, o,
-		resyncPeriod, cache.Indexers{})
+		0, cache.Indexers{})
 
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -116,12 +116,12 @@ func NewController(client kubernetes.Interface, mrc controller2.MemberRollContro
 				return client.ExtensionsV1beta1().Ingresses(namespace).Watch(options)
 			},
 		}
-	})
+	}, &extensionsv1beta1.Ingress{}, options.ResyncPeriod)
 
 	if mrc != nil {
 		mrc.Register(mlw)
 	}
-	informer := cache.NewSharedIndexInformer(mlw, &extensionsv1beta1.Ingress{}, options.ResyncPeriod, cache.Indexers{})
+	informer := cache.NewSharedIndexInformer(mlw, &extensionsv1beta1.Ingress{}, 0, cache.Indexers{})
 
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -112,11 +112,11 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig,
 				return client.ExtensionsV1beta1().Ingresses(namespace).Watch(opts)
 			},
 		}
-	})
+	}, &v1beta1.Ingress{}, options.ResyncPeriod)
 	if mrc != nil {
 		mrc.Register(mlw)
 	}
-	informer := cache.NewSharedIndexInformer(mlw, &v1beta1.Ingress{}, options.ResyncPeriod, cache.Indexers{})
+	informer := cache.NewSharedIndexInformer(mlw, &v1beta1.Ingress{}, 0, cache.Indexers{})
 
 	st := StatusSyncer{
 		client:              client,

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -210,11 +210,11 @@ func NewController(client kubernetes.Interface, mrc controller.MemberRollControl
 				return client.CoreV1().Services(namespace).Watch(opts)
 			},
 		}
-	})
+	}, &v1.Service{}, options.ResyncPeriod)
 	if mrc != nil {
 		mrc.Register(svcMlw)
 	}
-	svcInformer := cache.NewSharedIndexInformer(svcMlw, &v1.Service{}, options.ResyncPeriod,
+	svcInformer := cache.NewSharedIndexInformer(svcMlw, &v1.Service{}, 0,
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	out.services = out.createCacheHandler(svcInformer, "Services")
 
@@ -227,11 +227,11 @@ func NewController(client kubernetes.Interface, mrc controller.MemberRollControl
 				return client.CoreV1().Endpoints(namespace).Watch(opts)
 			},
 		}
-	})
+	}, &v1.Endpoints{}, options.ResyncPeriod)
 	if mrc != nil {
 		mrc.Register(epMlw)
 	}
-	epInformer := cache.NewSharedIndexInformer(epMlw, &v1.Endpoints{}, options.ResyncPeriod, cache.Indexers{})
+	epInformer := cache.NewSharedIndexInformer(epMlw, &v1.Endpoints{}, 0, cache.Indexers{})
 	out.endpoints = out.createEDSCacheHandler(epInformer, "Endpoints")
 
 	if options.PodLocalitySource == podLocalitySourcePod {
@@ -260,11 +260,11 @@ func NewController(client kubernetes.Interface, mrc controller.MemberRollControl
 				return client.CoreV1().Pods(namespace).Watch(opts)
 			},
 		}
-	})
+	}, &v1.Pod{}, options.ResyncPeriod)
 	if mrc != nil {
 		mrc.Register(podMlw)
 	}
-	podInformer := cache.NewSharedIndexInformer(podMlw, &v1.Pod{}, options.ResyncPeriod, cache.Indexers{})
+	podInformer := cache.NewSharedIndexInformer(podMlw, &v1.Pod{}, 0, cache.Indexers{})
 	out.pods = newPodCache(out.createCacheHandler(podInformer, "Pod"), out)
 
 	return out

--- a/pkg/listwatch/listinformer.go
+++ b/pkg/listwatch/listinformer.go
@@ -1,0 +1,160 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides multiple namespace listerWatcher. This implementation is Largely from
+// https://github.com/coreos/prometheus-operator/pkg/listwatch/listwatch.go
+
+package listwatch
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+/*
+ * This type adapts the events from the informer into events which would come
+ * from a Watch, in this way we can use this as a lower level cache handling
+ * individual namespaces to feed a higher level cache aggregating across all
+ * the namespaces.
+ *
+ * This type will also support draining in that once the namespace has been removed
+ * from the aggregated cache it will issue DELETED events for each entry within this
+ * namespace so that the upper level cache is consistent.
+ */
+type listerInformer struct {
+	namespace  string
+	informer   cache.SharedInformer
+	lllw       *listLenListerWatcher
+	events     func(*watch.Event)
+	stopped    chan struct{}
+	hasStopped bool
+	draining   bool
+	drained    func(string)
+	lock       sync.RWMutex
+}
+
+func newListerInformer(namespace string, f func(string) cache.ListerWatcher, exampleObject runtime.Object,
+	resyncPeriod time.Duration, events func(*watch.Event), drained func(string)) *listerInformer {
+
+	lllw := newListLenListerWatcher(f(namespace))
+	informer := cache.NewSharedInformer(lllw, exampleObject, resyncPeriod)
+
+	li := &listerInformer{
+		namespace: namespace,
+		informer:  informer,
+		lllw:      lllw,
+		events:    events,
+		stopped:   make(chan struct{}),
+		drained:   drained,
+	}
+	informer.AddEventHandler(li)
+	go informer.Run(li.stopped)
+	return li
+}
+
+// The lister informer is considered synced if the underlying
+// informer has synced *and* we have passed sufficient ADDED events
+// to the higher level cache to match the underlying List count.
+func (li *listerInformer) hasSynced() bool {
+	return li.informer.HasSynced() && li.lllw.hasReachedListCount()
+}
+
+func (li *listerInformer) isDraining() bool {
+	li.lock.RLock()
+	defer li.lock.RUnlock()
+	return li.draining
+}
+
+func (li *listerInformer) isStopped() bool {
+	li.lock.RLock()
+	defer li.lock.RUnlock()
+	return li.hasStopped
+}
+
+func (li *listerInformer) drain() {
+	// If we are already draining then there is nothing to do
+	shouldDrain := func() bool {
+		li.lock.Lock()
+		defer li.lock.Unlock()
+		if li.draining {
+			return false
+		}
+		li.draining = true
+		// We are draining.  Stop the underlying informer so it
+		// cannot interfere with our Delete events
+		li.stopInformer()
+		return true
+	}()
+	if shouldDrain {
+		go func() {
+			// Issue Delete events for each entry remaining in the store
+			store := li.informer.GetStore()
+			resourcesToDrain := store.List()
+			for _, resource := range resourcesToDrain {
+				li.OnDelete(resource)
+			}
+			li.lock.Lock()
+			defer li.lock.Unlock()
+			if !li.hasStopped {
+				li.hasStopped = true
+				li.drained(li.namespace)
+			}
+		}()
+	}
+}
+
+func (li *listerInformer) stopInformer() {
+	close(li.stopped)
+}
+
+func (li *listerInformer) stop() {
+	li.lock.Lock()
+	defer li.lock.Unlock()
+	li.hasStopped = true
+	li.stopInformer()
+}
+
+func (li *listerInformer) newWatchEvent(eventType watch.EventType, obj interface{}) *watch.Event {
+	return &watch.Event{
+		eventType, obj.(runtime.Object),
+	}
+}
+
+func (li *listerInformer) sendEvent(event *watch.Event) {
+	li.lock.RLock()
+	defer li.lock.RUnlock()
+	if !li.hasStopped {
+		li.events(event)
+	}
+}
+
+// Adapt an OnAdd event into a watch ADDED event
+func (li *listerInformer) OnAdd(obj interface{}) {
+	li.sendEvent(li.newWatchEvent(watch.Added, obj))
+	li.lllw.incAddCount()
+}
+
+// Adapt an OnUpdate event into a watch MODIFIED event
+func (li *listerInformer) OnUpdate(oldObj, newObj interface{}) {
+	li.sendEvent(li.newWatchEvent(watch.Modified, newObj))
+}
+
+// Adapt an OnDelete event into a watch DELETED event
+func (li *listerInformer) OnDelete(obj interface{}) {
+	li.sendEvent(li.newWatchEvent(watch.Deleted, obj))
+}

--- a/pkg/listwatch/listinformer_test.go
+++ b/pkg/listwatch/listinformer_test.go
@@ -1,0 +1,187 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listwatch
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+func getNamespace(prefix string, id int) string {
+	return fmt.Sprintf("%v-%v", prefix, id)
+}
+
+func getPodName(prefix string, id int) string {
+	return fmt.Sprintf("%v-%v", prefix, id)
+}
+
+func getPodKey(namespace string, prefix string, id int) string {
+	if namespace != "" {
+		return fmt.Sprintf("%v/%v", namespace, getPodName(prefix, id))
+	}
+	return getPodName(prefix, id)
+}
+
+func createPod(namespace string, prefix string, id int) *v1.Pod {
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "",
+			APIVersion: "",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getPodName(prefix, id),
+			Namespace: namespace,
+		},
+		Spec: v1.PodSpec{},
+	}
+}
+
+func createPodList(namespace string, prefix string, count int) *v1.PodList {
+	l := v1.PodList{}
+	index := 1
+	for index <= count {
+		l.Items = append(l.Items, *createPod(namespace, prefix, index))
+		index++
+	}
+	return &l
+}
+
+func checkEvents(t *testing.T, namespace string, events chan *watch.Event, eventType watch.EventType, prefix string, first int, last int) {
+	index := first
+	for index <= last {
+		select {
+		case nextEvent := <-events:
+			if nextEvent.Type != eventType {
+				t.Fatalf("Expected event type %v but received %v", eventType, nextEvent.Type)
+			}
+			pod := nextEvent.Object.(*v1.Pod)
+			if pod.Namespace != namespace {
+				t.Fatalf("Expected pod namespace %v but received %v", namespace, pod.Namespace)
+			}
+			expectedPodName := getPodName(prefix, index)
+			if pod.Name != expectedPodName {
+				t.Fatalf("Expected pod name %v but received %v", expectedPodName, pod.Name)
+			}
+		case <-time.After(time.Minute):
+			t.Fatalf("Expected to receive an event for index %v but did not receive anything", index)
+		}
+		index++
+	}
+}
+
+func TestListInformer(t *testing.T) {
+	testNamespace := "test_namespace"
+	events := make(chan *watch.Event, 100)
+	drained := make(chan string)
+	prefix := "pod"
+	unblock := make(chan struct{})
+	synced := make(chan struct{})
+	w := watch.NewRaceFreeFake()
+	numListPods := 20
+
+	li := newListerInformer(testNamespace, func(string) cache.ListerWatcher {
+		return &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				<-unblock
+				return createPodList(testNamespace, prefix, numListPods), nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				synced <- struct{}{}
+				<-unblock
+				return w, nil
+			},
+		}
+	}, &v1.Pod{}, 0, func(event *watch.Event) {
+		events <- event
+	}, func(namespace string) {
+		drained <- namespace
+	})
+
+	if li.hasSynced() {
+		t.Error("Expected hasSynced to return false before List returns")
+	}
+	unblock <- struct{}{}
+
+	// Check we get pod events added
+	checkEvents(t, testNamespace, events, watch.Added, prefix, 1, numListPods)
+
+	<-synced
+	// Now check synced
+
+	if !li.hasSynced() {
+		t.Error("Expected hasSynced to return true after List returns")
+	}
+
+	// unblock Wait
+	unblock <- struct{}{}
+
+	nextPodID := numListPods + 1
+	// Check added events
+	w.Add(createPod(testNamespace, prefix, nextPodID))
+	checkEvents(t, testNamespace, events, watch.Added, prefix, nextPodID, nextPodID)
+
+	// Check Modified events
+	w.Modify(createPod(testNamespace, prefix, nextPodID))
+	checkEvents(t, testNamespace, events, watch.Modified, prefix, nextPodID, nextPodID)
+
+	// Check Adding an existing one results in a modify event
+	w.Add(createPod(testNamespace, prefix, nextPodID))
+	checkEvents(t, testNamespace, events, watch.Modified, prefix, nextPodID, nextPodID)
+
+	// Check Deleted events
+	w.Delete(createPod(testNamespace, prefix, nextPodID))
+	checkEvents(t, testNamespace, events, watch.Deleted, prefix, nextPodID, nextPodID)
+
+	li.drain()
+	select {
+	case drainedNamespace := <-drained:
+		if testNamespace != drainedNamespace {
+			t.Fatalf("Expected namespace notification for %v on drained channel, received %v",
+				testNamespace, drainedNamespace)
+		}
+	case <-time.After(time.Minute):
+		t.Fatalf("Did not receive notification from draining channel")
+	}
+	drainedPods := make(map[string]string)
+	close(events)
+
+	for event, ok := <-events; ok; {
+		if watch.Deleted != event.Type {
+			t.Fatalf("Expected to see a %v event but received %v", watch.Deleted, event.Type)
+		}
+		name := event.Object.(*v1.Pod).Name
+		drainedPods[name] = name
+		event, ok = <-events
+	}
+	if len(drainedPods) != numListPods {
+		t.Fatalf("Expected to see %v pods, but received %v", numListPods, len(drainedPods))
+	}
+
+	index := 1
+	for index <= numListPods {
+		name := getPodName(prefix, index)
+		if _, ok := drainedPods[name]; !ok {
+			t.Fatalf("Expected to see information about pod %v but it is not part of the drain", name)
+		}
+		index++
+	}
+}

--- a/pkg/listwatch/listlenlisterwatcher.go
+++ b/pkg/listwatch/listlenlisterwatcher.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides multiple namespace listerWatcher. This implementation is Largely from
+// https://github.com/coreos/prometheus-operator/pkg/listwatch/listwatch.go
+
+package listwatch
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+/*
+ * This type allows us to track the count of resources returned from the informer's
+ * invocation of the List method and compare it with the number of add events which
+ * have been sent from the list informer.  We use this comparison to gauge whether
+ * the informer has synced and that all events have been passed through to the upper
+ * level cache.
+ */
+type listLenListerWatcher struct {
+	listerWatcher cache.ListerWatcher
+	listCount     int
+	addCount      int
+	lock          sync.Mutex
+}
+
+func newListLenListerWatcher(listerWatcher cache.ListerWatcher) *listLenListerWatcher {
+	return &listLenListerWatcher{
+		listerWatcher: listerWatcher,
+		listCount:     -1,
+	}
+}
+
+func (lllw *listLenListerWatcher) resetCounts() {
+	lllw.lock.Lock()
+	defer lllw.lock.Unlock()
+	lllw.listCount = -1
+	lllw.addCount = 0
+}
+
+func (lllw *listLenListerWatcher) setListCount(listCount int) {
+	lllw.lock.Lock()
+	defer lllw.lock.Unlock()
+	lllw.listCount = listCount
+}
+
+func (lllw *listLenListerWatcher) incAddCount() {
+	lllw.lock.Lock()
+	defer lllw.lock.Unlock()
+	if lllw.listCount < 0 || lllw.addCount < lllw.listCount {
+		lllw.addCount++
+	}
+}
+
+func (lllw *listLenListerWatcher) hasReachedListCount() bool {
+	lllw.lock.Lock()
+	defer lllw.lock.Unlock()
+	return lllw.listCount <= lllw.addCount
+}
+
+func (lllw *listLenListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	lllw.resetCounts()
+	result, err := lllw.listerWatcher.List(options)
+	if err != nil {
+		return result, err
+	}
+	lllw.setListCount(meta.LenList(result))
+	return result, err
+}
+
+func (lllw *listLenListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	return lllw.listerWatcher.Watch(options)
+}

--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -18,17 +18,23 @@
 package listwatch
 
 import (
-	"fmt"
-	"strings"
 	"sync"
+	"time"
 
+	"github.com/pkg/errors"
 	"istio.io/istio/pkg/servicemesh/controller"
-	"istio.io/pkg/log"
-	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+
+	"istio.io/pkg/log"
+)
+
+var (
+	scope = log.RegisterScope("mlw", "mlw", 0)
 )
 
 type NamespaceListerWatcher interface {
@@ -36,266 +42,294 @@ type NamespaceListerWatcher interface {
 	controller.MemberRollListener
 }
 
-// MultiNamespaceListerWatcher takes a list of namespaces and a
-// cache.ListerWatcher generator func and returns a single cache.ListerWatcher
-// capable of operating on multiple namespaces.
-func MultiNamespaceListerWatcher(namespaces []string, f func(string) cache.ListerWatcher) NamespaceListerWatcher {
-	return newMultiListerWatcher(namespaces, f)
+// MultiNamespaceListerWatcher takes a list of namespaces,
+// cache.ListerWatcher generator func, an Object and a Duration
+// and returns a single cache.ListerWatcher capable of operating on multiple namespaces.
+func MultiNamespaceListerWatcher(namespaces []string, f func(string) cache.ListerWatcher,
+	exampleObject runtime.Object, resyncPeriod time.Duration) NamespaceListerWatcher {
+	return newMultiListerWatcher(namespaces, f, exampleObject, resyncPeriod)
 }
-
-// multiListerWatcher abstracts several cache.ListerWatchers, allowing them
-// to be treated as a single cache.ListerWatcher.
 
 type listerWatcherState int
 
 const (
-	created      listerWatcherState = 0
-	listed       listerWatcherState = 1
-	watching     listerWatcherState = 2
-	errorOnWatch listerWatcherState = 3
-	stopping     listerWatcherState = 4
+	created listerWatcherState = iota
+	listing
+	listed
+	watching
 )
 
-type listerWatcher struct {
-	lw      cache.ListerWatcher
-	stopper func()
-}
-
+// multiListerWatcher encapsulates multiple informers and aggregates their content through a single channel
 type multiListerWatcher struct {
-	namespaces []string
-	f          func(string) cache.ListerWatcher
-	state      listerWatcherState
-	result     chan watch.Event
-	stopped    chan struct{}
-	wg         *sync.WaitGroup
-	lwMap      map[string]*listerWatcher
-	lock       sync.Mutex
+	namespaces    []string
+	f             func(string) cache.ListerWatcher
+	state         listerWatcherState
+	result        chan watch.Event
+	exampleObject runtime.Object
+	resyncPeriod  time.Duration
+	stopped       chan struct{}
+	events        chan *watch.Event
+	activeMap     map[string]*listerInformer
+	drainingMap   map[string]*listerInformer
+	drained       chan string
+	listingMap    map[string]*runtime.Object
+	lock          sync.RWMutex
 }
 
-type combinedEvent struct {
-	namespace string
-	event     watch.Event
-}
+func newMultiListerWatcher(namespaces []string, f func(string) cache.ListerWatcher, exampleObject runtime.Object,
+	resyncPeriod time.Duration) *multiListerWatcher {
 
-func newMultiListerWatcher(namespaces []string, f func(string) cache.ListerWatcher) *multiListerWatcher {
 	return &multiListerWatcher{
-		namespaces: append(namespaces[:0:0], namespaces...),
-		f:          f,
-		state:      created,
+		namespaces:    append(namespaces[:0:0], namespaces...),
+		f:             f,
+		state:         created,
+		exampleObject: exampleObject,
+		resyncPeriod:  resyncPeriod,
 	}
+}
+
+// Proxy the event on behalf of each namespace
+func (mlw *multiListerWatcher) handleEvents(event *watch.Event) {
+	select {
+	case <-mlw.stopped:
+	case mlw.events <- event:
+	}
+}
+
+// Proxy the drained notification on behalf of each namespace
+func (mlw *multiListerWatcher) handleDrained(namespace string) {
+	select {
+	case <-mlw.stopped:
+	case mlw.drained <- namespace:
+	}
+}
+
+// Must hold the lock around this function,  should not be called when in created state
+// create a new lister informer for a specific namespace
+func (mlw *multiListerWatcher) addNamespace(namespace string) *listerInformer {
+	return newListerInformer(namespace, mlw.f, mlw.exampleObject, mlw.resyncPeriod, mlw.handleEvents, mlw.handleDrained)
+}
+
+// Must hold the lock around this function
+func (mlw *multiListerWatcher) drainNamespace(namespace string) {
+	// If the namespace is in the active map then move it to the draining map and invokc drain
+	if li, ok := mlw.activeMap[namespace]; ok {
+		mlw.drainingMap[namespace] = li
+		delete(mlw.activeMap, namespace)
+		li.drain()
+	}
+}
+
+// Handle the update of namespaces
+// Must hold the lock around this function
+func (mlw *multiListerWatcher) updateNamespaces(namespaces []string) []string {
+	activeMap := make(map[string]*listerInformer)
+	for _, namespace := range namespaces {
+		if li, ok := mlw.activeMap[namespace]; ok {
+			// If we are already watching the namespace then move it to the new map
+			activeMap[namespace] = li
+			delete(mlw.activeMap, namespace)
+		} else if dli, ok := mlw.drainingMap[namespace]; ok {
+			// If we are already draining the namespace then move it to the new map
+			// Once the drain has completed a new list informer will be created
+			// to enumerate the namespace contents at that time
+			activeMap[namespace] = dli
+			delete(mlw.drainingMap, namespace)
+		} else {
+			// We are watching a new namespace, create the underlying informer and add to the map
+			activeMap[namespace] = mlw.addNamespace(namespace)
+		}
+	}
+
+	// Drain all remaining namespaces in the map, the informer will be moved into the draining map
+	drainedNamespaces := make([]string, 0, len(mlw.activeMap))
+	for namespace := range mlw.activeMap {
+		drainedNamespaces = append(drainedNamespaces, namespace)
+		mlw.drainNamespace(namespace)
+	}
+
+	mlw.activeMap = activeMap
+	return drainedNamespaces
 }
 
 // Update the set of namespaces being tracked
 func (mlw *multiListerWatcher) UpdateNamespaces(namespaces []string) {
+	scope.Debugf("Namespaces updated: %s", namespaces)
 	mlw.lock.Lock()
 	defer mlw.lock.Unlock()
 
-	mlw.namespaces = append(namespaces[:0:0], namespaces...)
+	mlwNamespaces := append(namespaces[:0:0], namespaces...)
 
-	switch mlw.state {
-	case listed:
-		mlw.state = errorOnWatch
-	case watching:
-		mlw.reportError("Namespaces Updated")
+	if mlw.state == listed || mlw.state == watching {
+		mlw.updateNamespaces(mlwNamespaces)
 	}
+	mlw.namespaces = mlwNamespaces
 }
 
-// Report error on result channel and close, state changes to created
-// Must be called with lock held
-func (mlw *multiListerWatcher) reportError(message string) {
-	if mlw.state != watching {
-		return
-	}
-	mlw.state = stopping
-	mlw.wg.Add(1)
-	go func(result chan watch.Event, stopped chan struct{}, wg *sync.WaitGroup) {
-		defer wg.Done()
-		select {
-		case <-stopped:
-			return
-		case result <- watch.Event{Type: watch.Error, Object: &metav1.Status{
-			Status:  metav1.StatusFailure,
-			Reason:  metav1.StatusReasonExpired,
-			Message: message,
-		}}:
-			return
+// Wait for all the underlying caches to sync, this means that they
+// will all have performed a List and sent sufficient events through
+// this layer to ensure Listed events are returned
+func (mlw *multiListerWatcher) waitForCacheSync() bool {
+	return cache.WaitForCacheSync(mlw.stopped, func() bool {
+		mlw.lock.RLock()
+		defer mlw.lock.RUnlock()
+		for _, liValue := range mlw.activeMap {
+			if !liValue.hasSynced() {
+				return false
+			}
 		}
-	}(mlw.result, mlw.stopped, mlw.wg)
+		return true
+	})
 }
 
 // List implements the ListerWatcher interface.
-// It combines the output of the List method of every ListerWatcher into
+// It combines the output of each synced informer into
 // a single result.
 func (mlw *multiListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
-	l := metav1.List{}
-	var resourceVersions []string
+	scope.Debugf("List() called with ResourceVersion '%s'", options.ResourceVersion)
 
-	mlw.lock.Lock()
-	defer mlw.lock.Unlock()
+	stopped := make(chan struct{})
 
-	if mlw.state == watching || mlw.state == stopping {
-		mlw.stopInternal()
+	err := func() error {
+		mlw.lock.Lock()
+		defer mlw.lock.Unlock()
+
+		if mlw.state != created {
+			return errors.Errorf("Unexpected state, expected to be in %v but am in %v", created, mlw.state)
+		}
+
+		var (
+			result      = make(chan watch.Event)
+			events      = make(chan *watch.Event)
+			activeMap   = make(map[string]*listerInformer)
+			drainingMap = make(map[string]*listerInformer)
+			drained     = make(chan string)
+			listingMap  = make(map[string]*runtime.Object)
+		)
+		mlw.result = result
+		mlw.stopped = stopped
+		mlw.events = events
+		mlw.activeMap = activeMap
+		mlw.drainingMap = drainingMap
+		mlw.drained = drained
+		mlw.listingMap = listingMap
+
+		mlw.state = listing
+
+		// goroutine for processing events from the individual namespace caches
+		// and forwarding them through to the top level, aggregated cache
+		go func() {
+			defer close(result)
+			for {
+				select {
+				case <-stopped:
+					return
+				case nextEvent := <-events:
+					key, err := cache.MetaNamespaceKeyFunc(nextEvent.Object)
+					if err == nil {
+						sendResult := func() bool {
+							mlw.lock.Lock()
+							defer mlw.lock.Unlock()
+							// If we are still listing then we track the resources in the listing map so the List
+							// function can return them as a result
+							if mlw.state == listing {
+								if nextEvent.Type == watch.Added || nextEvent.Type == watch.Modified {
+									mlw.listingMap[key] = &nextEvent.Object
+								} else if nextEvent.Type == watch.Deleted {
+									delete(mlw.listingMap, key)
+								}
+								return false
+							}
+							// otherwise we send the result through the channel to the watcher
+							return true
+						}()
+						if sendResult {
+							select {
+							case <-stopped:
+								break
+							case result <- *nextEvent:
+							}
+						}
+					}
+				}
+			}
+		}()
+
+		// goroutine for processing drained notifications sent after the underlying
+		// cache has issued all appropriate Delete events
+		go func() {
+			for {
+				select {
+				case <-stopped:
+					return
+				case drainedNamespace := <-drained:
+					func() {
+						mlw.lock.Lock()
+						defer mlw.lock.Unlock()
+						// If we are active (listed/watching) then check to see
+						// if the namespace has been added back into the active map
+						if mlw.state == listed || mlw.state == watching {
+							if _, ok := mlw.drainingMap[drainedNamespace]; ok {
+								// namespace is really removed, delete it from the draining map
+								delete(mlw.drainingMap, drainedNamespace)
+							} else if _, ok := mlw.activeMap[drainedNamespace]; ok {
+								// namespace has been moved back to the active map, create a new informer
+								mlw.activeMap[drainedNamespace] = mlw.addNamespace(drainedNamespace)
+							}
+						}
+					}()
+				}
+			}
+		}()
+
+		// process all namespaces currently being listed, creating informers for each namespace
+		mlw.updateNamespaces(mlw.namespaces)
+		return nil
+	}()
+
+	if err != nil {
+		mlw.Stop()
+		return nil, err
 	}
 
-	mlw.lwMap = make(map[string]*listerWatcher)
+	// Wait for all the underlying informers to sync
+	mlw.waitForCacheSync()
+	// Retrieve the listingMap containing all received events, after this point
+	// the events will go to the event channel
+	listingMap := func() map[string]*runtime.Object {
+		mlw.lock.Lock()
+		defer mlw.lock.Unlock()
+		mlw.state = listed
+		listingMap := mlw.listingMap
+		mlw.listingMap = nil
+		return listingMap
+	}()
 
-	mlw.state = listed
-
-	for _, n := range mlw.namespaces {
-		lws := &listerWatcher{lw: mlw.f(n)}
-		mlw.lwMap[n] = lws
-		list, err := lws.lw.List(options)
-		if err != nil {
-			return nil, err
-		}
-		items, err := meta.ExtractList(list)
-		if err != nil {
-			return nil, err
-		}
-		metaObj, err := meta.ListAccessor(list)
-		if err != nil {
-			return nil, err
-		}
-		for _, item := range items {
-			l.Items = append(l.Items, runtime.RawExtension{Object: item.DeepCopyObject()})
-		}
-		resourceVersions = append(resourceVersions, fmt.Sprintf("%s=%s", n, metaObj.GetResourceVersion()))
+	l := v1.List{}
+	for _, item := range listingMap {
+		l.Items = append(l.Items, runtime.RawExtension{Object: *item})
 	}
-	// Combine the resource versions so that the composite Watch method can
-	// distribute appropriate versions to each underlying Watch func.
-	l.ListMeta.ResourceVersion = strings.Join(resourceVersions, "/")
+	l.ListMeta.ResourceVersion = "0"
 
 	return &l, nil
 }
 
 // Watch implements the ListerWatcher interface.
-// It returns a watch.Interface that combines the output from the
-// watch.Interface of every cache.ListerWatcher into a single result chan.
+// It returns a watch.Interface implementation which aggregates the events from
+// each individual namespace Informer into a single result chan.
 func (mlw *multiListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
-	resourceVersions := make(map[string]string)
+	scope.Debugf("Watch() called with ResourceVersion '%s'", options.ResourceVersion)
 
-	// Allow resource versions to be "".
-	if options.ResourceVersion != "" {
-		rvs := strings.Split(options.ResourceVersion, "/")
-		for _, nrv := range rvs {
-			equalsIndex := strings.IndexByte(nrv, '=')
-			if equalsIndex == -1 {
-				log.Infof("Received unexpected resource version %s", nrv)
-			} else {
-				namespace := nrv[:equalsIndex]
-				resourceVersion := nrv[equalsIndex+1:]
-				resourceVersions[namespace] = resourceVersion
-			}
-		}
-	}
-	if err := mlw.newMultiWatch(resourceVersions, options); err != nil {
-		return nil, err
-	}
-	return mlw, nil
-}
-
-// newMultiWatch returns a new multiWatch or an error if one of the underlying
-// Watch funcs errored. The length of []cache.ListerWatcher and []string must
-// match.
-func (mlw *multiListerWatcher) newMultiWatch(resourceVersions map[string]string, options metav1.ListOptions) error {
 	mlw.lock.Lock()
 	defer mlw.lock.Unlock()
-
-	var (
-		result         = make(chan watch.Event)
-		stopped        = make(chan struct{})
-		wg             sync.WaitGroup
-		combinedResult = make(chan *combinedEvent)
-	)
-	mlw.result = result
-	mlw.stopped = stopped
-	mlw.wg = &wg
-
-	if mlw.state == errorOnWatch {
-		mlw.state = watching
-
-		mlw.reportError("Namespaces Updated")
-		return nil
+	if mlw.state != listed {
+		mlw.stopInternal()
+		return nil, errors.Errorf("Unexpected state, expected to be in %v but am in %v", listed, mlw.state)
 	}
 
 	mlw.state = watching
 
-	wg.Add(len(mlw.lwMap) + 1)
-
-	go func() {
-		defer wg.Done()
-		resourceVersions := make(map[string]string)
-		for {
-			var event *combinedEvent
-			select {
-			case event = <-combinedResult:
-			case <-stopped:
-				return
-			}
-
-			resultEvent := *event.event.DeepCopy()
-			resultNamespace := event.namespace
-			if resultEvent.Type != watch.Error {
-				metaObj, err := meta.Accessor(resultEvent.Object)
-				if err != nil {
-					log.Infof("Unable to identify watch event, ignoring resource version")
-				} else {
-					resourceVersions[resultNamespace] = fmt.Sprintf("%s=%s", resultNamespace, metaObj.GetResourceVersion())
-					var versions []string
-					for _, resourceVersion := range resourceVersions {
-						versions = append(versions, resourceVersion)
-					}
-					newResourceVersion := strings.Join(versions, "/")
-					metaObj.SetResourceVersion(newResourceVersion)
-				}
-			}
-
-			select {
-			case result <- resultEvent:
-			case <-stopped:
-				return
-			}
-		}
-	}()
-
-	for n, lws := range mlw.lwMap {
-		o := options.DeepCopy()
-		o.ResourceVersion = resourceVersions[n]
-		w, err := lws.lw.Watch(*o)
-		if err != nil {
-			return err
-		}
-
-		go func(namespace string) {
-			defer wg.Done()
-
-			for {
-				event, ok := <-w.ResultChan()
-				if !ok {
-					mlw.lock.Lock()
-					defer mlw.lock.Unlock()
-					mlw.reportError("Underlying Result Channel closed")
-					return
-				}
-
-				select {
-				case combinedResult <- &combinedEvent{namespace, event}:
-				case <-stopped:
-					return
-				}
-			}
-		}(n)
-		lws.stopper = w.Stop
-	}
-
-	// result chan must be closed,
-	// once all event sender goroutines exited.
-	go func() {
-		wg.Wait()
-		close(combinedResult)
-		close(result)
-	}()
-	return nil
+	return mlw, nil
 }
 
 // ResultChan implements the watch.Interface interface.
@@ -304,7 +338,6 @@ func (mlw *multiListerWatcher) ResultChan() <-chan watch.Event {
 }
 
 // Stop implements the watch.Interface interface.
-// It stops all of the underlying watch.Interfaces and closes the backing chan.
 // Can safely be called more than once.
 func (mlw *multiListerWatcher) Stop() {
 	mlw.lock.Lock()
@@ -318,12 +351,12 @@ func (mlw *multiListerWatcher) stopInternal() {
 	case <-mlw.stopped:
 		// nothing to do, we are already stopped
 	default:
-		for _, lw := range mlw.lwMap {
-			if lw.stopper != nil {
-				lw.stopper()
-			}
+		for _, li := range mlw.activeMap {
+			li.stop()
 		}
 		close(mlw.stopped)
+		mlw.activeMap = nil
+		mlw.drainingMap = nil
 		mlw.state = created
 	}
 }

--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -16,10 +16,13 @@ package listwatch
 
 import (
 	"errors"
-	"k8s.io/api/core/v1"
 	"sync"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,68 +32,61 @@ import (
 
 var _ watch.Interface = &multiListerWatcher{}
 
-func setupMultiWatch(t *testing.T, namespaces []string, rvs map[string]string) (map[string]*watch.FakeWatcher, *multiListerWatcher) {
+func checkError(t *testing.T, msg string, err error, args ...interface{}) {
+	if err != nil {
+		t.Errorf(msg, args...)
+	}
+}
+
+//nolint:unparam
+func setupMultiWatch(t *testing.T, namespaces []string, exampleObject runtime.Object,
+	resyncPeriod time.Duration) (map[string]*watch.FakeWatcher, *sync.Mutex, *multiListerWatcher) {
 	n := len(namespaces)
 	ws := make(map[string]*watch.FakeWatcher, n)
+	wsLock := sync.Mutex{}
 
 	mlw := newMultiListerWatcher(namespaces, func(namespace string) cache.ListerWatcher {
 		return &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				l := metav1.List{}
-				l.ListMeta.ResourceVersion = rvs[namespace]
+				l.ListMeta.ResourceVersion = "0"
 				return &l, nil
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				wsLock.Lock()
+				defer wsLock.Unlock()
 				w := watch.NewFake()
 				ws[namespace] = w
 				return w, nil
 			},
 		}
-	})
+	}, exampleObject, resyncPeriod)
 
 	if _, err := mlw.List(metav1.ListOptions{}); err != nil {
-		t.Fatalf("failed to invoke List: %v", err)
+		t.Errorf("failed to invoke List: %v", err)
 	}
 
-	if err := mlw.newMultiWatch(rvs, metav1.ListOptions{}); err != nil {
-		t.Fatalf("failed to create new multiWatch: %v", err)
+	if _, err := mlw.Watch(metav1.ListOptions{}); err != nil {
+		t.Errorf("failed to create new multiWatch: %v", err)
 	}
-	return ws, mlw
-}
-
-func TestNewMultiWatch(t *testing.T) {
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("newMultiWatch should not panic when number of resource versions is less than ListerWatchers; got: %v", r)
-			}
-		}()
-		// Create a multiWatch from 2 ListerWatchers but only pass 1 resource version.
-		_, _ = setupMultiWatch(t, []string{"1", "2"}, map[string]string{"1": "resource1"})
-	}()
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("newMultiWatch should not panic when number of resource versions matches ListerWatchers; got: %v", r)
-			}
-		}()
-		// Create a multiWatch from 2 ListerWatchers and pass 2 resource versions.
-		_, _ = setupMultiWatch(t, []string{"1", "2"}, map[string]string{"1": "resource1", "2": "resource2"})
-	}()
+	return ws, &wsLock, mlw
 }
 
 func TestMultiWatchResultChan(t *testing.T) {
-	ws, m := setupMultiWatch(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}, map[string]string{})
+	ws, wsLock, m := setupMultiWatch(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}, &v1.Pod{}, 0)
 	defer m.Stop()
 	var events []watch.Event
 	var wg sync.WaitGroup
-	for _, w := range ws {
-		w := w
-		wg.Add(1)
-		go func() {
-			w.Add(&v1.Pod{})
-		}()
-	}
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		for n, w := range ws {
+			wg.Add(1)
+			go func(n string, w *watch.FakeWatcher) {
+				w.Add(createPod(n, "pod", 1))
+			}(n, w)
+		}
+	}()
 	go func() {
 		for {
 			event, ok := <-m.ResultChan()
@@ -108,18 +104,22 @@ func TestMultiWatchResultChan(t *testing.T) {
 }
 
 func TestMultiWatchStop(t *testing.T) {
-	ws, m := setupMultiWatch(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}, map[string]string{})
+	ws, wsLock, m := setupMultiWatch(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}, &v1.Pod{}, 0)
 	m.Stop()
-	var stopped int
-	for _, w := range ws {
-		_, running := <-w.ResultChan()
-		if !running && w.IsStopped() {
-			stopped++
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		var stopped int
+		for _, w := range ws {
+			_, running := <-w.ResultChan()
+			if !running && w.IsStopped() {
+				stopped++
+			}
 		}
-	}
-	if stopped != len(ws) {
-		t.Errorf("expected %d watchers to be stopped but got %d", len(ws), stopped)
-	}
+		if stopped != len(ws) {
+			t.Errorf("expected %d watchers to be stopped but got %d", len(ws), stopped)
+		}
+	}()
 	select {
 	case <-m.stopped:
 		// all good, watcher is closed, proceed
@@ -133,36 +133,45 @@ func TestMultiWatchStop(t *testing.T) {
 }
 
 func TestMultiWatchResultChannelStop(t *testing.T) {
-	ws, m := setupMultiWatch(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}, map[string]string{})
+	ws, wsLock, m := setupMultiWatch(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}, &v1.Pod{}, 0)
 
-	ws["1"].Stop();
-	ws["2"].Stop();
-	event, running := <-m.ResultChan()
-	if !running {
-		t.Errorf("expected multiWatch chan to remain open for error")
-	}
-	if event.Type != watch.Error {
-		t.Errorf("expected multiWatch chan to return error")
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		ws["1"].Stop()
+		ws["2"].Stop()
+	}()
+	select {
+	case _, running := <-m.ResultChan():
+		if !running {
+			t.Errorf("expected multiWatch chan to remain open")
+		}
+	case <-time.After(5 * time.Second):
+		break
 	}
 	m.Stop()
 
-	var stopped int
-	for _, w := range ws {
-		_, running := <-w.ResultChan()
-		if !running && w.IsStopped() {
-			stopped++
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		var stopped int
+		for _, w := range ws {
+			_, running := <-w.ResultChan()
+			if !running && w.IsStopped() {
+				stopped++
+			}
 		}
-	}
-	if stopped != len(ws) {
-		t.Errorf("expected %d watchers to be stopped but got %d", len(ws), stopped)
-	}
+		if stopped != len(ws) {
+			t.Errorf("expected %d watchers to be stopped but got %d", len(ws), stopped)
+		}
+	}()
 	select {
 	case <-m.stopped:
 		// all good, watcher is closed, proceed
 	default:
 		t.Error("expected multiWatch to be stopped")
 	}
-	_, running = <-m.ResultChan()
+	_, running := <-m.ResultChan()
 	if running {
 		t.Errorf("expected multiWatch chan to be closed")
 	}
@@ -171,6 +180,7 @@ func TestMultiWatchResultChannelStop(t *testing.T) {
 type mockListerWatcher struct {
 	evCh    chan watch.Event
 	stopped bool
+	lock    sync.Mutex
 }
 
 func (m *mockListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
@@ -182,7 +192,15 @@ func (m *mockListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, 
 }
 
 func (m *mockListerWatcher) Stop() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	m.stopped = true
+}
+
+func (m *mockListerWatcher) isStopped() bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.stopped
 }
 
 func (m *mockListerWatcher) ResultChan() <-chan watch.Event {
@@ -192,9 +210,9 @@ func (m *mockListerWatcher) ResultChan() <-chan watch.Event {
 func TestRacyMultiWatch(t *testing.T) {
 	evCh := make(chan watch.Event)
 	lw := &mockListerWatcher{evCh: evCh}
+	testNamespace := "testNamespace"
 
-	namespaces := []string{"namespace"}
-	rsv := map[string]string{"namespace": "foo"}
+	namespaces := []string{testNamespace}
 
 	mlw := newMultiListerWatcher(namespaces, func(namespace string) cache.ListerWatcher {
 		return &cache.ListWatch{
@@ -207,27 +225,26 @@ func TestRacyMultiWatch(t *testing.T) {
 				return lw, nil
 			},
 		}
-	})
+	}, &v1.Pod{}, 0)
 
 	if _, err := mlw.List(metav1.ListOptions{}); err != nil {
 		t.Error(err)
 		return
 	}
 
-	if err := mlw.newMultiWatch(rsv, metav1.ListOptions{}); err != nil {
+	if _, err := mlw.Watch(metav1.ListOptions{}); err != nil {
 		t.Error(err)
 		return
 	}
 
-	// this will not block, as newMultiWatch started a goroutine,
-	// receiving that event and block on the dispatching it there.
+	// this will not block, as the informers process this asynchronously
 	evCh <- watch.Event{
-		Type: "foo",
-		Object: &v1.Pod{},
+		Type:   watch.Added,
+		Object: createPod(testNamespace, "pod", 1),
 	}
 
-	if got := <-mlw.ResultChan(); got.Type != "foo" {
-		t.Errorf("expected foo, got %s", got.Type)
+	if got := <-mlw.ResultChan(); got.Type != watch.Added {
+		t.Errorf("expected %v, got %s", watch.Added, got.Type)
 		return
 	}
 
@@ -235,11 +252,13 @@ func TestRacyMultiWatch(t *testing.T) {
 	// In conjunction with go test -race this asserts
 	// if there is a race between stopping and dispatching an event
 	evCh <- watch.Event{
-		Type: "bar",
+		Type:   watch.Modified,
+		Object: createPod(testNamespace, "pod", 1),
 	}
 	mlw.Stop()
 
-	if got := lw.stopped; got != true {
+	time.Sleep(time.Second * 1)
+	if got := lw.isStopped(); got != true {
 		t.Errorf("expected watcher to be closed true, got %t", got)
 	}
 
@@ -250,19 +269,24 @@ func TestRacyMultiWatch(t *testing.T) {
 
 func TestUpdatingNamespaceAfterWatch(t *testing.T) {
 	namespaces1 := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
-	ws, m := setupMultiWatch(t, namespaces1, map[string]string{})
+	ws, wsLock, m := setupMultiWatch(t, namespaces1, &v1.Pod{}, 0)
 
-	if len(m.lwMap) != len(namespaces1) {
-		t.Errorf("Expected lwMap to be of size %d, found %d", len(namespaces1), len(m.lwMap))
+	if len(m.activeMap) != len(namespaces1) {
+		t.Errorf("Expected activeMap to be of size %d, found %d", len(namespaces1), len(m.activeMap))
 		return
 	}
 
 	namespaces2 := []string{"1", "2", "3", "4", "5"}
 	m.UpdateNamespaces(namespaces2)
 
-	if got := <-m.ResultChan(); got.Type != watch.Error {
-		t.Errorf("Unexpected type on result channel, retrieved type %s but exected %s", got.Type, watch.Error)
-		return
+	// Should remain open with no errors
+	select {
+	case _, running := <-m.ResultChan():
+		if !running {
+			t.Errorf("expected multiWatch chan to remain open")
+		}
+	case <-time.After(5 * time.Second):
+		break
 	}
 
 	select {
@@ -272,16 +296,20 @@ func TestUpdatingNamespaceAfterWatch(t *testing.T) {
 		m.Stop()
 	}
 
-	var stopped int
-	for _, w := range ws {
-		_, running := <-w.ResultChan()
-		if !running && w.IsStopped() {
-			stopped++
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		var stopped int
+		for _, w := range ws {
+			_, running := <-w.ResultChan()
+			if !running && w.IsStopped() {
+				stopped++
+			}
 		}
-	}
-	if stopped != len(ws) {
-		t.Errorf("expected %d watchers to be stopped but got %d", len(ws), stopped)
-	}
+		if stopped != len(ws) {
+			t.Errorf("expected %d watchers to be stopped but got %d", len(ws), stopped)
+		}
+	}()
 	select {
 	case <-m.stopped:
 		// all good, watcher is closed, proceed
@@ -306,25 +334,31 @@ func TestUpdatingNamespaceAfterWatch(t *testing.T) {
 		return
 	}
 
-	if len(m.lwMap) != len(namespaces2) {
-		t.Errorf("Expected lwMap to be of size %d, found %d", len(namespaces2), len(m.lwMap))
+	if len(m.activeMap) != len(namespaces2) {
+		t.Errorf("Expected activeMap to be of size %d, found %d", len(namespaces2), len(m.activeMap))
 		return
 	}
 
-	var running int
-	for _, w := range ws {
-		if !w.IsStopped() {
-			running++
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		var running int
+		for _, w := range ws {
+			if !w.IsStopped() {
+				running++
+			}
 		}
-	}
-	if running != len(ws) {
-		t.Errorf("expected %d watchers to be running but got %d", len(ws), running)
-	}
+		if running != len(ws) {
+			t.Errorf("expected %d watchers to be running but got %d", len(ws), running)
+		}
+	}()
+	m.Stop()
 }
 
 func TestUpdatingNamespaceAfterListed(t *testing.T) {
 	namespaces1 := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
 	ws := make(map[string]*watch.FakeWatcher)
+	wsLock := sync.Mutex{}
 
 	m := newMultiListerWatcher(namespaces1, func(namespace string) cache.ListerWatcher {
 		return &cache.ListWatch{
@@ -333,39 +367,58 @@ func TestUpdatingNamespaceAfterListed(t *testing.T) {
 				return &l, nil
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				wsLock.Lock()
+				defer wsLock.Unlock()
 				w := watch.NewFake()
 				ws[namespace] = w
 				return w, nil
 			},
 		}
-	})
+	}, &v1.Pod{}, 0)
 
 	if _, err := m.List(metav1.ListOptions{}); err != nil {
-		t.Fatalf("failed to invoke List: %v", err)
+		t.Errorf("failed to invoke List: %v", err)
 	}
 
-	if len(m.lwMap) != len(namespaces1) {
-		t.Errorf("Expected lwMap to be of size %d, found %d", len(namespaces1), len(m.lwMap))
+	if len(m.activeMap) != len(namespaces1) {
+		t.Errorf("Expected activeMap to be of size %d, found %d", len(namespaces1), len(m.activeMap))
 		return
 	}
 
-	if len(ws) != 0 {
-		t.Errorf("Expected ws to be of size 0, found %d", len(ws))
-		return
-	}
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		if len(ws) != len(namespaces1) {
+			t.Errorf("Expected ws to be of size 0, found %d", len(ws))
+			return
+		}
+	}()
 
 	namespaces2 := []string{"1", "2", "3", "4", "5"}
 	m.UpdateNamespaces(namespaces2)
 
-	w, err := m.Watch(metav1.ListOptions{})
-	if err != nil {
-		t.Errorf("Received unexpected error invoking Watch, %v", err)
-		return
+	time.Sleep(5 * time.Second)
+
+	var stopped1 int
+	for _, w := range ws {
+		if w.IsStopped() {
+			stopped1++
+		}
+	}
+	expected := len(namespaces1) - len(namespaces2)
+	if stopped1 != expected {
+		t.Errorf("expected %d watchers to be stopped but got %d", expected, stopped1)
 	}
 
-	if got := <-w.ResultChan(); got.Type != watch.Error {
-		t.Errorf("Unexpected type on result channel, retrieved type %s but exected %s", got.Type, watch.Error)
-		return
+	w, err := m.Watch(metav1.ListOptions{})
+	checkError(t, "Received unexpected error invoking Watch, %v", err)
+
+	select {
+	case got := <-w.ResultChan():
+		if got.Type != watch.Error {
+			t.Errorf("Unexpected type on result channel, retrieved type %s but exected %s", got.Type, watch.Error)
+		}
+	case <-time.After(5 * time.Second):
 	}
 
 	select {
@@ -374,6 +427,8 @@ func TestUpdatingNamespaceAfterListed(t *testing.T) {
 	default:
 		w.Stop()
 	}
+
+	time.Sleep(5 * time.Second)
 
 	var stopped int
 	for _, w := range ws {
@@ -389,6 +444,7 @@ func TestUpdatingNamespaceAfterListed(t *testing.T) {
 func TestUpdatingNamespaceAfterCreated(t *testing.T) {
 	namespaces1 := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
 	ws := make(map[string]*watch.FakeWatcher)
+	wsLock := sync.Mutex{}
 
 	m := newMultiListerWatcher(namespaces1, func(namespace string) cache.ListerWatcher {
 		return &cache.ListWatch{
@@ -397,15 +453,17 @@ func TestUpdatingNamespaceAfterCreated(t *testing.T) {
 				return &l, nil
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				wsLock.Lock()
+				defer wsLock.Unlock()
 				w := watch.NewFake()
 				ws[namespace] = w
 				return w, nil
 			},
 		}
-	})
+	}, &v1.Pod{}, 0)
 
-	if len(m.lwMap) != 0 {
-		t.Errorf("Expected lwMap to be of size 0, found %d", len(m.lwMap))
+	if len(m.activeMap) != 0 {
+		t.Errorf("Expected activeMap to be of size 0, found %d", len(m.activeMap))
 		return
 	}
 
@@ -427,26 +485,34 @@ func TestUpdatingNamespaceAfterCreated(t *testing.T) {
 		return
 	}
 
-	if len(m.lwMap) != len(namespaces2) {
-		t.Errorf("Expected lwMap to be of size %d, found %d", len(namespaces2), len(m.lwMap))
+	if len(m.activeMap) != len(namespaces2) {
+		t.Errorf("Expected activeMap to be of size %d, found %d", len(namespaces2), len(m.activeMap))
 		return
 	}
 
-	var running int
-	for _, w := range ws {
-		if !w.IsStopped() {
-			running++
+	func() {
+		wsLock.Lock()
+		defer wsLock.Unlock()
+		var running int
+		for _, w := range ws {
+			if !w.IsStopped() {
+				running++
+			}
 		}
-	}
-	if running != len(ws) {
-		t.Errorf("expected %d watchers to be running but got %d", len(ws), running)
-	}
+		if running != len(ws) {
+			t.Errorf("expected %d watchers to be running but got %d", len(ws), running)
+		}
+	}()
+	m.Stop()
 }
 
 func TestMultiWatchDoesNotDeadlock(t *testing.T) {
 	namespaces := []string{"1", "2", "3", "4", "5"}
 
 	ws := make(map[string]*watch.FakeWatcher)
+	wsLock := sync.Mutex{}
+	errorRaised := make(chan struct{})
+
 	m := newMultiListerWatcher(namespaces, func(namespace string) cache.ListerWatcher {
 		return &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -455,30 +521,38 @@ func TestMultiWatchDoesNotDeadlock(t *testing.T) {
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if namespace == "4" {
-					return nil, errors.New("Some error occurred")
+					defer func() { errorRaised <- struct{}{} }()
+					return nil, errors.New("deliberate error forced")
 				}
+				wsLock.Lock()
+				defer wsLock.Unlock()
 				w := watch.NewFake()
 				ws[namespace] = w
 				return w, nil
 			},
 		}
-	})
+	}, &v1.Pod{}, 0)
 
 	if _, err := m.List(metav1.ListOptions{}); err != nil {
 		t.Errorf("Error while listing: %v", err)
 	}
 
-	if _, err := m.Watch(metav1.ListOptions{}); err == nil {
-		t.Error("Expected error while watching, got nil")
+	// We wait for two notifications on errorRaised so we know the Watch has been retried
+	<-errorRaised
+	<-errorRaised
+
+	// We shouldn't get an error, the underlying cache will retry on watch
+	if _, err := m.Watch(metav1.ListOptions{}); err != nil {
+		t.Errorf("Did not expect an error while watching, received %v", err)
 	}
 
 	timeout := time.NewTimer(2 * time.Second)
 
 	listChan := make(chan struct{})
 	go func() {
-		// this one is going to deadlock
-		if _, err := m.List(metav1.ListOptions{}); err != nil {
-			t.Logf("Error while listing: %v", err)
+		// Make sure concurrent Lists do not deadlock
+		if _, err := m.List(metav1.ListOptions{}); err == nil {
+			t.Error("Expected to receive an error for List while in watching state")
 		}
 		listChan <- struct{}{}
 	}()
@@ -488,5 +562,323 @@ func TestMultiWatchDoesNotDeadlock(t *testing.T) {
 		t.Error("Deadlock while calling List()")
 	case <-listChan:
 	}
+	m.Stop()
+}
 
+func getObjectMap(t *testing.T, list runtime.Object) map[string]*runtime.Object {
+	runtimeObjects, err := meta.ExtractList(list)
+	checkError(t, "Unexpected error extracing list, %v", err)
+
+	objectMap := make(map[string]*runtime.Object)
+	for _, runtimeObject := range runtimeObjects {
+		key, err := cache.MetaNamespaceKeyFunc(runtimeObject)
+		checkError(t, "Unexpected error retrieving the key, %v, %v", err, runtimeObject)
+		objectMap[key] = &runtimeObject
+	}
+	return objectMap
+}
+
+//nolint:unparam
+func checkNamespaceObjects(t *testing.T, objectMap map[string]*runtime.Object,
+	namespacePrefix string, firstNamespace int, lastNamespace int,
+	podPrefix string, firstPod int, lastPod int) {
+	count := firstNamespace
+	for count <= lastNamespace {
+		namespace := getNamespace(namespacePrefix, count)
+		podCount := firstPod
+		for podCount <= lastPod {
+			key := getPodKey(namespace, podPrefix, podCount)
+			_, ok := objectMap[key]
+			if !ok {
+				t.Errorf("Could not find resource %v", key)
+			}
+			podCount++
+		}
+		count++
+	}
+}
+
+func TestInformerBehaviour(t *testing.T) {
+	podPrefix := "pod"
+	namespacePrefix := "ns"
+	w := make(map[string]*watch.RaceFreeFakeWatcher)
+	numNamespaces := 200
+	numListPods := 20
+
+	var testNamespaces []string = nil
+	count := 1
+	for count <= numNamespaces {
+		namespace := getNamespace(namespacePrefix, count)
+		testNamespaces = append(testNamespaces, namespace)
+		w[namespace] = watch.NewRaceFreeFake()
+		count++
+	}
+
+	mlw := newMultiListerWatcher(testNamespaces, func(namespace string) cache.ListerWatcher {
+		return &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return createPodList(namespace, podPrefix, numListPods), nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return w[namespace], nil
+			},
+		}
+	}, &v1.Pod{}, 0)
+
+	if activeMapLen := len(mlw.activeMap); activeMapLen != 0 {
+		t.Errorf("Expected activeMap to be of zero length, length is %v", activeMapLen)
+	}
+
+	if drainingMapLen := len(mlw.drainingMap); drainingMapLen != 0 {
+		t.Errorf("Expected drainingMap to be of zero length, length is %v", drainingMapLen)
+	}
+
+	if listingMapLen := len(mlw.listingMap); listingMapLen != 0 {
+		t.Errorf("Expected listingMap to be of zero length, length is %v", listingMapLen)
+	}
+
+	list, err := mlw.List(metav1.ListOptions{})
+	checkError(t, "Unexpected error listing mlw, %v", err)
+
+	if listLen := meta.LenList(list); listLen != numListPods*numNamespaces {
+		t.Errorf("Expected to receive %d pods, actual count was %v", numListPods*numNamespaces, listLen)
+	}
+
+	objectMap := getObjectMap(t, list)
+
+	checkNamespaceObjects(t, objectMap, namespacePrefix, 1, numNamespaces,
+		podPrefix, 1, numListPods)
+
+	watcher, err := mlw.Watch(metav1.ListOptions{})
+	checkError(t, "Unexpected error invoking Watch, %v", err)
+
+	results := watcher.ResultChan()
+
+	podID := numListPods + 1
+	for _, namespace := range testNamespaces {
+		pod := createPod(namespace, podPrefix, podID)
+		w[namespace].Add(pod)
+		checkEvent(t, results, watch.Added, getPodKey(namespace, podPrefix, podID))
+		w[namespace].Add(pod)
+		checkEvent(t, results, watch.Modified, getPodKey(namespace, podPrefix, podID))
+		w[namespace].Modify(pod)
+		checkEvent(t, results, watch.Modified, getPodKey(namespace, podPrefix, podID))
+		w[namespace].Delete(pod)
+		checkEvent(t, results, watch.Deleted, getPodKey(namespace, podPrefix, podID))
+
+		count++
+	}
+
+	testNamespaces2 := testNamespaces[1:]
+	mlw.UpdateNamespaces(testNamespaces2)
+	objectMap = getEventsAsObjectMap(t, results, watch.Deleted, numListPods)
+	checkNamespaceObjects(t, objectMap, namespacePrefix, 1, 1,
+		podPrefix, 1, numListPods)
+
+	// Now test re-adding, should see deletes as they drain followed by adds when resuming
+	deletedNamespace := getNamespace(namespacePrefix, 2)
+	func() {
+		mlw.lock.Lock()
+		defer mlw.lock.Unlock()
+		testNamespaces3 := testNamespaces2[1:]
+
+		drainedNamespaces := mlw.updateNamespaces(testNamespaces3)
+		if len(drainedNamespaces) != 1 {
+			t.Errorf("Expected only one namespace to be drained, received %d", len(drainedNamespaces))
+		}
+		if drainedNamespaces[0] != deletedNamespace {
+			t.Errorf("Expected to see %s as the deleted namespace, instead recevied %v", deletedNamespace, drainedNamespaces[0])
+		}
+		_, ok := mlw.drainingMap[deletedNamespace]
+		if !ok {
+			t.Errorf("Expected to see namespace %v in the drainingMap", deletedNamespace)
+		}
+		_, ok = mlw.activeMap[deletedNamespace]
+		if ok {
+			t.Errorf("Did not expect to see namespace %v in the activeMap", deletedNamespace)
+		}
+		// add back within the same lock
+		drainedNamespaces = mlw.updateNamespaces(testNamespaces2)
+		if len(drainedNamespaces) != 0 {
+			t.Errorf("Expected no namespaces to be drained, received %d", len(drainedNamespaces))
+		}
+		_, ok = mlw.drainingMap[deletedNamespace]
+		if ok {
+			t.Errorf("Did not expect to see namespace %v in the drainingMap", deletedNamespace)
+		}
+		_, ok = mlw.activeMap[deletedNamespace]
+		if !ok {
+			t.Errorf("Expected to see namespace %v in the activeMap", deletedNamespace)
+		}
+	}()
+
+	objectMap = getEventsAsObjectMap(t, results, watch.Deleted, numListPods)
+	checkNamespaceObjects(t, objectMap, namespacePrefix, 2, 2,
+		podPrefix, 1, numListPods)
+
+	objectMap = getEventsAsObjectMap(t, results, watch.Added, numListPods)
+	checkNamespaceObjects(t, objectMap, namespacePrefix, 2, 2,
+		podPrefix, 1, numListPods)
+	mlw.Stop()
+}
+
+func TestErrorBehaviour(t *testing.T) {
+	podPrefix := "pod"
+	namespacePrefix := "ns"
+	w := make(map[string]*watch.RaceFreeFakeWatcher)
+	numNamespaces := 200
+	numListPods := 20
+
+	var testNamespaces []string = nil
+	count := 1
+	for count <= numNamespaces {
+		namespace := getNamespace(namespacePrefix, count)
+		testNamespaces = append(testNamespaces, namespace)
+		w[namespace] = watch.NewRaceFreeFake()
+		count++
+	}
+
+	listChan := make(chan string, numNamespaces)
+
+	mlw := newMultiListerWatcher(testNamespaces, func(namespace string) cache.ListerWatcher {
+		return &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				listChan <- namespace
+				w[namespace].Reset()
+				return createPodList(namespace, podPrefix, numListPods), nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return w[namespace], nil
+			},
+		}
+	}, &v1.Pod{}, 0)
+	list, err := mlw.List(metav1.ListOptions{})
+	checkError(t, "Unexpected error listing mlw, %v", err)
+
+	if listLen := meta.LenList(list); listLen != numListPods*numNamespaces {
+		t.Errorf("Expected to receive %d pods, actual count was %v", numListPods*numNamespaces, listLen)
+	}
+
+	// make sure we have a list for each namespace
+	count = 0
+	for count < numNamespaces {
+		select {
+		case <-listChan:
+		case <-time.After(5 * time.Second):
+			t.Errorf("Unexpected timeout waiting for list to occur")
+		}
+		count++
+	}
+
+	// make sure no lists are outstanding
+	select {
+	case <-listChan:
+		t.Errorf("Unexpected list occurred")
+	case <-time.After(5 * time.Second):
+	}
+
+	watcher, err := mlw.Watch(metav1.ListOptions{})
+	checkError(t, "Unexpected error invoking Watch, %v", err)
+
+	results := watcher.ResultChan()
+
+	// send error
+	errorNamespace := getNamespace(namespacePrefix, 1)
+	// &Status{Status:Failure,Message:too old resource version: 6437976 (6438283),Reason:Expired,Details:nil,Code:410,}
+	w[errorNamespace].Error(&metav1.Status{
+		Status:  "Failure",
+		Message: "too old resource version: XXXX",
+		Reason:  metav1.StatusReasonExpired,
+		Code:    410,
+	})
+
+	// check for list on the namespace
+	select {
+	case namespace := <-listChan:
+		if namespace != errorNamespace {
+			t.Errorf("Expected a repeated list for namespace %v but received %v", errorNamespace, namespace)
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("Unexpected timeout waiting for list to occur")
+	}
+
+	// We should receive modified updates for errorNamespace pods
+	count = 0
+	metaAccessor := meta.NewAccessor()
+	for count < numListPods {
+		select {
+		case event := <-results:
+			if event.Type != watch.Modified {
+				t.Errorf("Expected %v event type but received %v", watch.Modified, event.Type)
+			}
+			eventNamespace, _ := metaAccessor.Namespace(event.Object)
+			if eventNamespace != errorNamespace {
+				t.Errorf("Expected namespace %v but received %v", errorNamespace, eventNamespace)
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("Expected modified event for existing pod, count is %v", count)
+		}
+		count++
+	}
+
+	// make sure no lists are outstanding
+	select {
+	case namespace := <-listChan:
+		t.Errorf("Unexpected list occurred for namespace %v", namespace)
+	case <-time.After(5 * time.Second):
+	}
+
+	// We should receive no new updates from the result channel
+	select {
+	case event := <-results:
+		t.Errorf("Unexpected event occurred %v", event)
+	case <-time.After(5 * time.Second):
+	}
+
+	// double check events are still occurring
+	podID := numListPods + 1
+	for _, namespace := range testNamespaces {
+		pod := createPod(namespace, podPrefix, podID)
+		w[namespace].Add(pod)
+		checkEvent(t, results, watch.Added, getPodKey(namespace, podPrefix, podID))
+		w[namespace].Add(pod)
+		checkEvent(t, results, watch.Modified, getPodKey(namespace, podPrefix, podID))
+		w[namespace].Modify(pod)
+		checkEvent(t, results, watch.Modified, getPodKey(namespace, podPrefix, podID))
+		w[namespace].Delete(pod)
+		checkEvent(t, results, watch.Deleted, getPodKey(namespace, podPrefix, podID))
+
+		count++
+	}
+}
+
+func checkEvent(t *testing.T, events <-chan watch.Event, eventType watch.EventType, expectedKey string) {
+	event := <-events
+	if event.Type != eventType {
+		t.Errorf("Expected event type %v but received %v", eventType, event.Type)
+	}
+	key, err := cache.MetaNamespaceKeyFunc(event.Object)
+	checkError(t, "Unexpected error retrieving the key, %v, %v", err, event)
+	if expectedKey != key {
+		t.Errorf("Unexpected pod key %v, expected key was %v", key, expectedKey)
+	}
+}
+
+func getEventsAsObjectMap(t *testing.T, events <-chan watch.Event, eventType watch.EventType,
+	numEvents int) map[string]*runtime.Object {
+	count := 0
+	objectMap := make(map[string]*runtime.Object)
+	for count < numEvents {
+		event := <-events
+		if event.Type != eventType {
+			t.Errorf("Expected event type %v but received %v", eventType, event.Type)
+		}
+		runtimeObject := event.Object
+		key, err := cache.MetaNamespaceKeyFunc(runtimeObject)
+		checkError(t, "Unexpected error retrieving the key, %v, %v", err, runtimeObject)
+		objectMap[key] = &runtimeObject
+
+		count++
+	}
+	return objectMap
 }

--- a/security/pkg/k8s/chiron/controller.go
+++ b/security/pkg/k8s/chiron/controller.go
@@ -161,10 +161,10 @@ func NewWebhookController(gracePeriodRatio float32, minGracePeriod time.Duration
 					return core.Secrets(namespace).Watch(options)
 				},
 			}
-		})
+		}, &v1.Secret{}, secretResyncPeriod)
 		// The certificate rotation is handled by scrtUpdated().
 		c.scrtStore, c.scrtController =
-			cache.NewInformer(scrtLW, &v1.Secret{}, secretResyncPeriod, cache.ResourceEventHandlerFuncs{
+			cache.NewInformer(scrtLW, &v1.Secret{}, 0, cache.ResourceEventHandlerFuncs{
 				DeleteFunc: c.scrtDeleted,
 				UpdateFunc: c.scrtUpdated,
 			})

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -229,14 +229,14 @@ func NewSecretController(ca certificateAuthority, enableNamespacesByDefault bool
 				return core.ServiceAccounts(namespace).Watch(options)
 			},
 		}
-	})
+	}, &v1.ServiceAccount{}, time.Minute)
 	if mrc != nil {
 		mrc.Register(saLW)
 		mrc.Register(c)
 	}
 
 	c.saStore, c.saController =
-		cache.NewInformer(saLW, &v1.ServiceAccount{}, time.Minute, cache.ResourceEventHandlerFuncs{
+		cache.NewInformer(saLW, &v1.ServiceAccount{}, 0, cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.saAdded,
 			DeleteFunc: c.saDeleted,
 		})
@@ -253,14 +253,14 @@ func NewSecretController(ca certificateAuthority, enableNamespacesByDefault bool
 				return core.Secrets(namespace).Watch(options)
 			},
 		}
-	})
+	}, &v1.Secret{}, secretResyncPeriod)
 
 	if mrc != nil {
 		mrc.Register(scrtLW)
 	}
 
 	c.scrtStore, c.scrtController =
-		cache.NewInformer(scrtLW, &v1.Secret{}, secretResyncPeriod, cache.ResourceEventHandlerFuncs{
+		cache.NewInformer(scrtLW, &v1.Secret{}, 0, cache.ResourceEventHandlerFuncs{
 			DeleteFunc: c.scrtDeleted,
 			UpdateFunc: c.scrtUpdated,
 		})
@@ -273,9 +273,9 @@ func NewSecretController(ca certificateAuthority, enableNamespacesByDefault bool
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				return core.Namespaces().Watch(options)
 			}}
-	})
+	}, &v1.Namespace{}, namespaceResyncPeriod)
 	c.namespaceStore, c.namespaceController =
-		cache.NewInformer(namespaceLW, &v1.Namespace{}, namespaceResyncPeriod, cache.ResourceEventHandlerFuncs{
+		cache.NewInformer(namespaceLW, &v1.Namespace{}, 0, cache.ResourceEventHandlerFuncs{
 			UpdateFunc: c.namespaceUpdated,
 		})
 

--- a/security/pkg/registry/kube/service.go
+++ b/security/pkg/registry/kube/service.go
@@ -63,7 +63,7 @@ func NewServiceController(core corev1.CoreV1Interface, namespaces []string, mrc 
 				return core.Services(namespace).Watch(options)
 			},
 		}
-	})
+	}, &v1.Service{}, time.Minute)
 	if mrc != nil {
 		mrc.Register(LW)
 	}
@@ -73,7 +73,7 @@ func NewServiceController(core corev1.CoreV1Interface, namespaces []string, mrc 
 		DeleteFunc: c.serviceDeleted,
 		UpdateFunc: c.serviceUpdated,
 	}
-	_, c.controller = cache.NewInformer(LW, &v1.Service{}, time.Minute, handler)
+	_, c.controller = cache.NewInformer(LW, &v1.Service{}, 0, handler)
 	return c
 }
 

--- a/security/pkg/registry/kube/serviceaccount.go
+++ b/security/pkg/registry/kube/serviceaccount.go
@@ -65,12 +65,12 @@ func NewServiceAccountController(core corev1.CoreV1Interface, namespaces []strin
 				return core.ServiceAccounts(namespace).Watch(options)
 			},
 		}
-	})
+	}, &v1.ServiceAccount{}, time.Minute)
 	if mrc != nil {
 		mrc.Register(LW)
 	}
 
-	_, c.controller = cache.NewInformer(LW, &v1.ServiceAccount{}, time.Minute, cache.ResourceEventHandlerFuncs{
+	_, c.controller = cache.NewInformer(LW, &v1.ServiceAccount{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.serviceAccountAdded,
 		DeleteFunc: c.serviceAccountDeleted,
 		UpdateFunc: c.serviceAccountUpdated,


### PR DESCRIPTION
…ce issues

This PR implements a two layer cache for multiple namespaces, with the lower level caches handling individual namespaces, resync etc and being aggregated into a single upper layer cache for consumption by other parts of the code.

The lower level consumes events from an informer and adapts them as Watch events, these watch events are then consumed by the upper level cache to create an aggregated set of watch events for consumers.

Note this does not suffer from the thrashing seen in the original implementation, it also removes the need to track the resource versions for each namespace as they are now handled independently of each other.

