### PR TITLE
MAISTRA-2355: Change httpbin port to 8000

### DIFF
--- a/samples/httpbin/httpbin-nodeport.yaml
+++ b/samples/httpbin/httpbin-nodeport.yaml
@@ -27,7 +27,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 80
+    targetPort: 8000
   selector:
     app: httpbin
 ---
@@ -52,4 +52,5 @@ spec:
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 80
+        - containerPort: 8000
+        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]

--- a/samples/httpbin/httpbin-vault.yaml
+++ b/samples/httpbin/httpbin-vault.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 80
+    targetPort: 8000
   selector:
     app: httpbin
 ---
@@ -52,4 +52,5 @@ spec:
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 80
+        - containerPort: 8000
+        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]

--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -31,7 +31,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 80
+    targetPort: 8000
   selector:
     app: httpbin
 ---
@@ -59,4 +59,5 @@ spec:
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 80
+        - containerPort: 8000
+        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]


### PR DESCRIPTION
From the default `80`, which is not allowed by default in OpenShift.
Service already uses port `8000`, so this change should have minimal
impact.
