### PR TITLE
MAISTRA-2682 Fix watch mechanism in federation

### DIFF
--- a/pkg/servicemesh/federation/server/server.go
+++ b/pkg/servicemesh/federation/server/server.go
@@ -450,6 +450,7 @@ func (s *meshServer) handleWatch(response http.ResponseWriter, request *http.Req
 		select {
 		case event = <-watch:
 		case <-request.Context().Done():
+			s.logger.Debugf("watch handler: request context closed")
 			return
 		}
 		respBytes, err := json.Marshal(event)

--- a/pkg/servicemesh/federation/status/handler.go
+++ b/pkg/servicemesh/federation/status/handler.go
@@ -478,7 +478,7 @@ func (h *handler) Flush() error {
 		return err
 	}
 
-	h.logger.Debugf("status patch:\n%s\n", string(patch))
+	h.logger.Debugf("status patch: %s", string(patch))
 
 	if len(patch) == 0 || string(patch) == "{}" {
 		// nothing to patch
@@ -578,8 +578,8 @@ func (h *handler) createPatch(newObj, oldObj interface{}, metadata strategicpatc
 		return nil, err
 	}
 
-	h.logger.Debugf("old bytes:\n%s\n", string(oldBytes))
-	h.logger.Debugf("new bytes:\n%s\n", string(newBytes))
+	h.logger.Debugf("old bytes: %s", string(oldBytes))
+	h.logger.Debugf("new bytes: %s", string(newBytes))
 
 	patch, err := strategicpatch.CreateTwoWayMergePatchUsingLookupPatchMeta(oldBytes, newBytes, metadata)
 	if err != nil {


### PR DESCRIPTION
Previously, no events were read from the watch response, because the read started with an endless loop that waited for data to be available in the decoder's buffer. This never happened, because the buffer is only written to when you call decoder.Decode(); this function was never called because the code waited for the buffer to have data.