### PR TITLE
MAISTRA-2617: Do not watch all namespaces in Extensions controller

### DIFF
--- a/pkg/servicemesh/controller/extension/controller.go
+++ b/pkg/servicemesh/controller/extension/controller.go
@@ -57,9 +57,12 @@ func NewControllerFromConfigFile(kubeConfig string, namespaces []string, mrc mem
 		return nil, err
 	}
 
-	namespaceSet := xnsinformers.NewNamespaceSet(namespaces...)
+	namespaceSet := xnsinformers.NewNamespaceSet()
 	if mrc != nil {
 		mrc.Register(namespaceSet, "extensions-controller")
+	} else {
+		// No MemberRoll configured, set namespaces based on args.
+		namespaceSet.SetNamespaces(namespaces...)
 	}
 
 	newInformer := func(namespace string) cache.SharedIndexInformer {


### PR DESCRIPTION
When using MemberRoll, we should rely on it to provide the list
of namespaces to watch. If not using it, defaults to command line
arguments.

This fixes an istiod startup error as seen in the logs:
```
github.com/maistra/xns-informer/pkg/informers/informer.go:204: Failed to watch *v1.ServiceMeshExtension: failed to list *v1.ServiceMeshExtension: servicemeshextensions.maistra.io is forbidden: User "system:serviceaccount:i1:istiod-service-account-basic" cannot list resource "servicemeshextensions" in API group "maistra.io" at the cluster scope
```