### PR TITLE
Do not download envoy-centos image (#234)

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -121,7 +121,7 @@ endif
 
 # Envoy binary variables Keep the default URLs up-to-date with the latest push from istio/proxy.
 
-export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/istio-build/proxy
+export ISTIO_ENVOY_BASE_URL ?= https://storage.googleapis.com/maistra-prow-testing/proxy
 
 # Use envoy as the sidecar by default
 export SIDECAR ?= envoy

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -126,6 +126,7 @@ fi
 download_envoy_if_necessary "${ISTIO_ENVOY_LINUX_RELEASE_URL}" "$ISTIO_ENVOY_LINUX_RELEASE_PATH" "${SIDECAR}"
 download_envoy_if_necessary "${ISTIO_ENVOY_CENTOS_RELEASE_URL}" "$ISTIO_ENVOY_CENTOS_LINUX_RELEASE_PATH" "${SIDECAR}-centos"
 
+
 if [[ "$GOOS_LOCAL" == "darwin" ]]; then
   # Download and extract the Envoy macOS release binary
   download_envoy_if_necessary "${ISTIO_ENVOY_MACOS_RELEASE_URL}" "$ISTIO_ENVOY_MACOS_RELEASE_PATH" "${SIDECAR}"

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,21 +1,8 @@
-# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
+FROM centos:8
 
-# Version is the base image version from the TLD Makefile
-ARG BASE_VERSION=latest
-
-# The following section is used as base image if BASE_DISTRIBUTION=default
-FROM gcr.io/istio-release/base:${BASE_VERSION} as default
-
-# The following section is used as base image if BASE_DISTRIBUTION=distroless
-# This image is a custom built debian9 distroless image with multiarchitecture support.
-# It is built on the base distroless image, with iptables binary and libraries added
-# The source can be found at https://github.com/istio/distroless/tree/iptables
-FROM gcr.io/istio-release/iptables@sha256:8601b3cb13984e375d9a9a85687f23c88bc798e4f2ec9a80cca5e6abda66c6f9 as distroless
-
-# This will build the final image based on either default or distroless from above
-# hadolint ignore=DL3006
-FROM ${BASE_DISTRIBUTION}
+RUN dnf -y upgrade --refresh && \
+    dnf -y install iptables iproute openssl && \
+    dnf -y clean all
 
 WORKDIR /
 
@@ -26,6 +13,9 @@ ARG SIDECAR=envoy
 # Copy Envoy bootstrap templates used by pilot-agent
 COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+
+RUN useradd -m --uid 1337 istio-proxy
+RUN chown -R istio-proxy /var/lib/istio
 
 # Install Envoy.
 COPY $SIDECAR /usr/local/bin/$SIDECAR

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -574,7 +574,7 @@ func GenerateService(cfg echo.Config) (string, error) {
 	return tmpl.Execute(serviceTemplate, params)
 }
 
-const DefaultVMImage = "app_sidecar_ubuntu_bionic"
+const DefaultVMImage = "app_sidecar_centos_8"
 
 func templateParams(cfg echo.Config, settings *image.Settings, versions resource.RevVerMap) (map[string]interface{}, error) {
 	if settings == nil {

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -103,11 +103,11 @@ function build_images() {
   # Build just the images needed for tests
   targets="docker.pilot docker.proxyv2 "
 
-  # use ubuntu:bionic to test vms by default
-  nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_bionic "
+  # use centos:8 to test vms by default
+  nonDistrolessTargets="docker.app docker.app_sidecar_centos_8 "
   if [[ "${SELECT_TEST}" == "test.integration.pilot.kube" ]]; then
     nonDistrolessTargets+="docker.app_sidecar_ubuntu_xenial docker.app_sidecar_ubuntu_focal docker.app_sidecar_ubuntu_bionic "
-    nonDistrolessTargets+="docker.app_sidecar_debian_9 docker.app_sidecar_debian_10 docker.app_sidecar_centos_7 docker.app_sidecar_centos_8 "
+    nonDistrolessTargets+="docker.app_sidecar_debian_9 docker.app_sidecar_debian_10 docker.app_sidecar_centos_7 docker.app_sidecar_ubuntu_bionic "
   fi
   targets+="docker.operator "
   targets+="docker.install-cni "


### PR DESCRIPTION
* Do not download envoy-centos image

We do not use it.

Also, change proxy SHA to match maistra proxy.

* Change proxy image to be centos based

And change default app sidecar to be centos based too.

Make `make docker` work again (#251)

- Point the Base URL to ours instead of upstream
- Download envoy-centos binary (Reverts
  https://github.com/maistra/istio/pull/234/commits/bb004bd823640ea15e747e21bbb7c0d706a6f9e3)
- Bump proxy SHA
