### PR TITLE
MAISTRA-2391: Push old extension config

### DIFF
--- a/pkg/servicemesh/extension/apply_extension.go
+++ b/pkg/servicemesh/extension/apply_extension.go
@@ -24,6 +24,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	structpb2 "google.golang.org/protobuf/types/known/structpb"
 	v1 "maistra.io/api/core/v1"
+	v1alpha1 "maistra.io/api/core/v1alpha1"
 
 	"istio.io/istio/istioctl/pkg/authz"
 	"istio.io/istio/pilot/pkg/model"
@@ -59,7 +60,6 @@ func ApplyListenerPatches(
 		return listener
 	}
 
-	// FIXME: https://issues.redhat.com/browse/MAISTRA-2321
 	relevantFilterChains := []string{fmt.Sprintf("0.0.0.0_%d", proxy.ServiceInstances[0].Endpoint.EndpointPort)}
 	for _, si := range proxy.ServiceInstances {
 		relevantFilterChains = append(relevantFilterChains, fmt.Sprintf("%s_%d", si.Endpoint.Address, si.Endpoint.EndpointPort))
@@ -167,10 +167,23 @@ func popAppend(list []*hcm_filter.HttpFilter,
 }
 
 func toEnvoyHTTPFilter(extension *maistramodel.ExtensionWrapper) *hcm_filter.HttpFilter {
-	configuration, err := structpb2.NewStruct(extension.Config.Data)
-	if err != nil {
-		log.Errorf("invalid configuration for extension %s: %v", extension.Name, err)
-		return nil
+	var configField *structpb.Value
+
+	if rawV1Alpha1Config, ok := extension.Config.Data[v1alpha1.RawV1Alpha1Config]; ok {
+		// Extension uses old config format (string), so pass it as a string
+		configField = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: rawV1Alpha1Config.(string)}}
+	} else {
+		// Otherwise, send it as a proper JSON object
+		configuration, err := structpb2.NewStruct(extension.Config.Data)
+		if err != nil {
+			log.Errorf("invalid configuration for extension %s: %v", extension.Name, err)
+			return nil
+		}
+
+		configField = &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
+			"@type": {Kind: &structpb.Value_StringValue{StringValue: "type.googleapis.com/google.protobuf.Struct"}},
+			"value": {Kind: &structpb.Value_StructValue{StructValue: configuration}},
+		}}}}
 	}
 
 	return &hcm_filter.HttpFilter{
@@ -181,12 +194,9 @@ func toEnvoyHTTPFilter(extension *maistramodel.ExtensionWrapper) *hcm_filter.Htt
 				Value: &structpb.Struct{
 					Fields: map[string]*structpb.Value{
 						"config": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
-							"name":   {Kind: &structpb.Value_StringValue{StringValue: extension.Name}},
-							"rootId": {Kind: &structpb.Value_StringValue{StringValue: extension.Name + "_root"}},
-							"configuration": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
-								"@type": {Kind: &structpb.Value_StringValue{StringValue: "type.googleapis.com/google.protobuf.Struct"}},
-								"value": {Kind: &structpb.Value_StructValue{StructValue: configuration}},
-							}}}},
+							"name":          {Kind: &structpb.Value_StringValue{StringValue: extension.Name}},
+							"rootId":        {Kind: &structpb.Value_StringValue{StringValue: extension.Name + "_root"}},
+							"configuration": configField,
 							"vmConfig": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 								"code": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 									"remote": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{


### PR DESCRIPTION
If it's present, meaning the conversion v1alpha1->v1 failed.

In this case, the old config field is a string that could not be
converted to JSON. So, just push the raw string into the extension
config field.