### PR TITLE
MAISTRA-2463: copy seed namespaces when set

### DIFF
--- a/pkg/servicemesh/controller/memberroll/controller.go
+++ b/pkg/servicemesh/controller/memberroll/controller.go
@@ -117,7 +117,7 @@ func (smmrc *serviceMeshMemberRollController) Start(stop chan struct{}) {
 	for _, obj := range smmrc.informer.GetStore().List() {
 		serviceMeshMemberRoll := getServiceMeshMemberRoll(obj)
 		if smmrc.memberRollName == serviceMeshMemberRoll.Name {
-			seedNamespaces := smmrc.getNamespaces(serviceMeshMemberRoll.Status.ConfiguredMembers)
+			seedNamespaces := serviceMeshMemberRoll.Status.ConfiguredMembers
 			smmrc.setSeedNamespaces(seedNamespaces)
 			break
 		}
@@ -151,8 +151,8 @@ func (smmrc *serviceMeshMemberRollController) getSeedNamespaces() []string {
 	return smmrc.seedNamespaces
 }
 
-func (smmrc *serviceMeshMemberRollController) setSeedNamespaces(seedNamespaces []string) {
-	sort.Strings(seedNamespaces)
+func (smmrc *serviceMeshMemberRollController) setSeedNamespaces(namespaces []string) {
+	seedNamespaces := append(namespaces[:0:0], namespaces...)
 	smmrc.lock.Lock()
 	defer smmrc.lock.Unlock()
 	smmrc.seedNamespaces = seedNamespaces
@@ -165,7 +165,7 @@ func (smmrc *serviceMeshMemberRollController) newServiceMeshMemberRollListener(l
 		currentNamespaces: nil,
 		name:              name,
 	}
-	handler.updateNamespaces("add", smmrc.memberRollName, smmrc.getNamespaces(smmrc.getSeedNamespaces()))
+	handler.updateNamespaces("add", smmrc.memberRollName, smmrc.getSeedNamespaces())
 	return handler
 }
 

--- a/pkg/servicemesh/controller/memberroll/controller_test.go
+++ b/pkg/servicemesh/controller/memberroll/controller_test.go
@@ -1,0 +1,34 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memberroll
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetSeedNamespaces(t *testing.T) {
+	testNamespaces := []string{"test-5", "test-4", "test-3", "test-2", "test-1"}
+	smmrc := &serviceMeshMemberRollController{
+		namespace: "istio-system",
+	}
+
+	copyTestNamespaces := append(testNamespaces[:0:0], testNamespaces...)
+	smmrc.setSeedNamespaces(testNamespaces)
+
+	if !reflect.DeepEqual(testNamespaces, copyTestNamespaces) {
+		t.Error("Input seed namespace slice has been modified")
+	}
+}


### PR DESCRIPTION
Ensure calls to setSeedNamespaces will not update the input slice.