### PR TITLE
Fixes to automatic route creation

### DIFF
--- a/pkg/servicemesh/federation/discovery/discovery.go
+++ b/pkg/servicemesh/federation/discovery/discovery.go
@@ -27,6 +27,7 @@ import (
 	rawnetworking "istio.io/api/networking/v1alpha3"
 	rawsecurity "istio.io/api/security/v1beta1"
 	rawtype "istio.io/api/type/v1beta1"
+	"istio.io/istio/pilot/pkg/config/kube/ior"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -336,7 +337,8 @@ func (c *Controller) discoveryIngressGateway(instance *v1.ServiceMeshPeer) *conf
 			Name:             name,
 			Namespace:        instance.Namespace,
 			Annotations: map[string]string{
-				generationAnnotation: fmt.Sprintf("%d", instance.Generation),
+				generationAnnotation:            fmt.Sprintf("%d", instance.Generation),
+				ior.ShouldManageRouteAnnotation: "false",
 			},
 		},
 		Spec: &rawnetworking.Gateway{
@@ -374,7 +376,8 @@ func (c *Controller) discoveryEgressGateway(instance *v1.ServiceMeshPeer) *confi
 			Name:             name,
 			Namespace:        instance.Namespace,
 			Annotations: map[string]string{
-				generationAnnotation: fmt.Sprintf("%d", instance.Generation),
+				generationAnnotation:            fmt.Sprintf("%d", instance.Generation),
+				ior.ShouldManageRouteAnnotation: "false",
 			},
 		},
 		Spec: &rawnetworking.Gateway{

--- a/pkg/servicemesh/federation/server/routing.go
+++ b/pkg/servicemesh/federation/server/routing.go
@@ -24,6 +24,7 @@ import (
 	rawnetworking "istio.io/api/networking/v1alpha3"
 	rawsecurity "istio.io/api/security/v1beta1"
 	rawtype "istio.io/api/type/v1beta1"
+	"istio.io/istio/pilot/pkg/config/kube/ior"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -207,6 +208,7 @@ func (s *meshServer) gatewayForExport(source federationmodel.ServiceKey, target 
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
 			Name:             resourceName,
 			Namespace:        s.mesh.Namespace,
+			Annotations:      map[string]string{ior.ShouldManageRouteAnnotation: "false"},
 		},
 		Spec: &rawnetworking.Gateway{
 			Selector: map[string]string{


### PR DESCRIPTION
This PR addresses two issues:
- MAISTRA-2205: Add an option to opt-out for automatic route creation
- MAISTRA-2375: Do not create automatic routes for Federation Gateways