### PR TITLE
MAISTRA-2683 Properly close incoming watch connections when shutting down

### DIFF
--- a/pkg/servicemesh/federation/server/server.go
+++ b/pkg/servicemesh/federation/server/server.go
@@ -449,6 +449,10 @@ func (s *meshServer) handleWatch(response http.ResponseWriter, request *http.Req
 		var event *federationmodel.WatchEvent
 		select {
 		case event = <-watch:
+			if event == nil {
+				s.logger.Debugf("watch handler: watch closed")
+				return
+			}
 		case <-request.Context().Done():
 			return
 		}


### PR DESCRIPTION
On shutdown, all the watch channels are closed. The channel thus returns nil. After fetching the event from the channel, the code did not check if it was nil and called `json.Marshal(nil)`. This returned an empty array, which was written to the response and flushed (this was basically a no-op). Then the code read from the channel again and again and again until the process was eventually killed.