### PR TITLE
MAISTRA-2655: Fix the DNS capture with CNI

### DIFF
--- a/cni/cmd/istio-cni/iptables.go
+++ b/cni/cmd/istio-cni/iptables.go
@@ -56,7 +56,7 @@ func (ipt *iptables) Program(netns string, rdrct *Redirect) error {
 		"-k", rdrct.kubevirtInterfaces,
 	}
 	if rdrct.redirectDNS {
-		nsenterArgs = append(nsenterArgs, "--redirect-dns")
+		nsenterArgs = append(nsenterArgs, "--redirect-dns", "--capture-all-dns")
 	}
 	log.Infof("nsenter args: %s", strings.Join(nsenterArgs, " "))
 	out, err := exec.Command("nsenter", nsenterArgs...).CombinedOutput()

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -97,6 +97,7 @@ func constructConfig() *config.Config {
 		SkipRuleApply:           viper.GetBool(constants.SkipRuleApply),
 		RunValidation:           viper.GetBool(constants.RunValidation),
 		RedirectDNS:             viper.GetBool(constants.RedirectDNS),
+		CaptureAllDNS:           viper.GetBool(constants.CaptureAllDNS),
 	}
 
 	// TODO: Make this more configurable, maybe with an allowlist of users to be captured for output instead of a denylist.
@@ -125,7 +126,9 @@ func constructConfig() *config.Config {
 
 	// Lookup DNS nameservers. We only do this if DNS is enabled in case of some obscure theoretical
 	// case where reading /etc/resolv.conf could fail.
-	if cfg.RedirectDNS {
+	// If capture all DNS option is enabled, we don't need to read from the dns resolve conf. All
+	// traffic to port 53 will be captured.
+	if cfg.RedirectDNS && !cfg.CaptureAllDNS {
 		dnsConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")
 		if err != nil {
 			panic(fmt.Sprintf("failed to load /etc/resolv.conf: %v", err))
@@ -316,6 +319,14 @@ func init() {
 		handleError(err)
 	}
 	viper.SetDefault(constants.RedirectDNS, dnsCaptureByAgent)
+
+	rootCmd.Flags().Bool(constants.CaptureAllDNS, false,
+		"Instead of only capturing DNS traffic to DNS server IP, capture all DNS traffic at port 53. This setting is only effective when redirect dns is enabled.")
+
+	if err := viper.BindPFlag(constants.CaptureAllDNS, rootCmd.Flags().Lookup(constants.CaptureAllDNS)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.CaptureAllDNS, false)
 }
 
 func GetCommand() *cobra.Command {

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	EnableInboundIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
 	DNSServersV4            []string      `json:"DNS_SERVERS_V4"`
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
+	CaptureAllDNS           bool          `json:"CAPTURE_ALL_DNS"`
 }
 
 func (c *Config) String() string {
@@ -69,6 +70,7 @@ func (c *Config) Print() {
 	fmt.Printf("PROXY_UID=%s\n", c.ProxyUID)
 	fmt.Printf("PROXY_GID=%s\n", c.ProxyGID)
 	fmt.Printf("REDIRECT_DNS=%v\n", c.RedirectDNS)
+	fmt.Printf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS)
 	fmt.Printf("INBOUND_INTERCEPTION_MODE=%s\n", c.InboundInterceptionMode)
 	fmt.Printf("INBOUND_TPROXY_MARK=%s\n", c.InboundTProxyMark)
 	fmt.Printf("INBOUND_TPROXY_ROUTE_TABLE=%s\n", c.InboundTProxyRouteTable)

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -88,6 +88,7 @@ const (
 	IptablesProbePort         = "iptables-probe-port"
 	ProbeTimeout              = "probe-timeout"
 	RedirectDNS               = "redirect-dns"
+	CaptureAllDNS             = "capture-all-dns"
 )
 
 const (


### PR DESCRIPTION
DNS capture is not correct when using CNI. It's capturing packets
with the destination of the server found in /etc/resolv.conf.

Since with CNI the iptables binary runs on the node, it's getting
the contents of resolv.conf from the node, not from the container.

Upstream fixed this with the addition of an istio-iptables CLI argument,
(`--capture-all-dns`) that is meant to capture all DNS traffic,
not only those targeting the DNS server listed in /etc/resolv.conf.

This is the full upstream PR: https://github.com/istio/istio/issues/29511

Since the code diverges a lot from our version and upstream,
this PR does a minimal manual backport of the upstream fix.