### PR TITLE
MAISTRA-2283: Add integration test suite for Maistra 

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -146,14 +146,14 @@ func init() {
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.TrustDomain, "trust-domain", "",
 		"The domain serves to identify the system with spiffe")
 
-	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.MemberRollName, "memberRollName", "",
-		"The name of the MemberRoll resource")
-	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableCRDScan, "enableCRDScan", true,
-		"Whether to scan CRDs at startup")
-	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.DisableNodeAccess, "disableNodeAccess", false,
-		"Whether to prevent istiod watching Node objects")
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.MemberRollName, "memberRollName",
+		features.MemberRollName, "The name of the MemberRoll resource")
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableCRDScan, "enableCRDScan",
+		features.EnableCRDScan, "Whether to scan CRDs at startup")
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.DisableNodeAccess, "disableNodeAccess",
+		features.DisableNodeAccess, "Whether to prevent istiod watching Node objects")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableIngressClassName, "enableIngressClassName",
-		true, "Whether support processing Ingress resources that use the new ingressClassName field in their spec")
+		features.EnableIngressClassName, "Whether support processing Ingress resources that use the new ingressClassName field in their spec")
 	discoveryCmd.PersistentFlags().StringVar(&extension.CacheCluster, "cacheCluster", extension.DefaultCacheCluster,
 		"Cluster pointing to Extension Cache component. This is used in proxies to retrieve WASM filters.")
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -399,4 +399,14 @@ var (
 	EnableFederationDiscoveryServer = env.RegisterBoolVar("PILOT_ENABLE_FEDERATION_DISCOVERY_SERVER", true, "").Get()
 
 	FederationDiscoveryEndpoint = env.RegisterStringVar("PILOT_REMOTE_FEDERATION_DISCOVERY", "", "").Get()
+
+	MemberRollName = env.RegisterStringVar("MEMBER_ROLL_NAME", "", "The name of the MemberRoll resource").Get()
+
+	EnableCRDScan = env.RegisterBoolVar("ENABLE_CRD_SCAN", true, "Whether to scan CRDs at startup").Get()
+
+	DisableNodeAccess = env.RegisterBoolVar("DISABLE_NODE_ACCESS", false,
+		"Whether to prevent istiod watching Node objects").Get()
+
+	EnableIngressClassName = env.RegisterBoolVar("ENABLE_INGRESS_CLASS_NAME", true,
+		"Whether support processing Ingress resources that use the new ingressClassName field in their spec").Get()
 )

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -39,6 +39,7 @@ import (
 
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	"istio.io/istio/pkg/kube"
+	servicemeshv1 "istio.io/istio/pkg/servicemesh/client/v1/clientset/versioned"
 	memberroll "istio.io/istio/pkg/servicemesh/controller"
 	"istio.io/pkg/version"
 )
@@ -133,6 +134,10 @@ func (c MockClient) AddMemberRoll(namespace, memberRollName string) error {
 }
 
 func (c MockClient) GetMemberRoll() memberroll.MemberRollController {
+	panic("not used in mock")
+}
+
+func (c MockClient) ServiceMeshV1() servicemeshv1.Interface {
 	panic("not used in mock")
 }
 

--- a/tests/integration/maistra/main_test.go
+++ b/tests/integration/maistra/main_test.go
@@ -1,0 +1,159 @@
+// +build integ
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maistra
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	servicemeshv1 "istio.io/istio/pkg/servicemesh/apis/servicemesh/v1"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var i istio.Instance
+
+const smmrName = "maistra-test"
+
+const maistraValues = `values:
+  pilot:
+    env:
+      MEMBER_ROLL_NAME: "maistra-test"
+      ENABLE_CRD_SCAN: "false"
+      DISABLE_NODE_ACCESS: "true"
+      ENABLE_INGRESS_CLASS_NAME: "false"
+      PILOT_ENABLED_SERVICE_APIS: "false"`
+
+// TestMain defines the entrypoint for pilot tests using a standard Istio installation.
+// If a test requires a custom install it should go into its own package, otherwise it should go
+// here to reuse a single install across tests.
+func TestMain(m *testing.M) {
+	// TODO: It might be better to disable the injection webhooks here to more
+	// closely mimic a Maistra deployment, but that complicates deployments.
+	framework.
+		NewSuite(m).
+		Setup(applyResources).
+		Setup(waitForCRDs).
+		Setup(createSMMR).
+		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
+			cfg.ControlPlaneValues = maistraValues
+		})).
+		Run()
+}
+
+// applyResources applies the YAML in the testdata directory.
+func applyResources(ctx resource.Context) error {
+	resources := []string{"namespace.yaml", "crd.yaml", "rbac.yaml"}
+
+	for _, file := range resources {
+		yaml, err := ioutil.ReadFile(filepath.Join("testdata", file))
+		if err != nil {
+			return err
+		}
+
+		if err := ctx.Config().ApplyYAML("", string(yaml)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// waitForCRDs waits for the Maistra CRDs we need to become available.
+func waitForCRDs(ctx resource.Context) error {
+	return wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+		crds := ctx.Clusters().Default().Ext().ApiextensionsV1beta1().CustomResourceDefinitions()
+		smmr, err := crds.Get(context.TODO(), "servicemeshmemberrolls.maistra.io", metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		for _, cond := range smmr.Status.Conditions {
+			if cond.Type == apiextv1beta1.Established && cond.Status == apiextv1beta1.ConditionTrue {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+}
+
+// createSMMR creates the SMMR resource and updates the status.
+func createSMMR(ctx resource.Context) error {
+	namespace := istio.DefaultSystemNamespace
+	maistra := ctx.Clusters().Default().ServiceMeshV1().MaistraV1()
+	memberRolls := maistra.ServiceMeshMemberRolls(namespace)
+
+	smmr := &servicemeshv1.ServiceMeshMemberRoll{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      smmrName,
+			Namespace: namespace,
+		},
+	}
+
+	_, err := memberRolls.Create(context.TODO(), smmr, metav1.CreateOptions{})
+	return err
+}
+
+// updateSMMR sets the given namespaces as the configuired members on the SMMR.
+func updateSMMR(ctx resource.Context, namespaces ...namespace.Instance) error {
+	maistra := ctx.Clusters().Default().ServiceMeshV1().MaistraV1()
+	memberRolls := maistra.ServiceMeshMemberRolls(istio.DefaultSystemNamespace)
+
+	smmr, err := memberRolls.Get(context.TODO(), smmrName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	var members []string
+
+	for _, ns := range namespaces {
+		members = append(members, ns.Name())
+	}
+
+	smmr.Status.ConfiguredMembers = members
+	_, err = memberRolls.UpdateStatus(context.TODO(), smmr, metav1.UpdateOptions{})
+	return err
+}
+
+// enableMTLS enables mTLS in strict mode mesh-wide.
+func enableMTLS(ctx resource.Context) error {
+	mtls, err := ioutil.ReadFile(filepath.Join("testdata", "global-mtls.yaml"))
+	if err != nil {
+		return err
+	}
+
+	return ctx.Config().ApplyYAML("", string(mtls))
+}
+
+// disableMTLS disables mTLS in strict mode mesh-wide.
+func disableMTLS(ctx resource.Context) error {
+	mtls, err := ioutil.ReadFile(filepath.Join("testdata", "global-mtls.yaml"))
+	if err != nil {
+		return err
+	}
+
+	return ctx.Config().DeleteYAML("", string(mtls))
+}

--- a/tests/integration/maistra/namespace_test.go
+++ b/tests/integration/maistra/namespace_test.go
@@ -1,0 +1,100 @@
+// +build integ
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maistra
+
+import (
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+func TestMultiNamespace(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			// Enable mTLS in strict mode for the entire mesh.
+			if err := enableMTLS(ctx); err != nil {
+				ctx.Fatal(err)
+			}
+
+			member1 := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "member",
+				Inject: true,
+			})
+
+			member2 := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "member",
+				Inject: true,
+			})
+
+			_ = namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "non-member",
+				Inject: true,
+			})
+
+			// Add member namespaces to the SMMR.
+			if err := updateSMMR(ctx, member1, member2); err != nil {
+				ctx.Fatal(err)
+			}
+
+			var memberClient, server echo.Instance
+
+			echoboot.NewBuilder(ctx).
+				With(&memberClient, echo.Config{
+					Service:   "client",
+					Namespace: member1,
+					Ports:     []echo.Port{},
+				}).
+				With(&server, echo.Config{
+					Service:   "server",
+					Namespace: member2,
+					Ports: []echo.Port{
+						{
+							Name:         "http",
+							Protocol:     protocol.HTTP,
+							InstancePort: 8090,
+						}},
+				}).
+				BuildOrFail(t)
+
+			// Traffic from member namespace to member namespace should succeed.
+			retry.UntilSuccessOrFail(t, func() error {
+				resp, err := memberClient.Call(echo.CallOptions{
+					Target:   server,
+					PortName: "http",
+				})
+				if err != nil {
+					return err
+				}
+				return resp.CheckOK()
+			}, retry.Delay(time.Millisecond*100))
+
+			t.Cleanup(func() {
+				if err := disableMTLS(ctx); err != nil {
+					t.Errorf("failed to disable mTLS: %v", err)
+				}
+
+				if err := updateSMMR(ctx); err != nil {
+					t.Errorf("failed to remove namespaces from SMMR: %v", err)
+				}
+			})
+		})
+}

--- a/tests/integration/maistra/testdata/crd.yaml
+++ b/tests/integration/maistra/testdata/crd.yaml
@@ -1,0 +1,6617 @@
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: servicemeshcontrolplanes.maistra.io
+spec:
+  group: maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshControlPlane
+    listKind: ServiceMeshControlPlaneList
+    plural: servicemeshcontrolplanes
+    shortNames:
+    - smcp
+    singular: servicemeshcontrolplane
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - additionalPrinterColumns:
+    - JSONPath: .status.annotations.readyComponentCount
+      description: How many of the total number of components are ready
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=="Reconciled")].reason
+      description: Whether or not the control plane installation is up to date.
+      name: Status
+      type: string
+    - JSONPath: .status.lastAppliedConfiguration.template
+      description: The configuration template to use as the base.
+      name: Template
+      type: string
+    - JSONPath: .status.lastAppliedConfiguration.version
+      description: The actual current version of the control plane installation.
+      name: Version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      description: The age of the object
+      name: Age
+      type: date
+    - JSONPath: .status.lastAppliedConfiguration.istio.global.hub
+      description: The image hub used as the base for all component images.
+      name: Image HUB
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              istio:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              networkType:
+                type: string
+              profiles:
+                items:
+                  type: string
+                type: array
+              template:
+                type: string
+              threeScale:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              version:
+                type: string
+            type: object
+          status:
+            nullable: true
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              components:
+                items:
+                  properties:
+                    children:
+                      items:
+                        properties:
+                          conditions:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  format: date-time
+                                  type: string
+                                message:
+                                  type: string
+                                reason:
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                    resource:
+                      type: string
+                  type: object
+                type: array
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              lastAppliedConfiguration:
+                properties:
+                  istio:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  networkType:
+                    type: string
+                  profiles:
+                    items:
+                      type: string
+                    type: array
+                  template:
+                    type: string
+                  threeScale:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  version:
+                    type: string
+                type: object
+              observedGeneration:
+                format: int64
+                type: integer
+              reconciledVersion:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - JSONPath: .status.annotations.readyComponentCount
+      description: How many of the total number of components are ready
+      name: Ready
+      type: string
+    - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+      description: Whether or not the control plane installation is up to date and
+        ready to handle requests.
+      name: Status
+      type: string
+    - JSONPath: .status.appliedSpec.profiles
+      description: The configuration profiles applied to the configuration.
+      name: Profiles
+      type: string
+    - JSONPath: .status.chartVersion
+      description: The actual current version of the control plane installation.
+      name: Version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      description: The age of the object
+      name: Age
+      type: date
+    - JSONPath: .status.appliedSpec.runtime.defaults.container.registry
+      description: The image registry used as the base for all component images.
+      name: Image Registry
+      priority: 1
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              addons:
+                properties:
+                  3scale:
+                    properties:
+                      backend:
+                        properties:
+                          cache_flush_interval:
+                            format: int32
+                            type: integer
+                          enable_cache:
+                            type: boolean
+                          policy_fail_closed:
+                            type: boolean
+                        type: object
+                      client:
+                        properties:
+                          allow_insecure_connections:
+                            type: boolean
+                          timeout:
+                            format: int32
+                            type: integer
+                        type: object
+                      enabled:
+                        type: boolean
+                      grpc:
+                        properties:
+                          max_conn_timeout:
+                            format: int32
+                            type: integer
+                        type: object
+                      listen_addr:
+                        format: int32
+                        type: integer
+                      log_grpc:
+                        type: boolean
+                      log_json:
+                        type: boolean
+                      log_level:
+                        type: string
+                      metrics:
+                        properties:
+                          port:
+                            format: int32
+                            type: integer
+                          report:
+                            type: boolean
+                        type: object
+                      system:
+                        properties:
+                          cache_max_size:
+                            format: int64
+                            type: integer
+                          cache_refresh_interval:
+                            format: int32
+                            type: integer
+                          cache_refresh_retries:
+                            format: int32
+                            type: integer
+                          cache_ttl:
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  grafana:
+                    properties:
+                      address:
+                        type: string
+                      enabled:
+                        type: boolean
+                      install:
+                        properties:
+                          config:
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              envSecrets:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          persistence:
+                            properties:
+                              accessMode:
+                                type: string
+                              capacity:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              enabled:
+                                type: boolean
+                              storageClassName:
+                                type: string
+                            type: object
+                          security:
+                            properties:
+                              enabled:
+                                type: boolean
+                              passphraseKey:
+                                type: string
+                              secretName:
+                                type: string
+                              usernameKey:
+                                type: string
+                            type: object
+                          selfManaged:
+                            type: boolean
+                          service:
+                            properties:
+                              ingress:
+                                properties:
+                                  contextPath:
+                                    type: string
+                                  enabled:
+                                    type: boolean
+                                  hosts:
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  tls:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodePort:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  jaeger:
+                    properties:
+                      install:
+                        properties:
+                          ingress:
+                            properties:
+                              enabled:
+                                type: boolean
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          storage:
+                            properties:
+                              elasticsearch:
+                                properties:
+                                  indexCleaner:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  nodeCount:
+                                    format: int32
+                                    type: integer
+                                  redundancyPolicy:
+                                    type: string
+                                  storage:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              memory:
+                                properties:
+                                  maxTraces:
+                                    format: int64
+                                    type: integer
+                                type: object
+                              type:
+                                type: string
+                            type: object
+                        type: object
+                      name:
+                        type: string
+                    type: object
+                  kiali:
+                    properties:
+                      enabled:
+                        type: boolean
+                      install:
+                        properties:
+                          dashboard:
+                            properties:
+                              enableGrafana:
+                                type: boolean
+                              enablePrometheus:
+                                type: boolean
+                              enableTracing:
+                                type: boolean
+                              viewOnly:
+                                type: boolean
+                            type: object
+                          service:
+                            properties:
+                              ingress:
+                                properties:
+                                  contextPath:
+                                    type: string
+                                  enabled:
+                                    type: boolean
+                                  hosts:
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  tls:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodePort:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      name:
+                        type: string
+                    type: object
+                  prometheus:
+                    properties:
+                      address:
+                        type: string
+                      enabled:
+                        type: boolean
+                      install:
+                        properties:
+                          retention:
+                            type: string
+                          scrapeInterval:
+                            type: string
+                          selfManaged:
+                            type: boolean
+                          service:
+                            properties:
+                              ingress:
+                                properties:
+                                  contextPath:
+                                    type: string
+                                  enabled:
+                                    type: boolean
+                                  hosts:
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  tls:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodePort:
+                                format: int32
+                                type: integer
+                            type: object
+                          useTLS:
+                            type: boolean
+                        type: object
+                      metricsExpiryDuration:
+                        type: string
+                      scrape:
+                        type: boolean
+                    type: object
+                  stackdriver:
+                    properties:
+                      telemetry:
+                        properties:
+                          accessLogging:
+                            properties:
+                              enabled:
+                                type: boolean
+                              logWindowDuration:
+                                type: string
+                            type: object
+                          auth:
+                            properties:
+                              apiKey:
+                                type: string
+                              appCredentials:
+                                type: boolean
+                              serviceAccountPath:
+                                type: string
+                            type: object
+                          configOverride:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          enableContextGraph:
+                            type: boolean
+                          enableLogging:
+                            type: boolean
+                          enableMetrics:
+                            type: boolean
+                          enabled:
+                            type: boolean
+                        type: object
+                      tracer:
+                        properties:
+                          debug:
+                            type: boolean
+                          maxNumberOfAnnotations:
+                            format: int64
+                            type: integer
+                          maxNumberOfAttributes:
+                            format: int64
+                            type: integer
+                          maxNumberOfMessageEvents:
+                            format: int64
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              cluster:
+                properties:
+                  meshExpansion:
+                    properties:
+                      enabled:
+                        type: boolean
+                      ilbGateway:
+                        properties:
+                          enabled:
+                            type: boolean
+                          namespace:
+                            type: string
+                          routerMode:
+                            type: string
+                          runtime:
+                            properties:
+                              container:
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              deployment:
+                                properties:
+                                  autoScaling:
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                      maxReplicas:
+                                        format: int32
+                                        type: integer
+                                      minReplicas:
+                                        format: int32
+                                        type: integer
+                                      targetCPUUtilizationPercentage:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  replicas:
+                                    format: int32
+                                    type: integer
+                                  strategy:
+                                    properties:
+                                      rollingUpdate:
+                                        properties:
+                                          maxSurge:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          maxUnavailable:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      type:
+                                        type: string
+                                    type: object
+                                type: object
+                              pod:
+                                properties:
+                                  affinity:
+                                    properties:
+                                      podAntiAffinity:
+                                        properties:
+                                          preferredDuringScheduling:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                topologyKey:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          requiredDuringScheduling:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                topologyKey:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  priorityClassName:
+                                    type: string
+                                  tolerations:
+                                    items:
+                                      properties:
+                                        effect:
+                                          type: string
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        tolerationSeconds:
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          service:
+                            properties:
+                              clusterIP:
+                                type: string
+                              externalIPs:
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                type: string
+                              externalTrafficPolicy:
+                                type: string
+                              healthCheckNodePort:
+                                format: int32
+                                type: integer
+                              ipFamily:
+                                type: string
+                              loadBalancerIP:
+                                type: string
+                              loadBalancerSourceRanges:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              ports:
+                                items:
+                                  properties:
+                                    appProtocol:
+                                      type: string
+                                    name:
+                                      type: string
+                                    nodePort:
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              sessionAffinity:
+                                type: string
+                              sessionAffinityConfig:
+                                properties:
+                                  clientIP:
+                                    properties:
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              topologyKeys:
+                                items:
+                                  type: string
+                                type: array
+                              type:
+                                type: string
+                            type: object
+                          volumes:
+                            items:
+                              properties:
+                                volume:
+                                  properties:
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                volumeMount:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  multiCluster:
+                    properties:
+                      enabled:
+                        type: boolean
+                      meshNetworks:
+                        additionalProperties:
+                          properties:
+                            endpoints:
+                              items:
+                                properties:
+                                  fromCIDR:
+                                    type: string
+                                  fromRegistry:
+                                    type: string
+                                type: object
+                              type: array
+                            gateways:
+                              items:
+                                properties:
+                                  address:
+                                    type: string
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        type: object
+                    type: object
+                  name:
+                    type: string
+                  network:
+                    type: string
+                type: object
+              gateways:
+                properties:
+                  additionalEgress:
+                    additionalProperties:
+                      properties:
+                        enabled:
+                          type: boolean
+                        namespace:
+                          type: string
+                        requestedNetworkView:
+                          items:
+                            type: string
+                          type: array
+                        routerMode:
+                          type: string
+                        runtime:
+                          properties:
+                            container:
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                              type: object
+                            deployment:
+                              properties:
+                                autoScaling:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    maxReplicas:
+                                      format: int32
+                                      type: integer
+                                    minReplicas:
+                                      format: int32
+                                      type: integer
+                                    targetCPUUtilizationPercentage:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                replicas:
+                                  format: int32
+                                  type: integer
+                                strategy:
+                                  properties:
+                                    rollingUpdate:
+                                      properties:
+                                        maxSurge:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        maxUnavailable:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    type:
+                                      type: string
+                                  type: object
+                              type: object
+                            pod:
+                              properties:
+                                affinity:
+                                  properties:
+                                    podAntiAffinity:
+                                      properties:
+                                        preferredDuringScheduling:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        requiredDuringScheduling:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                metadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                priorityClassName:
+                                  type: string
+                                tolerations:
+                                  items:
+                                    properties:
+                                      effect:
+                                        type: string
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      tolerationSeconds:
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        service:
+                          properties:
+                            clusterIP:
+                              type: string
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            ipFamily:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            ports:
+                              items:
+                                properties:
+                                  appProtocol:
+                                    type: string
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - port
+                              x-kubernetes-list-type: map
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
+                              properties:
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            topologyKeys:
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              type: string
+                          type: object
+                        volumes:
+                          items:
+                            properties:
+                              volume:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      defaultMode:
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  secret:
+                                    properties:
+                                      defaultMode:
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              volumeMount:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    type: object
+                  additionalIngress:
+                    additionalProperties:
+                      properties:
+                        enabled:
+                          type: boolean
+                        namespace:
+                          type: string
+                        routerMode:
+                          type: string
+                        runtime:
+                          properties:
+                            container:
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                              type: object
+                            deployment:
+                              properties:
+                                autoScaling:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    maxReplicas:
+                                      format: int32
+                                      type: integer
+                                    minReplicas:
+                                      format: int32
+                                      type: integer
+                                    targetCPUUtilizationPercentage:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                replicas:
+                                  format: int32
+                                  type: integer
+                                strategy:
+                                  properties:
+                                    rollingUpdate:
+                                      properties:
+                                        maxSurge:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        maxUnavailable:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    type:
+                                      type: string
+                                  type: object
+                              type: object
+                            pod:
+                              properties:
+                                affinity:
+                                  properties:
+                                    podAntiAffinity:
+                                      properties:
+                                        preferredDuringScheduling:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        requiredDuringScheduling:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                metadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                priorityClassName:
+                                  type: string
+                                tolerations:
+                                  items:
+                                    properties:
+                                      effect:
+                                        type: string
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      tolerationSeconds:
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        sds:
+                          properties:
+                            enabled:
+                              type: boolean
+                            runtime:
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        service:
+                          properties:
+                            clusterIP:
+                              type: string
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            ipFamily:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            ports:
+                              items:
+                                properties:
+                                  appProtocol:
+                                    type: string
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - port
+                              x-kubernetes-list-type: map
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
+                              properties:
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            topologyKeys:
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              type: string
+                          type: object
+                        volumes:
+                          items:
+                            properties:
+                              volume:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      defaultMode:
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  secret:
+                                    properties:
+                                      defaultMode:
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                    type: object
+                                type: object
+                              volumeMount:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    type: object
+                  egress:
+                    properties:
+                      enabled:
+                        type: boolean
+                      namespace:
+                        type: string
+                      requestedNetworkView:
+                        items:
+                          type: string
+                        type: array
+                      routerMode:
+                        type: string
+                      runtime:
+                        properties:
+                          container:
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                            type: object
+                          deployment:
+                            properties:
+                              autoScaling:
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                  maxReplicas:
+                                    format: int32
+                                    type: integer
+                                  minReplicas:
+                                    format: int32
+                                    type: integer
+                                  targetCPUUtilizationPercentage:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              replicas:
+                                format: int32
+                                type: integer
+                              strategy:
+                                properties:
+                                  rollingUpdate:
+                                    properties:
+                                      maxSurge:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      maxUnavailable:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  type:
+                                    type: string
+                                type: object
+                            type: object
+                          pod:
+                            properties:
+                              affinity:
+                                properties:
+                                  podAntiAffinity:
+                                    properties:
+                                      preferredDuringScheduling:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            topologyKey:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      requiredDuringScheduling:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            topologyKey:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              priorityClassName:
+                                type: string
+                              tolerations:
+                                items:
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      service:
+                        properties:
+                          clusterIP:
+                            type: string
+                          externalIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            type: string
+                          externalTrafficPolicy:
+                            type: string
+                          healthCheckNodePort:
+                            format: int32
+                            type: integer
+                          ipFamily:
+                            type: string
+                          loadBalancerIP:
+                            type: string
+                          loadBalancerSourceRanges:
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sessionAffinity:
+                            type: string
+                          sessionAffinityConfig:
+                            properties:
+                              clientIP:
+                                properties:
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          topologyKeys:
+                            items:
+                              type: string
+                            type: array
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            volume:
+                              properties:
+                                configMap:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                secret:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMount:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  enabled:
+                    type: boolean
+                  ingress:
+                    properties:
+                      enabled:
+                        type: boolean
+                      ingress:
+                        type: boolean
+                      meshExpansionPorts:
+                        items:
+                          properties:
+                            appProtocol:
+                              type: string
+                            name:
+                              type: string
+                            nodePort:
+                              format: int32
+                              type: integer
+                            port:
+                              format: int32
+                              type: integer
+                            protocol:
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                      namespace:
+                        type: string
+                      routerMode:
+                        type: string
+                      runtime:
+                        properties:
+                          container:
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                            type: object
+                          deployment:
+                            properties:
+                              autoScaling:
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                  maxReplicas:
+                                    format: int32
+                                    type: integer
+                                  minReplicas:
+                                    format: int32
+                                    type: integer
+                                  targetCPUUtilizationPercentage:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              replicas:
+                                format: int32
+                                type: integer
+                              strategy:
+                                properties:
+                                  rollingUpdate:
+                                    properties:
+                                      maxSurge:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      maxUnavailable:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  type:
+                                    type: string
+                                type: object
+                            type: object
+                          pod:
+                            properties:
+                              affinity:
+                                properties:
+                                  podAntiAffinity:
+                                    properties:
+                                      preferredDuringScheduling:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            topologyKey:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      requiredDuringScheduling:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            topologyKey:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              priorityClassName:
+                                type: string
+                              tolerations:
+                                items:
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      sds:
+                        properties:
+                          enabled:
+                            type: boolean
+                          runtime:
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      service:
+                        properties:
+                          clusterIP:
+                            type: string
+                          externalIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            type: string
+                          externalTrafficPolicy:
+                            type: string
+                          healthCheckNodePort:
+                            format: int32
+                            type: integer
+                          ipFamily:
+                            type: string
+                          loadBalancerIP:
+                            type: string
+                          loadBalancerSourceRanges:
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sessionAffinity:
+                            type: string
+                          sessionAffinityConfig:
+                            properties:
+                              clientIP:
+                                properties:
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          topologyKeys:
+                            items:
+                              type: string
+                            type: array
+                          type:
+                            type: string
+                        type: object
+                      volumes:
+                        items:
+                          properties:
+                            volume:
+                              properties:
+                                configMap:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                secret:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMount:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  openshiftRoute:
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              general:
+                properties:
+                  logging:
+                    properties:
+                      componentLevels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      logAsJSON:
+                        type: boolean
+                    type: object
+                  validationMessages:
+                    type: boolean
+                type: object
+              policy:
+                properties:
+                  mixer:
+                    properties:
+                      adapters:
+                        properties:
+                          kubernetesenv:
+                            type: boolean
+                          useAdapterCRDs:
+                            type: boolean
+                        type: object
+                      enableChecks:
+                        type: boolean
+                      failOpen:
+                        type: boolean
+                      sessionAffinity:
+                        type: boolean
+                    type: object
+                  remote:
+                    properties:
+                      address:
+                        type: string
+                      createService:
+                        type: boolean
+                      enableChecks:
+                        type: boolean
+                      failOpen:
+                        type: boolean
+                    type: object
+                  type:
+                    type: string
+                type: object
+              profiles:
+                items:
+                  type: string
+                type: array
+              proxy:
+                properties:
+                  accessLogging:
+                    properties:
+                      envoyService:
+                        properties:
+                          address:
+                            type: string
+                          enabled:
+                            type: boolean
+                          tcpKeepalive:
+                            properties:
+                              interval:
+                                type: string
+                              probes:
+                                format: int32
+                                type: integer
+                              time:
+                                type: string
+                            type: object
+                          tlsSettings:
+                            properties:
+                              caCertificates:
+                                type: string
+                              clientCertificate:
+                                type: string
+                              mode:
+                                type: string
+                              privateKey:
+                                type: string
+                              sni:
+                                type: string
+                              subjectAltNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      file:
+                        properties:
+                          encoding:
+                            type: string
+                          format:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                    type: object
+                  adminPort:
+                    format: int32
+                    type: integer
+                  concurrency:
+                    format: int32
+                    type: integer
+                  envoyMetricsService:
+                    properties:
+                      address:
+                        type: string
+                      enabled:
+                        type: boolean
+                      tcpKeepalive:
+                        properties:
+                          interval:
+                            type: string
+                          probes:
+                            format: int32
+                            type: integer
+                          time:
+                            type: string
+                        type: object
+                      tlsSettings:
+                        properties:
+                          caCertificates:
+                            type: string
+                          clientCertificate:
+                            type: string
+                          mode:
+                            type: string
+                          privateKey:
+                            type: string
+                          sni:
+                            type: string
+                          subjectAltNames:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  injection:
+                    properties:
+                      alwaysInjectSelector:
+                        items:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        type: array
+                      autoInject:
+                        type: boolean
+                      injectedAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      neverInjectSelector:
+                        items:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  logging:
+                    properties:
+                      componentLevels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      level:
+                        type: string
+                    type: object
+                  networking:
+                    properties:
+                      clusterDomain:
+                        type: string
+                      connectionTimeout:
+                        type: string
+                      dns:
+                        properties:
+                          refreshRate:
+                            type: string
+                          searchSuffixes:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      initialization:
+                        properties:
+                          initContainer:
+                            properties:
+                              runtime:
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      maxConnectionAge:
+                        type: string
+                      protocol:
+                        properties:
+                          autoDetect:
+                            properties:
+                              inbound:
+                                type: boolean
+                              outbound:
+                                type: boolean
+                              timeout:
+                                type: string
+                            type: object
+                        type: object
+                      trafficControl:
+                        properties:
+                          inbound:
+                            properties:
+                              excludedPorts:
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                              includedPorts:
+                                items:
+                                  type: string
+                                type: array
+                              interceptionMode:
+                                type: string
+                            type: object
+                          outbound:
+                            properties:
+                              excludedIPRanges:
+                                items:
+                                  type: string
+                                type: array
+                              excludedPorts:
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                              includedIPRanges:
+                                items:
+                                  type: string
+                                type: array
+                              policy:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  runtime:
+                    properties:
+                      container:
+                        properties:
+                          env:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          imageName:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          imageRegistry:
+                            type: string
+                          imageTag:
+                            type: string
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                        type: object
+                      readiness:
+                        properties:
+                          failureThreshold:
+                            format: int32
+                            type: integer
+                          initialDelaySeconds:
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            type: integer
+                          rewriteApplicationProbes:
+                            type: boolean
+                          statusPort:
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              runtime:
+                properties:
+                  components:
+                    additionalProperties:
+                      properties:
+                        container:
+                          properties:
+                            env:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            imageName:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            imagePullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            imageRegistry:
+                              type: string
+                            imageTag:
+                              type: string
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                          type: object
+                        deployment:
+                          properties:
+                            autoScaling:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                maxReplicas:
+                                  format: int32
+                                  type: integer
+                                minReplicas:
+                                  format: int32
+                                  type: integer
+                                targetCPUUtilizationPercentage:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            replicas:
+                              format: int32
+                              type: integer
+                            strategy:
+                              properties:
+                                rollingUpdate:
+                                  properties:
+                                    maxSurge:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    maxUnavailable:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                type:
+                                  type: string
+                              type: object
+                          type: object
+                        pod:
+                          properties:
+                            affinity:
+                              properties:
+                                podAntiAffinity:
+                                  properties:
+                                    preferredDuringScheduling:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          topologyKey:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    requiredDuringScheduling:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          topologyKey:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            priorityClassName:
+                              type: string
+                            tolerations:
+                              items:
+                                properties:
+                                  effect:
+                                    type: string
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  tolerationSeconds:
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    type: object
+                  defaults:
+                    properties:
+                      container:
+                        properties:
+                          imagePullPolicy:
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          imageRegistry:
+                            type: string
+                          imageTag:
+                            type: string
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                        type: object
+                      deployment:
+                        properties:
+                          podDisruption:
+                            properties:
+                              enabled:
+                                type: boolean
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              minAvailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      pod:
+                        properties:
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          priorityClassName:
+                            type: string
+                          tolerations:
+                            items:
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              security:
+                properties:
+                  certificateAuthority:
+                    properties:
+                      custom:
+                        properties:
+                          address:
+                            type: string
+                        type: object
+                      istiod:
+                        properties:
+                          privateKey:
+                            properties:
+                              rootCADir:
+                                type: string
+                            type: object
+                          selfSigned:
+                            properties:
+                              checkPeriod:
+                                type: string
+                              enableJitter:
+                                type: boolean
+                              gracePeriod:
+                                type: string
+                              ttl:
+                                type: string
+                            type: object
+                          type:
+                            type: string
+                          workloadCertTTLDefault:
+                            type: string
+                          workloadCertTTLMax:
+                            type: string
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                  controlPlane:
+                    properties:
+                      certProvider:
+                        type: string
+                      mtls:
+                        type: boolean
+                      tls:
+                        properties:
+                          cipherSuites:
+                            items:
+                              type: string
+                            type: array
+                          ecdhCurves:
+                            items:
+                              type: string
+                            type: array
+                          maxProtocolVersion:
+                            type: string
+                          minProtocolVersion:
+                            type: string
+                        type: object
+                    type: object
+                  dataPlane:
+                    properties:
+                      automtls:
+                        type: boolean
+                      mtls:
+                        type: boolean
+                    type: object
+                  identity:
+                    properties:
+                      thirdParty:
+                        properties:
+                          audience:
+                            type: string
+                          issuer:
+                            type: string
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                  trust:
+                    properties:
+                      additionalDomains:
+                        items:
+                          type: string
+                        type: array
+                      domain:
+                        type: string
+                    type: object
+                type: object
+              techPreview:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              telemetry:
+                properties:
+                  mixer:
+                    properties:
+                      adapters:
+                        properties:
+                          kubernetesenv:
+                            type: boolean
+                          stdio:
+                            properties:
+                              enabled:
+                                type: boolean
+                              outputAsJSON:
+                                type: boolean
+                            type: object
+                          useAdapterCRDs:
+                            type: boolean
+                        type: object
+                      batching:
+                        properties:
+                          maxEntries:
+                            format: int32
+                            type: integer
+                          maxTime:
+                            type: string
+                        type: object
+                      loadshedding:
+                        properties:
+                          latencyThreshold:
+                            type: string
+                          mode:
+                            type: string
+                        type: object
+                      sessionAffinity:
+                        type: boolean
+                    type: object
+                  remote:
+                    properties:
+                      address:
+                        type: string
+                      batching:
+                        properties:
+                          maxEntries:
+                            format: int32
+                            type: integer
+                          maxTime:
+                            type: string
+                        type: object
+                      createService:
+                        type: boolean
+                    type: object
+                  type:
+                    type: string
+                type: object
+              tracing:
+                properties:
+                  sampling:
+                    format: int32
+                    maximum: 10000
+                    minimum: 0
+                    type: integer
+                  type:
+                    type: string
+                type: object
+              version:
+                type: string
+            type: object
+          status:
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              appliedSpec:
+                properties:
+                  addons:
+                    properties:
+                      3scale:
+                        properties:
+                          backend:
+                            properties:
+                              cache_flush_interval:
+                                format: int32
+                                type: integer
+                              enable_cache:
+                                type: boolean
+                              policy_fail_closed:
+                                type: boolean
+                            type: object
+                          client:
+                            properties:
+                              allow_insecure_connections:
+                                type: boolean
+                              timeout:
+                                format: int32
+                                type: integer
+                            type: object
+                          enabled:
+                            type: boolean
+                          grpc:
+                            properties:
+                              max_conn_timeout:
+                                format: int32
+                                type: integer
+                            type: object
+                          listen_addr:
+                            format: int32
+                            type: integer
+                          log_grpc:
+                            type: boolean
+                          log_json:
+                            type: boolean
+                          log_level:
+                            type: string
+                          metrics:
+                            properties:
+                              port:
+                                format: int32
+                                type: integer
+                              report:
+                                type: boolean
+                            type: object
+                          system:
+                            properties:
+                              cache_max_size:
+                                format: int64
+                                type: integer
+                              cache_refresh_interval:
+                                format: int32
+                                type: integer
+                              cache_refresh_retries:
+                                format: int32
+                                type: integer
+                              cache_ttl:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      grafana:
+                        properties:
+                          address:
+                            type: string
+                          enabled:
+                            type: boolean
+                          install:
+                            properties:
+                              config:
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  envSecrets:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              persistence:
+                                properties:
+                                  accessMode:
+                                    type: string
+                                  capacity:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  enabled:
+                                    type: boolean
+                                  storageClassName:
+                                    type: string
+                                type: object
+                              security:
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                  passphraseKey:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                  usernameKey:
+                                    type: string
+                                type: object
+                              selfManaged:
+                                type: boolean
+                              service:
+                                properties:
+                                  ingress:
+                                    properties:
+                                      contextPath:
+                                        type: string
+                                      enabled:
+                                        type: boolean
+                                      hosts:
+                                        items:
+                                          type: string
+                                        type: array
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      tls:
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                        type: object
+                      jaeger:
+                        properties:
+                          install:
+                            properties:
+                              ingress:
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              storage:
+                                properties:
+                                  elasticsearch:
+                                    properties:
+                                      indexCleaner:
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      nodeCount:
+                                        format: int32
+                                        type: integer
+                                      redundancyPolicy:
+                                        type: string
+                                      storage:
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  memory:
+                                    properties:
+                                      maxTraces:
+                                        format: int64
+                                        type: integer
+                                    type: object
+                                  type:
+                                    type: string
+                                type: object
+                            type: object
+                          name:
+                            type: string
+                        type: object
+                      kiali:
+                        properties:
+                          enabled:
+                            type: boolean
+                          install:
+                            properties:
+                              dashboard:
+                                properties:
+                                  enableGrafana:
+                                    type: boolean
+                                  enablePrometheus:
+                                    type: boolean
+                                  enableTracing:
+                                    type: boolean
+                                  viewOnly:
+                                    type: boolean
+                                type: object
+                              service:
+                                properties:
+                                  ingress:
+                                    properties:
+                                      contextPath:
+                                        type: string
+                                      enabled:
+                                        type: boolean
+                                      hosts:
+                                        items:
+                                          type: string
+                                        type: array
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      tls:
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          name:
+                            type: string
+                        type: object
+                      prometheus:
+                        properties:
+                          address:
+                            type: string
+                          enabled:
+                            type: boolean
+                          install:
+                            properties:
+                              retention:
+                                type: string
+                              scrapeInterval:
+                                type: string
+                              selfManaged:
+                                type: boolean
+                              service:
+                                properties:
+                                  ingress:
+                                    properties:
+                                      contextPath:
+                                        type: string
+                                      enabled:
+                                        type: boolean
+                                      hosts:
+                                        items:
+                                          type: string
+                                        type: array
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      tls:
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              useTLS:
+                                type: boolean
+                            type: object
+                          metricsExpiryDuration:
+                            type: string
+                          scrape:
+                            type: boolean
+                        type: object
+                      stackdriver:
+                        properties:
+                          telemetry:
+                            properties:
+                              accessLogging:
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                  logWindowDuration:
+                                    type: string
+                                type: object
+                              auth:
+                                properties:
+                                  apiKey:
+                                    type: string
+                                  appCredentials:
+                                    type: boolean
+                                  serviceAccountPath:
+                                    type: string
+                                type: object
+                              configOverride:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              enableContextGraph:
+                                type: boolean
+                              enableLogging:
+                                type: boolean
+                              enableMetrics:
+                                type: boolean
+                              enabled:
+                                type: boolean
+                            type: object
+                          tracer:
+                            properties:
+                              debug:
+                                type: boolean
+                              maxNumberOfAnnotations:
+                                format: int64
+                                type: integer
+                              maxNumberOfAttributes:
+                                format: int64
+                                type: integer
+                              maxNumberOfMessageEvents:
+                                format: int64
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  cluster:
+                    properties:
+                      meshExpansion:
+                        properties:
+                          enabled:
+                            type: boolean
+                          ilbGateway:
+                            properties:
+                              enabled:
+                                type: boolean
+                              namespace:
+                                type: string
+                              routerMode:
+                                type: string
+                              runtime:
+                                properties:
+                                  container:
+                                    properties:
+                                      env:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      imageName:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      imagePullSecrets:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      imageRegistry:
+                                        type: string
+                                      imageTag:
+                                        type: string
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  deployment:
+                                    properties:
+                                      autoScaling:
+                                        properties:
+                                          enabled:
+                                            type: boolean
+                                          maxReplicas:
+                                            format: int32
+                                            type: integer
+                                          minReplicas:
+                                            format: int32
+                                            type: integer
+                                          targetCPUUtilizationPercentage:
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      replicas:
+                                        format: int32
+                                        type: integer
+                                      strategy:
+                                        properties:
+                                          rollingUpdate:
+                                            properties:
+                                              maxSurge:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              maxUnavailable:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          type:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  pod:
+                                    properties:
+                                      affinity:
+                                        properties:
+                                          podAntiAffinity:
+                                            properties:
+                                              preferredDuringScheduling:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    topologyKey:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              requiredDuringScheduling:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    topologyKey:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      priorityClassName:
+                                        type: string
+                                      tolerations:
+                                        items:
+                                          properties:
+                                            effect:
+                                              type: string
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            tolerationSeconds:
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              service:
+                                properties:
+                                  clusterIP:
+                                    type: string
+                                  externalIPs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  externalName:
+                                    type: string
+                                  externalTrafficPolicy:
+                                    type: string
+                                  healthCheckNodePort:
+                                    format: int32
+                                    type: integer
+                                  ipFamily:
+                                    type: string
+                                  loadBalancerIP:
+                                    type: string
+                                  loadBalancerSourceRanges:
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  ports:
+                                    items:
+                                      properties:
+                                        appProtocol:
+                                          type: string
+                                        name:
+                                          type: string
+                                        nodePort:
+                                          format: int32
+                                          type: integer
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        protocol:
+                                          type: string
+                                        targetPort:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - port
+                                    x-kubernetes-list-type: map
+                                  publishNotReadyAddresses:
+                                    type: boolean
+                                  selector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  sessionAffinity:
+                                    type: string
+                                  sessionAffinityConfig:
+                                    properties:
+                                      clientIP:
+                                        properties:
+                                          timeoutSeconds:
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  topologyKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                  type:
+                                    type: string
+                                type: object
+                              volumes:
+                                items:
+                                  properties:
+                                    volume:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        secret:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            optional:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    volumeMount:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      multiCluster:
+                        properties:
+                          enabled:
+                            type: boolean
+                          meshNetworks:
+                            additionalProperties:
+                              properties:
+                                endpoints:
+                                  items:
+                                    properties:
+                                      fromCIDR:
+                                        type: string
+                                      fromRegistry:
+                                        type: string
+                                    type: object
+                                  type: array
+                                gateways:
+                                  items:
+                                    properties:
+                                      address:
+                                        type: string
+                                      port:
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: object
+                        type: object
+                      name:
+                        type: string
+                      network:
+                        type: string
+                    type: object
+                  gateways:
+                    properties:
+                      additionalEgress:
+                        additionalProperties:
+                          properties:
+                            enabled:
+                              type: boolean
+                            namespace:
+                              type: string
+                            requestedNetworkView:
+                              items:
+                                type: string
+                              type: array
+                            routerMode:
+                              type: string
+                            runtime:
+                              properties:
+                                container:
+                                  properties:
+                                    env:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    imageName:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    imageRegistry:
+                                      type: string
+                                    imageTag:
+                                      type: string
+                                    resources:
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                deployment:
+                                  properties:
+                                    autoScaling:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        maxReplicas:
+                                          format: int32
+                                          type: integer
+                                        minReplicas:
+                                          format: int32
+                                          type: integer
+                                        targetCPUUtilizationPercentage:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    replicas:
+                                      format: int32
+                                      type: integer
+                                    strategy:
+                                      properties:
+                                        rollingUpdate:
+                                          properties:
+                                            maxSurge:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            maxUnavailable:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                  type: object
+                                pod:
+                                  properties:
+                                    affinity:
+                                      properties:
+                                        podAntiAffinity:
+                                          properties:
+                                            preferredDuringScheduling:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  topologyKey:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            requiredDuringScheduling:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  topologyKey:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    priorityClassName:
+                                      type: string
+                                    tolerations:
+                                      items:
+                                        properties:
+                                          effect:
+                                            type: string
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          tolerationSeconds:
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            service:
+                              properties:
+                                clusterIP:
+                                  type: string
+                                externalIPs:
+                                  items:
+                                    type: string
+                                  type: array
+                                externalName:
+                                  type: string
+                                externalTrafficPolicy:
+                                  type: string
+                                healthCheckNodePort:
+                                  format: int32
+                                  type: integer
+                                ipFamily:
+                                  type: string
+                                loadBalancerIP:
+                                  type: string
+                                loadBalancerSourceRanges:
+                                  items:
+                                    type: string
+                                  type: array
+                                metadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                ports:
+                                  items:
+                                    properties:
+                                      appProtocol:
+                                        type: string
+                                      name:
+                                        type: string
+                                      nodePort:
+                                        format: int32
+                                        type: integer
+                                      port:
+                                        format: int32
+                                        type: integer
+                                      protocol:
+                                        type: string
+                                      targetPort:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - port
+                                  x-kubernetes-list-type: map
+                                publishNotReadyAddresses:
+                                  type: boolean
+                                selector:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                sessionAffinity:
+                                  type: string
+                                sessionAffinityConfig:
+                                  properties:
+                                    clientIP:
+                                      properties:
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                topologyKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                type:
+                                  type: string
+                              type: object
+                            volumes:
+                              items:
+                                properties:
+                                  volume:
+                                    properties:
+                                      configMap:
+                                        properties:
+                                          defaultMode:
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      secret:
+                                        properties:
+                                          defaultMode:
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          optional:
+                                            type: boolean
+                                          secretName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  volumeMount:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        type: object
+                      additionalIngress:
+                        additionalProperties:
+                          properties:
+                            enabled:
+                              type: boolean
+                            namespace:
+                              type: string
+                            routerMode:
+                              type: string
+                            runtime:
+                              properties:
+                                container:
+                                  properties:
+                                    env:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    imageName:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    imageRegistry:
+                                      type: string
+                                    imageTag:
+                                      type: string
+                                    resources:
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                deployment:
+                                  properties:
+                                    autoScaling:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        maxReplicas:
+                                          format: int32
+                                          type: integer
+                                        minReplicas:
+                                          format: int32
+                                          type: integer
+                                        targetCPUUtilizationPercentage:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    replicas:
+                                      format: int32
+                                      type: integer
+                                    strategy:
+                                      properties:
+                                        rollingUpdate:
+                                          properties:
+                                            maxSurge:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            maxUnavailable:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        type:
+                                          type: string
+                                      type: object
+                                  type: object
+                                pod:
+                                  properties:
+                                    affinity:
+                                      properties:
+                                        podAntiAffinity:
+                                          properties:
+                                            preferredDuringScheduling:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  topologyKey:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            requiredDuringScheduling:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  topologyKey:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    priorityClassName:
+                                      type: string
+                                    tolerations:
+                                      items:
+                                        properties:
+                                          effect:
+                                            type: string
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          tolerationSeconds:
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            sds:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                runtime:
+                                  properties:
+                                    env:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    imageName:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    imageRegistry:
+                                      type: string
+                                    imageTag:
+                                      type: string
+                                    resources:
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                            service:
+                              properties:
+                                clusterIP:
+                                  type: string
+                                externalIPs:
+                                  items:
+                                    type: string
+                                  type: array
+                                externalName:
+                                  type: string
+                                externalTrafficPolicy:
+                                  type: string
+                                healthCheckNodePort:
+                                  format: int32
+                                  type: integer
+                                ipFamily:
+                                  type: string
+                                loadBalancerIP:
+                                  type: string
+                                loadBalancerSourceRanges:
+                                  items:
+                                    type: string
+                                  type: array
+                                metadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                ports:
+                                  items:
+                                    properties:
+                                      appProtocol:
+                                        type: string
+                                      name:
+                                        type: string
+                                      nodePort:
+                                        format: int32
+                                        type: integer
+                                      port:
+                                        format: int32
+                                        type: integer
+                                      protocol:
+                                        type: string
+                                      targetPort:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - port
+                                  x-kubernetes-list-type: map
+                                publishNotReadyAddresses:
+                                  type: boolean
+                                selector:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                sessionAffinity:
+                                  type: string
+                                sessionAffinityConfig:
+                                  properties:
+                                    clientIP:
+                                      properties:
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                topologyKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                type:
+                                  type: string
+                              type: object
+                            volumes:
+                              items:
+                                properties:
+                                  volume:
+                                    properties:
+                                      configMap:
+                                        properties:
+                                          defaultMode:
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      secret:
+                                        properties:
+                                          defaultMode:
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          optional:
+                                            type: boolean
+                                          secretName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  volumeMount:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        type: object
+                      egress:
+                        properties:
+                          enabled:
+                            type: boolean
+                          namespace:
+                            type: string
+                          requestedNetworkView:
+                            items:
+                              type: string
+                            type: array
+                          routerMode:
+                            type: string
+                          runtime:
+                            properties:
+                              container:
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              deployment:
+                                properties:
+                                  autoScaling:
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                      maxReplicas:
+                                        format: int32
+                                        type: integer
+                                      minReplicas:
+                                        format: int32
+                                        type: integer
+                                      targetCPUUtilizationPercentage:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  replicas:
+                                    format: int32
+                                    type: integer
+                                  strategy:
+                                    properties:
+                                      rollingUpdate:
+                                        properties:
+                                          maxSurge:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          maxUnavailable:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      type:
+                                        type: string
+                                    type: object
+                                type: object
+                              pod:
+                                properties:
+                                  affinity:
+                                    properties:
+                                      podAntiAffinity:
+                                        properties:
+                                          preferredDuringScheduling:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                topologyKey:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          requiredDuringScheduling:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                topologyKey:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  priorityClassName:
+                                    type: string
+                                  tolerations:
+                                    items:
+                                      properties:
+                                        effect:
+                                          type: string
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        tolerationSeconds:
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          service:
+                            properties:
+                              clusterIP:
+                                type: string
+                              externalIPs:
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                type: string
+                              externalTrafficPolicy:
+                                type: string
+                              healthCheckNodePort:
+                                format: int32
+                                type: integer
+                              ipFamily:
+                                type: string
+                              loadBalancerIP:
+                                type: string
+                              loadBalancerSourceRanges:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              ports:
+                                items:
+                                  properties:
+                                    appProtocol:
+                                      type: string
+                                    name:
+                                      type: string
+                                    nodePort:
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              sessionAffinity:
+                                type: string
+                              sessionAffinityConfig:
+                                properties:
+                                  clientIP:
+                                    properties:
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              topologyKeys:
+                                items:
+                                  type: string
+                                type: array
+                              type:
+                                type: string
+                            type: object
+                          volumes:
+                            items:
+                              properties:
+                                volume:
+                                  properties:
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                volumeMount:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      enabled:
+                        type: boolean
+                      ingress:
+                        properties:
+                          enabled:
+                            type: boolean
+                          ingress:
+                            type: boolean
+                          meshExpansionPorts:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                          namespace:
+                            type: string
+                          routerMode:
+                            type: string
+                          runtime:
+                            properties:
+                              container:
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                              deployment:
+                                properties:
+                                  autoScaling:
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                      maxReplicas:
+                                        format: int32
+                                        type: integer
+                                      minReplicas:
+                                        format: int32
+                                        type: integer
+                                      targetCPUUtilizationPercentage:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  replicas:
+                                    format: int32
+                                    type: integer
+                                  strategy:
+                                    properties:
+                                      rollingUpdate:
+                                        properties:
+                                          maxSurge:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          maxUnavailable:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      type:
+                                        type: string
+                                    type: object
+                                type: object
+                              pod:
+                                properties:
+                                  affinity:
+                                    properties:
+                                      podAntiAffinity:
+                                        properties:
+                                          preferredDuringScheduling:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                topologyKey:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          requiredDuringScheduling:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                topologyKey:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  metadata:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  priorityClassName:
+                                    type: string
+                                  tolerations:
+                                    items:
+                                      properties:
+                                        effect:
+                                          type: string
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        tolerationSeconds:
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          sds:
+                            properties:
+                              enabled:
+                                type: boolean
+                              runtime:
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                type: object
+                            type: object
+                          service:
+                            properties:
+                              clusterIP:
+                                type: string
+                              externalIPs:
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                type: string
+                              externalTrafficPolicy:
+                                type: string
+                              healthCheckNodePort:
+                                format: int32
+                                type: integer
+                              ipFamily:
+                                type: string
+                              loadBalancerIP:
+                                type: string
+                              loadBalancerSourceRanges:
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              ports:
+                                items:
+                                  properties:
+                                    appProtocol:
+                                      type: string
+                                    name:
+                                      type: string
+                                    nodePort:
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              sessionAffinity:
+                                type: string
+                              sessionAffinityConfig:
+                                properties:
+                                  clientIP:
+                                    properties:
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              topologyKeys:
+                                items:
+                                  type: string
+                                type: array
+                              type:
+                                type: string
+                            type: object
+                          volumes:
+                            items:
+                              properties:
+                                volume:
+                                  properties:
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                volumeMount:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      openshiftRoute:
+                        properties:
+                          enabled:
+                            type: boolean
+                        type: object
+                    type: object
+                  general:
+                    properties:
+                      logging:
+                        properties:
+                          componentLevels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          logAsJSON:
+                            type: boolean
+                        type: object
+                      validationMessages:
+                        type: boolean
+                    type: object
+                  policy:
+                    properties:
+                      mixer:
+                        properties:
+                          adapters:
+                            properties:
+                              kubernetesenv:
+                                type: boolean
+                              useAdapterCRDs:
+                                type: boolean
+                            type: object
+                          enableChecks:
+                            type: boolean
+                          failOpen:
+                            type: boolean
+                          sessionAffinity:
+                            type: boolean
+                        type: object
+                      remote:
+                        properties:
+                          address:
+                            type: string
+                          createService:
+                            type: boolean
+                          enableChecks:
+                            type: boolean
+                          failOpen:
+                            type: boolean
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                  profiles:
+                    items:
+                      type: string
+                    type: array
+                  proxy:
+                    properties:
+                      accessLogging:
+                        properties:
+                          envoyService:
+                            properties:
+                              address:
+                                type: string
+                              enabled:
+                                type: boolean
+                              tcpKeepalive:
+                                properties:
+                                  interval:
+                                    type: string
+                                  probes:
+                                    format: int32
+                                    type: integer
+                                  time:
+                                    type: string
+                                type: object
+                              tlsSettings:
+                                properties:
+                                  caCertificates:
+                                    type: string
+                                  clientCertificate:
+                                    type: string
+                                  mode:
+                                    type: string
+                                  privateKey:
+                                    type: string
+                                  sni:
+                                    type: string
+                                  subjectAltNames:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          file:
+                            properties:
+                              encoding:
+                                type: string
+                              format:
+                                type: string
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                      adminPort:
+                        format: int32
+                        type: integer
+                      concurrency:
+                        format: int32
+                        type: integer
+                      envoyMetricsService:
+                        properties:
+                          address:
+                            type: string
+                          enabled:
+                            type: boolean
+                          tcpKeepalive:
+                            properties:
+                              interval:
+                                type: string
+                              probes:
+                                format: int32
+                                type: integer
+                              time:
+                                type: string
+                            type: object
+                          tlsSettings:
+                            properties:
+                              caCertificates:
+                                type: string
+                              clientCertificate:
+                                type: string
+                              mode:
+                                type: string
+                              privateKey:
+                                type: string
+                              sni:
+                                type: string
+                              subjectAltNames:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      injection:
+                        properties:
+                          alwaysInjectSelector:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            type: array
+                          autoInject:
+                            type: boolean
+                          injectedAnnotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          neverInjectSelector:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      logging:
+                        properties:
+                          componentLevels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          level:
+                            type: string
+                        type: object
+                      networking:
+                        properties:
+                          clusterDomain:
+                            type: string
+                          connectionTimeout:
+                            type: string
+                          dns:
+                            properties:
+                              refreshRate:
+                                type: string
+                              searchSuffixes:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          initialization:
+                            properties:
+                              initContainer:
+                                properties:
+                                  runtime:
+                                    properties:
+                                      env:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      imageName:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      imagePullSecrets:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      imageRegistry:
+                                        type: string
+                                      imageTag:
+                                        type: string
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                type: object
+                              type:
+                                type: string
+                            type: object
+                          maxConnectionAge:
+                            type: string
+                          protocol:
+                            properties:
+                              autoDetect:
+                                properties:
+                                  inbound:
+                                    type: boolean
+                                  outbound:
+                                    type: boolean
+                                  timeout:
+                                    type: string
+                                type: object
+                            type: object
+                          trafficControl:
+                            properties:
+                              inbound:
+                                properties:
+                                  excludedPorts:
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                  includedPorts:
+                                    items:
+                                      type: string
+                                    type: array
+                                  interceptionMode:
+                                    type: string
+                                type: object
+                              outbound:
+                                properties:
+                                  excludedIPRanges:
+                                    items:
+                                      type: string
+                                    type: array
+                                  excludedPorts:
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                  includedIPRanges:
+                                    items:
+                                      type: string
+                                    type: array
+                                  policy:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      runtime:
+                        properties:
+                          container:
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                            type: object
+                          readiness:
+                            properties:
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              rewriteApplicationProbes:
+                                type: boolean
+                              statusPort:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  runtime:
+                    properties:
+                      components:
+                        additionalProperties:
+                          properties:
+                            container:
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                              type: object
+                            deployment:
+                              properties:
+                                autoScaling:
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                    maxReplicas:
+                                      format: int32
+                                      type: integer
+                                    minReplicas:
+                                      format: int32
+                                      type: integer
+                                    targetCPUUtilizationPercentage:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                replicas:
+                                  format: int32
+                                  type: integer
+                                strategy:
+                                  properties:
+                                    rollingUpdate:
+                                      properties:
+                                        maxSurge:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        maxUnavailable:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    type:
+                                      type: string
+                                  type: object
+                              type: object
+                            pod:
+                              properties:
+                                affinity:
+                                  properties:
+                                    podAntiAffinity:
+                                      properties:
+                                        preferredDuringScheduling:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        requiredDuringScheduling:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                metadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                priorityClassName:
+                                  type: string
+                                tolerations:
+                                  items:
+                                    properties:
+                                      effect:
+                                        type: string
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      tolerationSeconds:
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        type: object
+                      defaults:
+                        properties:
+                          container:
+                            properties:
+                              imagePullPolicy:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                            type: object
+                          deployment:
+                            properties:
+                              podDisruption:
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  minAvailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          pod:
+                            properties:
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              priorityClassName:
+                                type: string
+                              tolerations:
+                                items:
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  security:
+                    properties:
+                      certificateAuthority:
+                        properties:
+                          custom:
+                            properties:
+                              address:
+                                type: string
+                            type: object
+                          istiod:
+                            properties:
+                              privateKey:
+                                properties:
+                                  rootCADir:
+                                    type: string
+                                type: object
+                              selfSigned:
+                                properties:
+                                  checkPeriod:
+                                    type: string
+                                  enableJitter:
+                                    type: boolean
+                                  gracePeriod:
+                                    type: string
+                                  ttl:
+                                    type: string
+                                type: object
+                              type:
+                                type: string
+                              workloadCertTTLDefault:
+                                type: string
+                              workloadCertTTLMax:
+                                type: string
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      controlPlane:
+                        properties:
+                          certProvider:
+                            type: string
+                          mtls:
+                            type: boolean
+                          tls:
+                            properties:
+                              cipherSuites:
+                                items:
+                                  type: string
+                                type: array
+                              ecdhCurves:
+                                items:
+                                  type: string
+                                type: array
+                              maxProtocolVersion:
+                                type: string
+                              minProtocolVersion:
+                                type: string
+                            type: object
+                        type: object
+                      dataPlane:
+                        properties:
+                          automtls:
+                            type: boolean
+                          mtls:
+                            type: boolean
+                        type: object
+                      identity:
+                        properties:
+                          thirdParty:
+                            properties:
+                              audience:
+                                type: string
+                              issuer:
+                                type: string
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      trust:
+                        properties:
+                          additionalDomains:
+                            items:
+                              type: string
+                            type: array
+                          domain:
+                            type: string
+                        type: object
+                    type: object
+                  techPreview:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  telemetry:
+                    properties:
+                      mixer:
+                        properties:
+                          adapters:
+                            properties:
+                              kubernetesenv:
+                                type: boolean
+                              stdio:
+                                properties:
+                                  enabled:
+                                    type: boolean
+                                  outputAsJSON:
+                                    type: boolean
+                                type: object
+                              useAdapterCRDs:
+                                type: boolean
+                            type: object
+                          batching:
+                            properties:
+                              maxEntries:
+                                format: int32
+                                type: integer
+                              maxTime:
+                                type: string
+                            type: object
+                          loadshedding:
+                            properties:
+                              latencyThreshold:
+                                type: string
+                              mode:
+                                type: string
+                            type: object
+                          sessionAffinity:
+                            type: boolean
+                        type: object
+                      remote:
+                        properties:
+                          address:
+                            type: string
+                          batching:
+                            properties:
+                              maxEntries:
+                                format: int32
+                                type: integer
+                              maxTime:
+                                type: string
+                            type: object
+                          createService:
+                            type: boolean
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                  tracing:
+                    properties:
+                      sampling:
+                        format: int32
+                        maximum: 10000
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                    type: object
+                  version:
+                    type: string
+                type: object
+              appliedValues:
+                properties:
+                  istio:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  networkType:
+                    type: string
+                  profiles:
+                    items:
+                      type: string
+                    type: array
+                  template:
+                    type: string
+                  threeScale:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  version:
+                    type: string
+                type: object
+              chartVersion:
+                type: string
+              components:
+                items:
+                  properties:
+                    children:
+                      items:
+                        properties:
+                          conditions:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  format: date-time
+                                  type: string
+                                message:
+                                  type: string
+                                reason:
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    conditions:
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                    resource:
+                      type: string
+                  type: object
+                type: array
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              operatorVersion:
+                type: string
+              readiness:
+                properties:
+                  components:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    type: object
+                type: object
+            required:
+            - readiness
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: servicemeshmemberrolls.maistra.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.annotations.configuredMemberCount
+    description: How many of the total number of member namespaces are configured
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    description: Whether all member namespaces have been configured or why that's
+      not the case
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the object
+    name: Age
+    type: date
+  - JSONPath: .status.members
+    description: Namespaces that are members of this Control Plane
+    name: Members
+    priority: 1
+    type: string
+  group: maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshMemberRoll
+    listKind: ServiceMeshMemberRollList
+    plural: servicemeshmemberrolls
+    shortNames:
+    - smmr
+    singular: servicemeshmemberroll
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            members:
+              items:
+                type: string
+              nullable: true
+              type: array
+          type: object
+        status:
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            configuredMembers:
+              items:
+                type: string
+              nullable: true
+              type: array
+            memberStatuses:
+              items:
+                properties:
+                  conditions:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          format: date-time
+                          type: string
+                        message:
+                          type: string
+                        reason:
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    type: array
+                  namespace:
+                    type: string
+                required:
+                - conditions
+                - namespace
+                type: object
+              nullable: true
+              type: array
+            members:
+              items:
+                type: string
+              nullable: true
+              type: array
+            meshGeneration:
+              format: int64
+              type: integer
+            meshReconciledVersion:
+              type: string
+            observedGeneration:
+              format: int64
+              type: integer
+            pendingMembers:
+              items:
+                type: string
+              nullable: true
+              type: array
+            terminatingMembers:
+              items:
+                type: string
+              nullable: true
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: servicemeshmembers.maistra.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.annotations.controlPlaneRef
+    description: The ServiceMeshControlPlane this namespace belongs to
+    name: Control Plane
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    description: Whether or not namespace is configured as a member of the mesh.
+    name: Ready
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: The age of the object
+    name: Age
+    type: date
+  group: maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshMember
+    listKind: ServiceMeshMemberList
+    plural: servicemeshmembers
+    shortNames:
+    - smm
+    singular: servicemeshmember
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            controlPlaneRef:
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - name
+              - namespace
+              type: object
+          required:
+          - controlPlaneRef
+          type: object
+        status:
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            meshGeneration:
+              format: int64
+              type: integer
+            meshReconciledVersion:
+              type: string
+            observedGeneration:
+              format: int64
+              type: integer
+          required:
+          - conditions
+          - observedGeneration
+          type: object
+      required:
+      - spec
+      type: object
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tests/integration/maistra/testdata/global-mtls.yaml
+++ b/tests/integration/maistra/testdata/global-mtls.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  mtls:
+    mode: STRICT

--- a/tests/integration/maistra/testdata/namespace.yaml
+++ b/tests/integration/maistra/testdata/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+spec:

--- a/tests/integration/maistra/testdata/rbac.yaml
+++ b/tests/integration/maistra/testdata/rbac.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: istio-system
+  name: member-roll-reader
+rules:
+- apiGroups: ["maistra.io"]
+  resources: ["servicemeshmemberrolls"]
+  verbs: ["get", "watch", "list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: istio-system
+  name: member-roll-reader
+subjects:
+- kind: ServiceAccount
+  name: istiod-service-account
+  namespace: istio-system
+roleRef:
+  kind: Role
+  name: member-roll-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This adds the beginnings of an integration test suite for Maistra specific features. It deploys an Istio control-plane with Maistra's options for limiting cluster-scoped access, and provides helpers to manage the ServiceMeshMemberRoll for the control-plane.

I had really hoped to have more here, but it turned out to be a bit more work than I thought, and I'm running out of time. I want to get something up that at least provides a framework and some initial value.