### PR TITLE
Increase the timeout for a test

### DIFF
--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -316,7 +316,7 @@ func TestPerf(t *testing.T) {
 	mrc.setNamespaces(generateNamespaces(qty)...)
 
 	// It takes ~ 2s on my laptop, it's slower on prow
-	_, ignore := getRoutes(t, routerClient, "istio-system", qty, time.Minute)
+	_, ignore := getRoutes(t, routerClient, "istio-system", qty, 3*time.Minute)
 	if err := getError(errorChannel); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
It's currently flaky, depending on the load of the prow node.
Time is not much important here, but the quantity of API calls is.
