### PR TITLE
MAISTRA-2472 allow DefaultKubernetesAudience to be configurable

### DIFF
--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -61,6 +61,12 @@ var (
 	TokenAudiences = strings.Split(env.RegisterStringVar("TOKEN_AUDIENCES", "istio-ca",
 		"A list of comma separated audiences to check in the JWT token before issuing a certificate. "+
 			"The token is accepted if it matches with one of the audiences").Get(), ",")
+
+	// DefaultKubernetesAudience specifies the default audience used by the kubernetes token issuer.
+	// This is used to support legacy first-person-jwt tokens issued to proxies.
+	DefaultKubernetesAudience = env.RegisterStringVar("DEFAULT_K8S_AUDIENCE", "https://kubernetes.default.svc",
+		"The default audience used by the kubernetes token issuer. "+
+			"This is used to support legacy first-person-jwt tokens issued to proxies.")
 )
 
 // Options provides all of the configuration parameters for secret discovery service

--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt.go
@@ -70,8 +70,6 @@ func (a *KubeJWTAuthenticator) AuthenticatorType() string {
 	return KubeJWTAuthenticatorType
 }
 
-const DefaultKubernetesAudience = "kubernetes.default.svc"
-
 // Authenticate authenticates the call using the K8s JWT from the context.
 // The returned Caller.Identities is in SPIFFE format.
 func (a *KubeJWTAuthenticator) Authenticate(ctx context.Context) (*authenticate.Caller, error) {
@@ -96,7 +94,7 @@ func (a *KubeJWTAuthenticator) Authenticate(ctx context.Context) (*authenticate.
 	// tolerate the unbound tokens.
 	if !util.IsK8SUnbound(targetJWT) || security.Require3PToken.Get() {
 		aud = security.TokenAudiences
-		if tokenAud, _ := util.ExtractJwtAud(targetJWT); len(tokenAud) == 1 && tokenAud[0] == DefaultKubernetesAudience {
+		if tokenAud, _ := util.ExtractJwtAud(targetJWT); len(tokenAud) == 1 && tokenAud[0] == security.DefaultKubernetesAudience.Get() {
 			if a.jwtPolicy == jwt.PolicyFirstParty && !security.Require3PToken.Get() {
 				// For backwards compatibility, if first-party-jwt is used and they don't require 3p, allow it but warn
 				// This is intended to support first-party-jwt on Kubernetes 1.21+, where BoundServiceAccountTokenVolume
@@ -107,7 +105,7 @@ func (a *KubeJWTAuthenticator) Authenticate(ctx context.Context) (*authenticate.
 			} else {
 				log.Warnf("Received token with aud %q, but expected %q. BoundServiceAccountTokenVolume, "+
 					"default in Kubernetes 1.21+, is not compatible with first-party-jwt",
-					DefaultKubernetesAudience, aud)
+					security.DefaultKubernetesAudience.Get(), aud)
 			}
 		}
 		// TODO: check the audience from token, no need to call


### PR DESCRIPTION
Signed-off-by: rcernich <rcernich@redhat.com>

Please provide a description for what this PR is for.

Istio assumes the default audience used by the kubernetes token issuer is `kubernetes.default.svc`.  However, in OpenShift, the default audience is `https://kubernetes.default.svc`.  Furthermore, the default audience is configurable and not guaranteed to be `https://kuberenetes.default.svc` (even for bare kuberenetes, as it's a command line option).

This PR adds support for explicitly setting the appropriate default audience in use by the token issuer.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
