### PR TITLE
MAISTRA-2639 Fix multi-root support

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -133,6 +133,7 @@ func initXdsProxy(ia *Agent) (*XdsProxy, error) {
 		xdsHeaders:            ia.cfg.XDSHeaders,
 		xdsUdsPath:            ia.cfg.XdsUdsPath,
 		wasmCache:             wasm.NewLocalFileCache(constants.IstioDataDir, wasm.DefaultWasmModulePurgeInteval, wasm.DefaultWasmModuleExpiry),
+		secretCache:           ia.secretCache,
 		ecdsUpdateChan:        make(chan *discovery.DiscoveryResponse, 10),
 		downstreamGrpcOptions: ia.cfg.DownstreamGrpcOptions,
 	}


### PR DESCRIPTION
One line of code [went missing](https://github.com/maistra/istio/commit/fa002543d6dca5a6dcf3ac36f34265d5b5563f6a#diff-28f4c7bff1620b7c858fda06ccf568082d13d184d589c79529c3b6c08c78b0b7L135) during the 1.9.8 merge and broke multi-root support, resulting in the following log line in the agent:

```
2021-09-03T08:27:38.182140Z	error	xdsproxy	failed to access secret cache
```

This adds it back and fixes multi-root support.