### PR TITLE
MAISTRA-2237 Encrypt service discovery traffic

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1209,6 +1209,28 @@ spec:
       name: cpu
       targetAverageUtilization: 80
 ---
+# Source: istio-discovery/templates/federation.yaml
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: istiod
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "Pilot"
+    app: istiod
+    istio: pilot
+    release: istio
+spec:
+  host: istiod.istio-system.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+    - port:
+        number: 8188
+      tls:
+        mode: SIMPLE
+---
 # Source: istio-discovery/templates/telemetryv2_1.8.yaml
 # Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3

--- a/manifests/charts/istio-control/istio-discovery/templates/federation.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/federation.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+    operator.istio.io/component: "Pilot"
+    app: istiod
+    istio: pilot
+    release: {{ .Release.Name }}
+spec:
+  host: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+    - port:
+        number: 8188
+      tls:
+        mode: SIMPLE
+---

--- a/pkg/servicemesh/federation/federation.go
+++ b/pkg/servicemesh/federation/federation.go
@@ -15,6 +15,7 @@
 package federation
 
 import (
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -68,6 +69,7 @@ type Options struct {
 	LocalClusterID      string
 	IstiodNamespace     string
 	IstiodPodName       string
+	TLSConfig           *tls.Config
 }
 
 type Federation struct {
@@ -109,6 +111,7 @@ func internalNew(opt Options, cs maistraclient.Interface) (*Federation, error) {
 		Env:         opt.Env,
 		Network:     opt.LocalNetwork,
 		ConfigStore: configStore,
+		TLSConfig:   opt.TLSConfig,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This configures istiod to serve federation service discovery endpoints via HTTPS using the same certificate that is used for XDS. The DestinationRule is added to make sure gateways connect using simple TLS.

I decided to put the DestinationRule in the `manifests/` directory as it is never changing and doesn't need to be dynamically-created like the other federation discovery resources. It'll require a separate operator PR to pull in those charts changes