### PR TITLE
MAISTRA-2649: Update the config map when it already exists

### DIFF
--- a/security/pkg/k8s/configutil.go
+++ b/security/pkg/k8s/configutil.go
@@ -51,7 +51,8 @@ func InsertDataToConfigMap(client corev1.ConfigMapsGetter, lister listerv1.Confi
 			// The lister may be outdated, thinking there's no config map when there is, so the attempt to create one will fail
 			// If this is the case, try updating it instead
 			if errors.IsAlreadyExists(err) {
-				return UpdateDataInConfigMap(client, configmap, data)
+				_, err := client.ConfigMaps(meta.Namespace).Update(context.TODO(), configmap, metav1.UpdateOptions{})
+				return err
 			}
 
 			return fmt.Errorf("error when creating configmap %v: %v", meta.Name, err)

--- a/security/pkg/k8s/configutil.go
+++ b/security/pkg/k8s/configutil.go
@@ -51,8 +51,10 @@ func InsertDataToConfigMap(client corev1.ConfigMapsGetter, lister listerv1.Confi
 			// The lister may be outdated, thinking there's no config map when there is, so the attempt to create one will fail
 			// If this is the case, try updating it instead
 			if errors.IsAlreadyExists(err) {
-				_, err := client.ConfigMaps(meta.Namespace).Update(context.TODO(), configmap, metav1.UpdateOptions{})
-				return err
+				if _, err := client.ConfigMaps(meta.Namespace).Update(context.TODO(), configmap, metav1.UpdateOptions{}); err != nil {
+					return fmt.Errorf("error when updating configmap %v: %v", configmap.Name, err)
+				}
+				return nil
 			}
 
 			return fmt.Errorf("error when creating configmap %v: %v", meta.Name, err)

--- a/security/pkg/k8s/configutil.go
+++ b/security/pkg/k8s/configutil.go
@@ -47,6 +47,13 @@ func InsertDataToConfigMap(client corev1.ConfigMapsGetter, lister listerv1.Confi
 			if errors.IsNotFound(err) {
 				return nil
 			}
+
+			// The lister may be outdated, thinking there's no config map when there is, so the attempt to create one will fail
+			// If this is the case, try updating it instead
+			if errors.IsAlreadyExists(err) {
+				return UpdateDataInConfigMap(client, configmap, data)
+			}
+
 			return fmt.Errorf("error when creating configmap %v: %v", meta.Name, err)
 		}
 	} else {


### PR DESCRIPTION
If the creation fails with an `Already Exists` error, that might be
because the lister needs a sync and contains outdated information.

In such cases, try updating it instead. The update logic is smart enough
to only update it only when necessary - only if anything changed.
