### PR TITLE
MAISTRA-2254: MEC: Garbage collects Image Streams

### DIFF
--- a/mec/pkg/model/interfaces.go
+++ b/mec/pkg/model/interfaces.go
@@ -16,11 +16,18 @@ package model
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type ImagePullStrategy interface {
 	// PullImage will go and Pull and image from a remote registry
-	PullImage(image *ImageRef, namespace string, pullPolicy corev1.PullPolicy, pullSecrets []corev1.LocalObjectReference) (Image, error)
+	PullImage(
+		image *ImageRef,
+		namespace string,
+		pullPolicy corev1.PullPolicy,
+		pullSecrets []corev1.LocalObjectReference,
+		smeName string,
+		smeUID types.UID) (Image, error)
 	// GetImage returns an image that has been pulled previously
 	GetImage(image *ImageRef) (Image, error)
 	// Login is used to provide credentials to the ImagePullStrategy

--- a/mec/pkg/pullstrategy/fake/strategy.go
+++ b/mec/pkg/pullstrategy/fake/strategy.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	v1 "maistra.io/api/core/v1"
 
 	"istio.io/istio/mec/pkg/model"
@@ -83,7 +84,9 @@ type PullStrategy struct {
 func (p *PullStrategy) PullImage(imageRef *model.ImageRef,
 	namespace string,
 	pullPolicy corev1.PullPolicy,
-	pullSecrets []corev1.LocalObjectReference) (model.Image, error) {
+	pullSecrets []corev1.LocalObjectReference,
+	smeName string,
+	smeUID types.UID) (model.Image, error) {
 
 	if p.pulledImages == nil {
 		p.pulledImages = make(map[string]model.Image)

--- a/mec/pkg/pullstrategy/ossm/strategy_test.go
+++ b/mec/pkg/pullstrategy/ossm/strategy_test.go
@@ -315,7 +315,7 @@ func TestPullImage(t *testing.T) {
 				client: clientSet.ImageV1(),
 				podman: fakePodman,
 			}
-			image, err := strategy.PullImage(tc.imageRef, "test", v1.PullAlways, nil)
+			image, err := strategy.PullImage(tc.imageRef, "test", v1.PullAlways, nil, "", "")
 			if tc.expectedError {
 				if err == nil {
 					t.Error("Expected error but got nil")

--- a/mec/pkg/server/worker.go
+++ b/mec/pkg/server/worker.go
@@ -143,7 +143,13 @@ func (w *Worker) processEvent(event ExtensionEvent) error {
 			pullPolicy = corev1.PullAlways
 		}
 
-		img, err = w.pullStrategy.PullImage(imageRef, extension.Namespace, pullPolicy, extension.Spec.ImagePullSecrets)
+		img, err = w.pullStrategy.PullImage(
+			imageRef,
+			extension.Namespace,
+			pullPolicy,
+			extension.Spec.ImagePullSecrets,
+			extension.Name,
+			extension.UID)
 		if err != nil {
 			message := fmt.Sprintf("failed to pull image %q: %v", imageRef.String(), err)
 			if err := w.updateStatusNotReady(extension, message); err != nil {


### PR DESCRIPTION
Set the `OwnerReferences` field of the Image Streams we create so
that they are automatically removed when the corresponding
`ServiceMeshExtension` resource is removed.
