### PR TITLE
MAISTRA-2249: Remove outdated comment

### DIFF
--- a/mec/pkg/server/worker.go
+++ b/mec/pkg/server/worker.go
@@ -129,7 +129,6 @@ func (w *Worker) processEvent(event ExtensionEvent) error {
 	// Only happens if image is in the format: quay.io/repo/image@sha256:...
 	if imageRef.SHA256 != "" {
 		workerlog.Debug("Trying to get an already pulled image")
-		// FIXME: GetImage() is broken and always returns an error: MAISTRA-2249
 		img, err = w.pullStrategy.GetImage(imageRef)
 		if err != nil {
 			workerlog.Errorf("failed to check whether image is already present: %v", err)


### PR DESCRIPTION
This is not an issue anymore. With the new podman shipped in our
base images (ubi8, based on rhel 8.4), this command (`podman image ls
-nq`) works fine. This is also valid for 2.0, because both use the same
ubi8 base image.
