### PR TITLE
MAISTRA-2390 Push trust bundle updates through xDS

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -276,6 +276,8 @@ func NewServer(args *PilotArgs) (*Server, error) {
 				IstiodNamespace:   args.Namespace,
 				IstiodPodName:     args.PodName,
 			})
+			s.XDSServer.Generators[v3.TrustBundleType] = &xds.TbdsGenerator{TrustBundleProvider: s.federation}
+
 			if err != nil {
 				return nil, fmt.Errorf("error initializing federation: %v", err)
 			}
@@ -785,9 +787,6 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 	s.secureGrpcServer = grpc.NewServer(opts...)
 	s.XDSServer.Register(s.secureGrpcServer)
 	reflection.Register(s.secureGrpcServer)
-	if s.federation != nil {
-		s.federation.Register(s.secureGrpcServer)
-	}
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go func() {

--- a/pilot/pkg/xds/tbds.go
+++ b/pilot/pkg/xds/tbds.go
@@ -1,0 +1,68 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	v1 "maistra.io/api/security/v1"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+	fedmodel "istio.io/istio/pkg/servicemesh/federation/model"
+)
+
+// TbdsGenerator generates trust bundle configuration for proxies to consume
+type TbdsGenerator struct {
+	TrustBundleProvider fedmodel.TrustBundleProvider
+}
+
+var _ model.XdsResourceGenerator = &TbdsGenerator{}
+
+func tbdsNeedsPush(req *model.PushRequest) bool {
+	if req == nil {
+		return true
+	}
+
+	if !req.Full {
+		return false
+	}
+
+	if len(req.ConfigsUpdated) == 0 {
+		return true
+	}
+
+	return false
+}
+
+// Generate returns protobuf containing TrustBundle for given proxy
+func (e *TbdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *model.WatchedResource, req *model.PushRequest) model.Resources {
+	if !tbdsNeedsPush(req) {
+		return nil
+	}
+	if e.TrustBundleProvider == nil {
+		return nil
+	}
+	tb := &v1.TrustBundleResponse{}
+	trustBundles := e.TrustBundleProvider.GetTrustBundles()
+	if len(trustBundles) == 0 {
+		return nil
+	}
+	for td, cert := range trustBundles {
+		tb.TrustBundles = append(tb.TrustBundles, &v1.TrustBundle{
+			TrustDomain: td,
+			RootCert:    cert,
+		})
+	}
+	return model.Resources{util.MessageToAny(tb)}
+}

--- a/pilot/pkg/xds/v3/model.go
+++ b/pilot/pkg/xds/v3/model.go
@@ -25,6 +25,8 @@ const (
 	RouteType     = resource.RouteType
 	SecretType    = resource.SecretType
 	NameTableType = "type.googleapis.com/istio.networking.nds.v1.NameTable"
+	// maistra xDS
+	TrustBundleType = "type.googleapis.com/maistra.security.v1.TrustBundleResponse"
 )
 
 // GetShortType returns an abbreviated form of a type, useful for logging or human friendly messages
@@ -42,6 +44,8 @@ func GetShortType(typeURL string) string {
 		return "SDS"
 	case NameTableType:
 		return "NDS"
+	case TrustBundleType:
+		return "TBDS"
 	default:
 		return typeURL
 	}
@@ -62,6 +66,8 @@ func GetMetricType(typeURL string) string {
 		return "sds"
 	case NameTableType:
 		return "nds"
+	case TrustBundleType:
+		return "tbds"
 	default:
 		return typeURL
 	}

--- a/pkg/servicemesh/federation/federation.go
+++ b/pkg/servicemesh/federation/federation.go
@@ -17,10 +17,8 @@ package federation
 import (
 	"fmt"
 
-	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
-	v1 "maistra.io/api/security/v1"
 
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
@@ -158,8 +156,8 @@ func (f *Federation) StartServer(stopCh <-chan struct{}) {
 	f.server.Run(stopCh)
 }
 
-func (f *Federation) Register(grpc *grpc.Server) {
-	v1.RegisterTrustBundleServiceServer(grpc, f.discoveryController)
+func (f *Federation) GetTrustBundles() map[string]string {
+	return f.discoveryController.GetTrustBundles()
 }
 
 func (opt Options) validate() error {

--- a/pkg/servicemesh/federation/model/model.go
+++ b/pkg/servicemesh/federation/model/model.go
@@ -15,8 +15,6 @@
 package model
 
 import (
-	"context"
-
 	hashstructure "github.com/mitchellh/hashstructure/v2"
 )
 
@@ -78,5 +76,5 @@ func (s *ServiceMessage) GenerateChecksum() uint64 {
 }
 
 type TrustBundleProvider interface {
-	GetTrustBundles(ctx context.Context) (map[string]string, error)
+	GetTrustBundles() map[string]string
 }

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
-	v1 "maistra.io/api/security/v1"
 
 	pb "istio.io/api/security/v1alpha1"
 	"istio.io/istio/pkg/security"
@@ -56,8 +55,6 @@ type citadelClient struct {
 	client        pb.IstioCertificateServiceClient
 	clusterID     string
 	conn          *grpc.ClientConn
-
-	trustBundleClient v1.TrustBundleServiceClient
 }
 
 // NewCitadelClient create a CA client for Citadel.
@@ -76,7 +73,6 @@ func NewCitadelClient(endpoint string, tls bool, rootCert []byte, clusterID stri
 	}
 	c.conn = conn
 	c.client = pb.NewIstioCertificateServiceClient(conn)
-	c.trustBundleClient = v1.NewTrustBundleServiceClient(conn)
 	return c, nil
 }
 
@@ -112,21 +108,6 @@ func (c *citadelClient) CSRSign(ctx context.Context, reqID string, csrPEM []byte
 	}
 
 	return resp.CertChain, nil
-}
-
-func (c *citadelClient) GetTrustBundles(ctx context.Context) (map[string]string, error) {
-	resp, err := c.trustBundleClient.GetTrustBundles(ctx, &v1.TrustBundleRequest{})
-	if err != nil {
-		citadelClientLog.Errorf("Failed to get trust bundles: %v", err)
-		return nil, err
-	}
-
-	trustBundleMap := map[string]string{}
-	for _, tb := range resp.TrustBundles {
-		trustBundleMap[tb.TrustDomain] = tb.RootCert
-	}
-	return trustBundleMap, nil
-
 }
 
 func (c *citadelClient) getTLSDialOption() (grpc.DialOption, error) {
@@ -218,6 +199,5 @@ func (c *citadelClient) reconnect() error {
 	}
 	c.conn = conn
 	c.client = pb.NewIstioCertificateServiceClient(conn)
-	c.trustBundleClient = v1.NewTrustBundleServiceClient(conn)
 	return err
 }


### PR DESCRIPTION
This replaces a bunch of code that was committed as part of #334 - looking back, I should have implemented it using a push mechanism from the start.

This completely removes the gRPC service that was previously used for polling. I could have even simplified the proto in maistra/api, but we can remove that in 2.2 anyway, so I'll keep it as it is.