### PR TITLE
MAISTRA-2271: Update xns-informers to fix delete events issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lestrrat-go/jwx v1.0.5
-	github.com/maistra/xns-informer v0.0.0-20210129184249-388865e61925
+	github.com/maistra/xns-informer v0.0.0-20210413152253-f6302cf13b64
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mholt/archiver/v3 v3.3.2
 	github.com/miekg/dns v1.1.34

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/maistra/xns-informer v0.0.0-20210129184249-388865e61925 h1:fU99/8bhj99zPCMLeUajzlU8u13DzMTGoikFjs7QvFY=
-github.com/maistra/xns-informer v0.0.0-20210129184249-388865e61925/go.mod h1:CxXEaRHBe2wDXrqPtEU4as5um6M5Kj43UpeYVOC3Gtg=
+github.com/maistra/xns-informer v0.0.0-20210413152253-f6302cf13b64 h1:KIAlcrXisUKEUKX04r6r8GgTeftcikDGGdU5C/G4WNc=
+github.com/maistra/xns-informer v0.0.0-20210413152253-f6302cf13b64/go.mod h1:CxXEaRHBe2wDXrqPtEU4as5um6M5Kj43UpeYVOC3Gtg=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -680,7 +680,7 @@ github.com/magiconair/properties
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
-# github.com/maistra/xns-informer v0.0.0-20210129184249-388865e61925
+# github.com/maistra/xns-informer v0.0.0-20210413152253-f6302cf13b64
 ## explicit
 github.com/maistra/xns-informer/pkg/generated/istio
 github.com/maistra/xns-informer/pkg/generated/istio/internalinterfaces


### PR DESCRIPTION
This updates xns-informers to include a fix for sending delete events
for all objects when a namespace is no longer watched.

See: https://github.com/maistra/xns-informer/pull/12
