### PR TITLE
MAISTRA-2297 Support updates of federation resources

### DIFF
--- a/pkg/servicemesh/federation/common/namemapping.go
+++ b/pkg/servicemesh/federation/common/namemapping.go
@@ -34,7 +34,6 @@ func setHostname(name *federationmodel.ServiceKey, domainSuffix string) {
 
 type NameMapper interface {
 	NameForService(svc *model.Service) *federationmodel.ServiceKey
-	UpdateDefaultMapper(defaults NameMapper)
 }
 
 type nameMatcher struct {
@@ -87,8 +86,6 @@ func (m *nameMatcher) NameForService(svc *model.Service) *federationmodel.Servic
 	return nil
 }
 
-func (m *nameMatcher) UpdateDefaultMapper(_ NameMapper) {}
-
 type labelMatcher struct {
 	domainSuffix string
 	namespace    string
@@ -134,5 +131,3 @@ func (m *labelMatcher) NameForService(svc *model.Service) *federationmodel.Servi
 	}
 	return nil
 }
-
-func (m *labelMatcher) UpdateDefaultMapper(_ NameMapper) {}

--- a/pkg/servicemesh/federation/common/testing.go
+++ b/pkg/servicemesh/federation/common/testing.go
@@ -1,0 +1,73 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import federationmodel "istio.io/istio/pkg/servicemesh/federation/model"
+
+type FakeStatusHandler struct{}
+
+// Outbound connections
+func (m *FakeStatusHandler) WatchInitiated() {
+}
+
+func (m *FakeStatusHandler) Watching() {
+}
+
+func (m *FakeStatusHandler) WatchEventReceived() {
+}
+
+func (m *FakeStatusHandler) FullSyncComplete() {
+}
+
+func (m *FakeStatusHandler) WatchTerminated(status string) {
+}
+
+// Inbound connections
+func (m *FakeStatusHandler) RemoteWatchAccepted(source string) {
+}
+
+func (m *FakeStatusHandler) WatchEventSent(source string) {
+}
+
+func (m *FakeStatusHandler) FullSyncSent(source string) {
+}
+
+func (m *FakeStatusHandler) RemoteWatchTerminated(source string) {
+}
+
+// Exports
+func (m *FakeStatusHandler) ExportAdded(service federationmodel.ServiceKey, exportedName string) {
+}
+
+func (m *FakeStatusHandler) ExportUpdated(service federationmodel.ServiceKey, exportedName string) {
+}
+
+func (m *FakeStatusHandler) ExportRemoved(service federationmodel.ServiceKey) {
+}
+
+// Imports
+func (m *FakeStatusHandler) ImportAdded(service federationmodel.ServiceKey, exportedName string) {
+}
+
+func (m *FakeStatusHandler) ImportUpdated(service federationmodel.ServiceKey, exportedName string) {
+}
+
+func (m *FakeStatusHandler) ImportRemoved(exportedName string) {
+}
+
+// Write status
+func (m *FakeStatusHandler) Flush() error {
+	return nil
+}

--- a/pkg/servicemesh/federation/common/util.go
+++ b/pkg/servicemesh/federation/common/util.go
@@ -17,6 +17,7 @@ package common
 import (
 	"fmt"
 
+	"github.com/mitchellh/hashstructure/v2"
 	corev1 "k8s.io/api/core/v1"
 	kubelabels "k8s.io/apimachinery/pkg/labels"
 	v1 "maistra.io/api/federation/v1"
@@ -70,4 +71,12 @@ func ServiceAccountsForService(client kube.Client, name, namespace string) (map[
 		Logger.Debugf("using ServiceAccount %s for gateway pod %s/%s", sa, pod.Namespace, pod.Name)
 	}
 	return serviceAccountByIP, nil
+}
+
+func RemoteChecksum(remote v1.ServiceMeshPeerRemote) uint64 {
+	checksum, err := hashstructure.Hash(remote, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	if err != nil {
+		return 0
+	}
+	return checksum
 }

--- a/pkg/servicemesh/federation/discovery/controller_test.go
+++ b/pkg/servicemesh/federation/discovery/controller_test.go
@@ -59,14 +59,14 @@ func (m *fakeStatusManager) IsLeader() bool {
 }
 
 func (m *fakeStatusManager) PeerAdded(mesh types.NamespacedName) status.Handler {
-	return nil
+	return &common.FakeStatusHandler{}
 }
 
 func (m *fakeStatusManager) PeerDeleted(mesh types.NamespacedName) {
 }
 
 func (m *fakeStatusManager) HandlerFor(mesh types.NamespacedName) status.Handler {
-	return nil
+	return &common.FakeStatusHandler{}
 }
 
 func (m *fakeStatusManager) PushStatus() error {

--- a/pkg/servicemesh/federation/server/server.go
+++ b/pkg/servicemesh/federation/server/server.go
@@ -159,7 +159,8 @@ func (s *Server) DeletePeer(name string) {
 func (s *Server) UpdateExportsForMesh(exports *v1.ExportedServiceSet) error {
 	untypedMeshServer, ok := s.meshes.Load(exports.Name)
 	if untypedMeshServer == nil || !ok {
-		return fmt.Errorf("cannot update exporter for non-existent federation: %s", exports.Name)
+		// not really an error; ExportedServiceSet might just be created earlier than ServiceMeshPeer
+		return nil
 	}
 	untypedMeshServer.(*meshServer).updateExportConfig(common.NewServiceExporter(exports, nil, exportDomainSuffix(exports.Name)))
 	return nil
@@ -417,7 +418,7 @@ func getClientConnectionKey(request *http.Request) string {
 }
 
 func (s *meshServer) handleWatch(response http.ResponseWriter, request *http.Request) {
-	watch := make(chan *federationmodel.WatchEvent)
+	watch := make(chan *federationmodel.WatchEvent, 10)
 	s.watchMut.Lock()
 	s.currentWatches = append(s.currentWatches, watch)
 	s.watchMut.Unlock()

--- a/pkg/servicemesh/federation/server/server_test.go
+++ b/pkg/servicemesh/federation/server/server_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	serviceregistrymemory "istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/servicemesh/federation/common"
 	federationmodel "istio.io/istio/pkg/servicemesh/federation/model"
 	istioenv "istio.io/istio/pkg/test/env"
 )
@@ -47,62 +48,6 @@ var (
 		Timeout: time.Second,
 	}
 )
-
-type fakeStatusHandler struct{}
-
-// Outbound connections
-func (m *fakeStatusHandler) WatchInitiated() {
-}
-
-func (m *fakeStatusHandler) Watching() {
-}
-
-func (m *fakeStatusHandler) WatchEventReceived() {
-}
-
-func (m *fakeStatusHandler) FullSyncComplete() {
-}
-
-func (m *fakeStatusHandler) WatchTerminated(status string) {
-}
-
-// Inbound connections
-func (m *fakeStatusHandler) RemoteWatchAccepted(source string) {
-}
-
-func (m *fakeStatusHandler) WatchEventSent(source string) {
-}
-
-func (m *fakeStatusHandler) FullSyncSent(source string) {
-}
-
-func (m *fakeStatusHandler) RemoteWatchTerminated(source string) {
-}
-
-// Exports
-func (m *fakeStatusHandler) ExportAdded(service federationmodel.ServiceKey, exportedName string) {
-}
-
-func (m *fakeStatusHandler) ExportUpdated(service federationmodel.ServiceKey, exportedName string) {
-}
-
-func (m *fakeStatusHandler) ExportRemoved(service federationmodel.ServiceKey) {
-}
-
-// Imports
-func (m *fakeStatusHandler) ImportAdded(service federationmodel.ServiceKey, exportedName string) {
-}
-
-func (m *fakeStatusHandler) ImportUpdated(service federationmodel.ServiceKey, exportedName string) {
-}
-
-func (m *fakeStatusHandler) ImportRemoved(exportedName string) {
-}
-
-// Write status
-func (m *fakeStatusHandler) Flush() error {
-	return nil
-}
 
 func TestServiceList(t *testing.T) {
 	federation := &v1.ServiceMeshPeer{
@@ -434,7 +379,7 @@ func TestServiceList(t *testing.T) {
 			go s.Run(stopCh)
 			defer close(stopCh)
 			s.resyncNetworkGateways()
-			s.AddPeer(federation, tc.serviceExports, &fakeStatusHandler{})
+			s.AddPeer(federation, tc.serviceExports, &common.FakeStatusHandler{})
 			for _, e := range tc.serviceEvents {
 				s.UpdateService(e.svc, e.event)
 			}
@@ -766,7 +711,7 @@ func TestWatch(t *testing.T) {
 			go s.Run(stopCh)
 			defer close(stopCh)
 			s.resyncNetworkGateways()
-			s.AddPeer(federation, tc.serviceExports, &fakeStatusHandler{})
+			s.AddPeer(federation, tc.serviceExports, &common.FakeStatusHandler{})
 			req, err := http.NewRequest("GET", "https://"+s.Addr()+"/v1/watch/"+tc.remoteName, nil)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Getting this working required quite a few changes to the federation serviceregistry and the discovery controller, including:
- addition of `restartWatch()` method to stop and restart a running watch (for when watched URL changes)
- untangling of controller.Options and settings derived from ServiceMeshPeer and ImportedServiceSet resource
- addition of UpdatePeerConfig() and UpdateImportConfig() methods to update CRD-derived controller fields
- refactor of discovery resource creation to remove some duplication
- when a watch is successfully established, we now trigger a resync first thing. this helps when the controller is started before the remote endpoints are reachable: previously, the watch would retry but the resync would just time out, meaning we'd have to wait for new events or the 5 minute resync timer to actually see exported services. in a cluster where no service import updates are happening (my test cluster, ahem), this was frustrating.
- addition of the 'remote' header in discovery requests. this is to avoid a race between an updated `spec.Remote` and a watch restart before the proxy would have applied the new configuration - we would restart the watch and connect to the old endpoint again. hashing the remote and including it in the header makes sure we never connect to an outdated endpoint.