### PR TITLE
MAISTRA-2640 Add federation integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20210312000640-9f480bcdc475
 	k8s.io/kubectl v0.20.1
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
-	maistra.io/api v0.0.0-20210823191737-259bd5854df6
+	maistra.io/api v0.0.0-20211119171546-348bbce3ca27
 	sigs.k8s.io/controller-runtime v0.7.0
 	sigs.k8s.io/service-apis v0.1.0
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6A
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
-cloud.google.com/go v0.50.0 h1:0E3eE8MX426vUOs7aHfI7aN1BrIzzzf4ccKCSfSjGmc=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.51.0/go.mod h1:hWtGJ6gnXH+KgDv+V0zFGDvpi07n3z8ZNj3T1RW0Gcw=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
@@ -15,9 +14,7 @@ cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bP
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
-cloud.google.com/go v0.63.0 h1:A+DfAZQ/eWca7gvu42CS6FNSDX4R8cghF+XfWLn4R6g=
 cloud.google.com/go v0.63.0/go.mod h1:GmezbQc7T2snqkEXWfZ0sy0VfkB/ivI2DdtJL2DEmlg=
-cloud.google.com/go v0.65.0 h1:Dg9iHVQfrhq82rUNu9ZxUDrJLaxFUe/HlCVaLyRruq8=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.73.0 h1:sGvc4e0Cmm4+DKQR76a9VwNukpacQK8TOl5pDl0Pcn0=
@@ -330,7 +327,6 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gobuffalo/envy v1.7.1/go.mod h1:FurDp9+EDPE4aIUS3ZLyD+7/9fpx7YRt/ukY6jIHf0w=
-github.com/gobuffalo/flect v0.2.0 h1:EWCvMGGxOjsgwlWaP+f4+Hh6yrrte7JeFL2S6b+0hdM=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobuffalo/logger v1.0.1/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8ze5s8JvPs=
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
@@ -1396,7 +1392,6 @@ k8s.io/code-generator v0.18.6/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8
 k8s.io/code-generator v0.19.0/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
 k8s.io/code-generator v0.19.2/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
 k8s.io/code-generator v0.19.4/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
-k8s.io/code-generator v0.20.1 h1:kre3GNich5gbO3d1FyTT8fHI4ZJezZV217yFdWlQaRQ=
 k8s.io/code-generator v0.20.1/go.mod h1:UsqdF+VX4PU2g46NC2JRs4gc+IfrctnwHb76RNbWHJg=
 k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmDfUM=
 k8s.io/component-base v0.18.6/go.mod h1:knSVsibPR5K6EW2XOjEHik6sdU5nCvKMrzMt2D4In14=
@@ -1410,7 +1405,6 @@ k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200728071708-7794989d0000/go.mod h1:aG2eeomYfcUw8sE3fa7YdkjgnGtyY56TjZlaJJ0ZoWo=
-k8s.io/gengo v0.0.0-20201113003025-83324d819ded h1:JApXBKYyB7l9xx+DK7/+mFjC7A9Bt5A93FPvFD0HIFE=
 k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1440,8 +1434,8 @@ k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-maistra.io/api v0.0.0-20210823191737-259bd5854df6 h1:xLPLJlHS1ueCLdnrxE6w2dLUO4bXgguHAATMBAKoxYA=
-maistra.io/api v0.0.0-20210823191737-259bd5854df6/go.mod h1:lr+bFp/3PnYhRC/0IrDhCy7GfnQPhiOTW/CQ8qgTV9U=
+maistra.io/api v0.0.0-20211119171546-348bbce3ca27 h1:/a3VKvmPXWB327XFCqIM6cRmdC09xLm4Ks/9YztfjDw=
+maistra.io/api v0.0.0-20211119171546-348bbce3ca27/go.mod h1:lr+bFp/3PnYhRC/0IrDhCy7GfnQPhiOTW/CQ8qgTV9U=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
@@ -1453,7 +1447,6 @@ sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJU
 sigs.k8s.io/controller-runtime v0.7.0 h1:bU20IBBEPccWz5+zXpLnpVsgBYxqclaHu1pVDl/gEt8=
 sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/controller-tools v0.4.0/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
-sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF4w=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -80,6 +80,7 @@ var (
 		RemoteClusterIOPFile:  IntegrationTestRemoteDefaultsIOP,
 		DeployEastWestGW:      true,
 		IstiodlessRemotes:     false,
+		ConfigureMultiCluster: true,
 	}
 )
 
@@ -158,6 +159,10 @@ type Config struct {
 	// IstiodlessRemotes makes remote clusters run without istiod, using webhooks/ca from the primary cluster.
 	// TODO we could set this per-cluster if istiod was smarter about patching remotes.
 	IstiodlessRemotes bool
+
+	ConfigureMultiCluster bool
+
+	DifferentTrustDomains bool
 }
 
 func (c *Config) OverridesYAML() string {

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -9,6 +9,7 @@ spec:
     defaultConfig:
       proxyMetadata:
         ISTIO_META_DNS_CAPTURE: "true"
+        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
   components:
     ingressGateways:
       - name: istio-ingressgateway

--- a/tests/integration/servicemesh/federation/federation.go
+++ b/tests/integration/servicemesh/federation/federation.go
@@ -1,0 +1,214 @@
+// +build integ
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicemesh
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+func setupConfig(_ resource.Context, cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.DeployEastWestGW = false
+	cfg.ConfigureMultiCluster = false
+	cfg.DifferentTrustDomains = true
+	cfg.ControlPlaneValues = `
+components:
+  ingressGateways:
+  - name: federation-ingress
+    namespace: istio-system
+    enabled: true
+    label:
+      unique: ingress
+    k8s:
+      env:
+      - name: ISTIO_META_ROUTER_MODE
+        value: sni-dnat
+      service:
+        ports:
+        # required for handling service requests from mesh2
+        - port: 15443
+          name: tls
+        # required for handing discovery requests from mesh2
+        - port: 8188
+          name: https-discovery
+  egressGateways:
+  - name: federation-egress
+    namespace: istio-system
+    enabled: true
+    label:
+      unique: egress
+    k8s:
+      env:
+      - name: ISTIO_META_ROUTER_MODE
+        value: sni-dnat
+      service:
+        ports:
+        # required for handling service requests from mesh2
+        - port: 15443
+          name: tls
+        # required for handing discovery requests from mesh2
+        - port: 8188
+          name: https-discovery
+`
+}
+
+// CreateServiceMeshPeers wires all primary clusters together in a federation.
+func CreateServiceMeshPeers(ctx framework.TestContext) error {
+	ctx.Log("Creating ServiceMeshPeer resources")
+	remoteIPs := map[string]string{}
+	remoteCerts := map[string]*v1.ConfigMap{}
+	for _, cluster := range ctx.Clusters().Primaries() {
+		svc, err := cluster.CoreV1().Services("istio-system").Get(context.TODO(), "federation-ingress", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if len(svc.Status.LoadBalancer.Ingress) < 1 {
+			return fmt.Errorf("federation-ingress svc has no public IP")
+		}
+		remoteIPs[cluster.Name()] = svc.Status.LoadBalancer.Ingress[0].IP
+		ctx.Logf("Cluster '%s': detected %s as public IP\n", cluster.Name(), remoteIPs[cluster.Name()])
+		configMap, err := cluster.CoreV1().ConfigMaps("istio-system").Get(context.TODO(), "istio-ca-root-cert", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		remoteCerts[cluster.Name()] = configMap.DeepCopy()
+	}
+	for _, cluster := range ctx.Clusters().Primaries() {
+		for remoteCluster, remoteIP := range remoteIPs {
+			// skip local cluster
+			if remoteCluster == cluster.Name() {
+				continue
+			}
+			configMap := remoteCerts[remoteCluster]
+			configMap.ObjectMeta = metav1.ObjectMeta{
+				Name: remoteCluster + "-ca-cert",
+			}
+			_, err := cluster.CoreV1().ConfigMaps("istio-system").Create(context.TODO(), configMap, metav1.CreateOptions{})
+			if err != nil {
+				return err
+			}
+			err = ctx.Config(cluster).ApplyYAML("istio-system", fmt.Sprintf(`
+apiVersion: federation.maistra.io/v1
+kind: ServiceMeshPeer
+metadata:
+    name: %s
+spec:
+    remote:
+        addresses:
+        - %s
+    gateways:
+        ingress:
+            name: federation-ingress
+        egress:
+            name: federation-egress
+    security:
+        trustDomain: %s
+        clientID: %s
+        certificateChain:
+            kind: ConfigMap
+            name: %s
+`, remoteCluster, remoteIP, remoteCluster+".local", remoteCluster+".local/ns/istio-system/sa/federation-egress-service-account", remoteCluster+"-ca-cert"))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func SetupExportsAndImports(ctx framework.TestContext, exportFrom string) {
+	primary := ctx.Clusters().GetByName("primary")
+	err := ctx.Config(primary).ApplyYAML("istio-system", fmt.Sprintf(`
+apiVersion: federation.maistra.io/v1
+kind: ExportedServiceSet
+metadata:
+  name: cross-network-primary
+  namespace: istio-system
+spec:
+  exportRules:
+  - type: NameSelector
+    nameSelector:
+      namespace: %s
+      name: ratings
+      alias:
+        namespace: bookinfo
+        name: ratings
+	`, exportFrom))
+	if err != nil {
+		ctx.Fatal(err)
+	}
+	secondary := ctx.Clusters().GetByName("cross-network-primary")
+	err = ctx.Config(secondary).ApplyYAML("istio-system", `
+apiVersion: federation.maistra.io/v1
+kind: ImportedServiceSet
+metadata:
+  name: primary
+  namespace: istio-system
+spec:
+  importRules:
+    - type: NameSelector
+      importAsLocal: false
+      nameSelector:
+        namespace: bookinfo
+`)
+	if err != nil {
+		ctx.Fatal(err)
+	}
+}
+
+func checkConnectivity(ctx framework.TestContext, source cluster.Cluster, namespace string) {
+	var podName string
+	err := retry.UntilSuccess(func() error {
+		podList, err := source.PodsForSelector(context.TODO(), namespace, "app=sleep")
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) < 1 {
+			return fmt.Errorf("no sleep pod found in namespace %s", namespace)
+		}
+		podName = podList.Items[0].Name
+		return nil
+	}, retry.Timeout(300*time.Second), retry.Delay(time.Second))
+	if err != nil {
+		ctx.Fatal(err)
+	}
+	cmd := "curl http://ratings.bookinfo.svc.primary-imports.local:9080/ratings/123"
+	err = retry.UntilSuccess(func() error {
+		stdout, _, err := source.PodExec(podName, namespace, "sleep", cmd)
+		if err != nil {
+			return err
+		} else if stdout != `{"id":123,"ratings":{"Reviewer1":5,"Reviewer2":4}}` {
+			return fmt.Errorf("podexec output does not look right: %s", stdout)
+		}
+		return nil
+	}, retry.Timeout(300*time.Second), retry.Delay(time.Second))
+	if err != nil {
+		ctx.Fatal(err)
+	}
+}

--- a/tests/integration/servicemesh/federation/federation_test.go
+++ b/tests/integration/servicemesh/federation/federation_test.go
@@ -1,0 +1,62 @@
+// +build integ
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicemesh
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/tests/integration/servicemesh"
+)
+
+var (
+	i istio.Instance
+)
+
+// GetIstioInstance gets Istio instance.
+func GetIstioInstance() *istio.Instance {
+	return &i
+}
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		RequireMinClusters(2).
+		Setup(servicemesh.ApplyServiceMeshCRDs).
+		Setup(istio.Setup(GetIstioInstance(), setupConfig)).
+		Run()
+}
+
+func TestFederation(t *testing.T) {
+	framework.NewTest(t).
+		Label(label.Multicluster).
+		Run(func(ctx framework.TestContext) {
+			err := CreateServiceMeshPeers(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			primary := ctx.Clusters().GetByName("primary")
+			secondary := ctx.Clusters().GetByName("cross-network-primary")
+			primaryNamespace := servicemesh.CreateNamespace(ctx, primary, "bookinfo")
+			secondaryNamespace := servicemesh.CreateNamespace(ctx, secondary, "bookinfo")
+			SetupExportsAndImports(ctx, primaryNamespace)
+			servicemesh.InstallBookinfo(ctx, primary, primaryNamespace)
+			servicemesh.InstallSleep(ctx, secondary, secondaryNamespace)
+			checkConnectivity(ctx, secondary, secondaryNamespace)
+		})
+}

--- a/tests/integration/servicemesh/util.go
+++ b/tests/integration/servicemesh/util.go
@@ -1,0 +1,123 @@
+// +build integ
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicemesh
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// import maistra CRD manifests
+	_ "maistra.io/api/manifests"
+
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/cluster"
+	"istio.io/istio/pkg/test/framework/resource"
+	kubetest "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+var (
+	manifestsDir      = env.IstioSrc + "/vendor/maistra.io/api/manifests"
+	bookinfoManifests = []string{
+		env.IstioSrc + "/samples/bookinfo/platform/kube/bookinfo.yaml",
+		env.IstioSrc + "/samples/bookinfo/networking/bookinfo-gateway.yaml",
+	}
+	sleepManifest = env.IstioSrc + "/samples/sleep/sleep.yaml"
+	rnd           = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
+
+func ApplyServiceMeshCRDs(ctx resource.Context) (err error) {
+	crds, err := findCRDs()
+	if err != nil {
+		return fmt.Errorf("cannot read maistra CRD YAMLs: %s", err)
+	}
+	for _, cluster := range ctx.Clusters().Kube().Primaries() {
+		if err = cluster.ApplyYAMLFiles("", crds...); err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func findCRDs() (list []string, err error) {
+	list = []string{}
+	files, err := ioutil.ReadDir(manifestsDir)
+	if err != nil {
+		return
+	}
+	for _, file := range files {
+		if !file.IsDir() && strings.HasSuffix(file.Name(), ".yaml") {
+			list = append(list, file.Name())
+		}
+	}
+	return
+}
+
+func InstallBookinfo(ctx framework.TestContext, c cluster.Cluster, namespace string) {
+	if err := c.ApplyYAMLFiles(namespace, bookinfoManifests...); err != nil {
+		ctx.Fatal(err)
+	}
+	if err := retry.UntilSuccess(func() error {
+		if _, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(c, namespace, "app=ratings")); err != nil {
+			return fmt.Errorf("ratings pod is not ready: %v", err)
+		}
+		return nil
+	}, retry.Timeout(300*time.Second), retry.Delay(time.Second)); err != nil {
+		ctx.Fatal(err)
+	}
+}
+
+func InstallSleep(ctx framework.TestContext, c cluster.Cluster, namespace string) {
+	if err := c.ApplyYAMLFiles(namespace, sleepManifest); err != nil {
+		ctx.Fatal(err)
+	}
+	if err := retry.UntilSuccess(func() error {
+		if _, err := kubetest.CheckPodsAreReady(kubetest.NewPodFetch(c, namespace, "app=sleep")); err != nil {
+			return fmt.Errorf("sleep pod is not ready: %v", err)
+		}
+		return nil
+	}, retry.Timeout(300*time.Second), retry.Delay(time.Second)); err != nil {
+		ctx.Fatal(err)
+	}
+}
+
+// TODO for some reason namespace.NewOrFail() doesn't work so I'm doing this manually
+func CreateNamespace(ctx framework.TestContext, cluster cluster.Cluster, prefix string) string {
+	ns, err := cluster.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%d", prefix, rnd.Intn(99999)),
+			Labels: map[string]string{
+				"istio-injection": "enabled",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		ctx.Fatal(err)
+	}
+	name := ns.Name
+	ctx.Cleanup(func() {
+		cluster.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	})
+	return name
+}

--- a/vendor/maistra.io/api/federation/v1/exportedserviceset_types.go
+++ b/vendor/maistra.io/api/federation/v1/exportedserviceset_types.go
@@ -23,9 +23,11 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ExportedServiceSet is the Schema for configuring exported services.  The name of
-// the ExportedServiceSet resource must match the name of a ServiceMeshPeer resource
-// defining the remote mesh to which the services will be exported.
+// ExportedServiceSet is the Schema for configuring exported services. It must be created
+// in the same namespace as the control plane. The name of the ExportedServiceSet
+// resource must match the name of a ServiceMeshPeer resource defining the remote mesh
+// to which the services will be exported. This implies there will be at most one
+// ExportedServiceSet resource per peer and control plane.
 type ExportedServiceSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -54,7 +56,7 @@ type ExportedServiceSetSpec struct {
 }
 
 type ExportedServiceRule struct {
-	// Type of rule.  One of Name or Label.
+	// Type of rule.  One of NameSelector or LabelSelector.
 	// +required
 	Type ServiceImportExportSelectorType `json:"type"`
 	// LabelSelector provides a mechanism for selecting services to export by

--- a/vendor/maistra.io/api/federation/v1/importedserviceset_types.go
+++ b/vendor/maistra.io/api/federation/v1/importedserviceset_types.go
@@ -23,9 +23,11 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ImportedServiceSet is the Schema for configuring imported services.  The name of
-// the ImportedServiceSet resource must match the name of a ServiceMeshPeer resource
-// defining the remote mesh from which the services will be imported.
+// ImportedServiceSet is the Schema for configuring imported services. It must be created
+// in the same namespace as the control plane. The name of the ImportedServiceSet
+// resource must match the name of a ServiceMeshPeer resource defining the remote mesh
+// from which the services will be imported. This implies there will be at most one
+// ImportedServiceSet resource per peer and control plane.
 type ImportedServiceSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -77,7 +79,7 @@ type ImportedServiceRule struct {
 	// workloads associated with the service.  This setting overrides DomainSuffix.
 	// +optional
 	ImportAsLocal bool `json:"importAsLocal,omitempty"`
-	// Type of rule.  Only Name type is supported.
+	// Type of rule.  Only NameSelector type is supported.
 	// +required
 	Type ServiceImportExportSelectorType `json:"type"`
 	// NameSelector provides a simple name matcher for importing services in

--- a/vendor/maistra.io/api/federation/v1/servicemeshpeer_types.go
+++ b/vendor/maistra.io/api/federation/v1/servicemeshpeer_types.go
@@ -84,7 +84,6 @@ type ServiceMeshPeerGateways struct {
 	Ingress corev1.LocalObjectReference `json:"ingress,omitempty"`
 
 	// Gateway through which outbound federated service traffic will travel.
-	// This is not required if AllowDirectOutbound is set to true.
 	Egress corev1.LocalObjectReference `json:"egress,omitempty"`
 }
 

--- a/vendor/maistra.io/api/manifests/federation.maistra.io_exportedservicesets.yaml
+++ b/vendor/maistra.io/api/manifests/federation.maistra.io_exportedservicesets.yaml
@@ -1,0 +1,163 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: exportedservicesets.federation.maistra.io
+spec:
+  group: federation.maistra.io
+  names:
+    kind: ExportedServiceSet
+    listKind: ExportedServiceSetList
+    plural: exportedservicesets
+    singular: exportedserviceset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ExportedServiceSet is the Schema for configuring exported services. It must be created in the same namespace as the control plane. The name of the ExportedServiceSet resource must match the name of a ServiceMeshPeer resource defining the remote mesh to which the services will be exported. This implies there will be at most one ExportedServiceSet resource per peer and control plane.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines rules for matching services to be exported.
+            properties:
+              exportRules:
+                description: ExportRules are the rules that determine which services are exported from the mesh.  The list is processed in order and the first spec in the list that applies to a service is the one that will be applied.  This allows more specific selectors to be placed before more general selectors.
+                items:
+                  properties:
+                    labelSelector:
+                      description: LabelSelector provides a mechanism for selecting services to export by using a label selector to match Service resources for export.
+                      properties:
+                        aliases:
+                          description: 'Aliases is a map of aliases to apply to exported services.  If a name is not found in the map, the original service name is exported.  A ''*'' will match any name. The Aliases list will be processed in order, with the first match found being applied to the exported service. Examples: */foo->*/bar will match foo service in any namesapce, exporting it as bar from its original namespace. */foo->bar/bar will match foo service in any namespace, exporting it as bar/bar. foo/*->bar/* will match any service in foo namespace, exporting it from the bar namespace with its original name */*->bar/* will match any service and export it from the bar namespace with its original name. */*->*/* is the same as not specifying anything'
+                          items:
+                            properties:
+                              alias:
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                          type: array
+                        namespace:
+                          description: Namespace specifies to which namespace the selector applies.  An empty value applies to all namespaces in the mesh.
+                          type: string
+                        selector:
+                          description: Selector used to select Service resources in the namespace/mesh.  An empty selector selects all services.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      type: object
+                    nameSelector:
+                      description: NameSelector provides a simple name matcher for exporting services in the mesh.
+                      properties:
+                        alias:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                    type:
+                      description: Type of rule.  One of NameSelector or LabelSelector.
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              exportedServices:
+                description: Exports provides details about the services exported by this mesh.
+                items:
+                  description: PeerServiceMapping represents the name mapping between an exported service and its local counterpart.
+                  properties:
+                    exportedName:
+                      description: ExportedName represents the fully qualified domain name (FQDN) of an exported service.  For an exporting mesh, this is the name that is exported to the remote mesh. For an importing mesh, this would be the name of the service exported by the remote mesh.
+                      type: string
+                    localService:
+                      description: LocalService represents the service in the local (i.e. this) mesh. For an exporting mesh, this would be the service being exported. For an importing mesh, this would be the imported service.
+                      properties:
+                        hostname:
+                          description: Hostname represents fully qualified domain name (FQDN) used to access the service.
+                          type: string
+                        name:
+                          description: Name represents the simple name of the service, e.g. the metadata.name field of a kubernetes Service.
+                          type: string
+                        namespace:
+                          description: Namespace represents the namespace within which the service resides.
+                          type: string
+                      required:
+                      - hostname
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - exportedName
+                  - localService
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - exportedName
+                x-kubernetes-list-type: map
+            required:
+            - exportedServices
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/vendor/maistra.io/api/manifests/federation.maistra.io_importedservicesets.yaml
+++ b/vendor/maistra.io/api/manifests/federation.maistra.io_importedservicesets.yaml
@@ -1,0 +1,131 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: importedservicesets.federation.maistra.io
+spec:
+  group: federation.maistra.io
+  names:
+    kind: ImportedServiceSet
+    listKind: ImportedServiceSetList
+    plural: importedservicesets
+    singular: importedserviceset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ImportedServiceSet is the Schema for configuring imported services. It must be created in the same namespace as the control plane. The name of the ImportedServiceSet resource must match the name of a ServiceMeshPeer resource defining the remote mesh from which the services will be imported. This implies there will be at most one ImportedServiceSet resource per peer and control plane.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines rules for matching services to be imported.
+            properties:
+              domainSuffix:
+                description: 'DomainSuffix specifies the domain suffix to be applies to imported services.  If no domain suffix is specified, imported services will be named as follows:    <imported-name>.<imported-namespace>.svc.<mesh-name>-imports.local If a domain suffix is specified, imported services will be named as follows:    <imported-name>.<imported-namespace>.<domain-suffix>'
+                type: string
+              importRules:
+                description: ImportRules are the rules that determine which services are imported to the mesh.  The list is processed in order and the first spec in the list that applies to a service is the one that will be applied.  This allows more specific selectors to be placed before more general selectors.
+                items:
+                  properties:
+                    domainSuffix:
+                      description: DomainSuffix applies the specified suffix to services imported by this rule.  The behavior is identical to that of ImportedServiceSetSpec.DomainSuffix.
+                      type: string
+                    importAsLocal:
+                      description: ImportAsLocal imports the service as a local service in the mesh.  For example, if an exported service, foo/bar is imported as some-ns/service, the service will be imported as service.some-ns.svc.cluster.local in the some-ns namespace.  If a service of this name already exists in the mesh, the imported service's endpoints will be aggregated with any other workloads associated with the service.  This setting overrides DomainSuffix.
+                      type: boolean
+                    nameSelector:
+                      description: NameSelector provides a simple name matcher for importing services in the mesh.
+                      properties:
+                        alias:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                    type:
+                      description: Type of rule.  Only NameSelector type is supported.
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+              locality:
+                description: Locality within which imported services should be associated.
+                properties:
+                  region:
+                    description: Region within which imported services are located.
+                    type: string
+                  subzone:
+                    description: Subzone within which imported services are located.  If Subzone is specified, Zone must also be specified.
+                    type: string
+                  zone:
+                    description: Zone within which imported services are located.  If Zone is specified, Region must also be specified.
+                    type: string
+                type: object
+            type: object
+          status:
+            properties:
+              importedServices:
+                description: Imports provides details about the services imported by this mesh.
+                items:
+                  description: PeerServiceMapping represents the name mapping between an exported service and its local counterpart.
+                  properties:
+                    exportedName:
+                      description: ExportedName represents the fully qualified domain name (FQDN) of an exported service.  For an exporting mesh, this is the name that is exported to the remote mesh. For an importing mesh, this would be the name of the service exported by the remote mesh.
+                      type: string
+                    localService:
+                      description: LocalService represents the service in the local (i.e. this) mesh. For an exporting mesh, this would be the service being exported. For an importing mesh, this would be the imported service.
+                      properties:
+                        hostname:
+                          description: Hostname represents fully qualified domain name (FQDN) used to access the service.
+                          type: string
+                        name:
+                          description: Name represents the simple name of the service, e.g. the metadata.name field of a kubernetes Service.
+                          type: string
+                        namespace:
+                          description: Namespace represents the namespace within which the service resides.
+                          type: string
+                      required:
+                      - hostname
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - exportedName
+                  - localService
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - exportedName
+                x-kubernetes-list-type: map
+            required:
+            - importedServices
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/vendor/maistra.io/api/manifests/federation.maistra.io_servicemeshpeers.yaml
+++ b/vendor/maistra.io/api/manifests/federation.maistra.io_servicemeshpeers.yaml
@@ -1,0 +1,280 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: servicemeshpeers.federation.maistra.io
+spec:
+  group: federation.maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshPeer
+    listKind: ServiceMeshPeerList
+    plural: servicemeshpeers
+    singular: servicemeshpeer
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ServiceMeshPeer is the Schema for joining two meshes together.  The resource name will be used to identify the 'cluster' to which imported services belong.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceMeshPeerSpec configures details required to support federation with another service mesh.
+            properties:
+              gateways:
+                description: Gateways configures the gateways used to facilitate ingress and egress with the other mesh.
+                properties:
+                  egress:
+                    description: Gateway through which outbound federated service traffic will travel.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  ingress:
+                    description: Gateway through which inbound federated service traffic will travel.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                type: object
+              remote:
+                description: Remote configures details related to the remote mesh with which this mesh is federating.
+                properties:
+                  addresses:
+                    description: Addresses are the addresses to which discovery and service requests should be sent (i.e. the addresses of ingress gateways on the remote mesh).  These may be specified as resolveable DNS names or IP addresses.
+                    items:
+                      type: string
+                    type: array
+                  discoveryPort:
+                    description: DiscoveryPort is the port on which the addresses are handling discovery requests.  Defaults to 8188, if unspecified.
+                    format: int32
+                    type: integer
+                  servicePort:
+                    description: ServicePort is the port on which the addresses are handling service requests.  Defaults to 15443, if unspecified.
+                    format: int32
+                    type: integer
+                type: object
+              security:
+                description: Security configures details for securing communication with the other mesh.
+                properties:
+                  certificateChain:
+                    description: Name of ConfigMap containing certificate chain to be used to validate the remote.  This is also used to validate certificates used by the remote services (both client and server certificates).  The name of the entry should be root-cert.pem.  If unspecified, it will look for a ConfigMap named <meshfederation-name>-ca-root-cert, e.g. if this resource is named mesh1, it will look for a ConfigMap named mesh1-ca-root-cert.
+                    properties:
+                      apiGroup:
+                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  clientID:
+                    description: ClientID of the remote mesh.  This is used to authenticate incoming requrests from the remote mesh's discovery client.
+                    type: string
+                  trustDomain:
+                    description: TrustDomain of remote mesh.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: ServiceMeshPeerStatus provides information related to the other mesh.
+            properties:
+              discoveryStatus:
+                description: DiscoveryStatus represents the discovery status of each pilot/istiod pod in the mesh.
+                properties:
+                  active:
+                    description: Active represents the pilot/istiod pods actively watching the other mesh for discovery.
+                    items:
+                      description: PodPeerDiscoveryStatus provides discovery details related to a specific pilot/istiod pod.
+                      properties:
+                        pod:
+                          description: Pod is the pod name to which these details apply.  This maps to a a pilot/istiod pod.
+                          type: string
+                        remotes:
+                          description: Remotes represents details related to the inbound connections from remote meshes.
+                          items:
+                            description: DiscoveryRemoteStatus represents details related to an inbound connection from a remote mesh.
+                            properties:
+                              connected:
+                                description: Connected identfies an active connection with the remote mesh.
+                                type: boolean
+                              lastConnected:
+                                description: LastConnected represents the last time a connection with the remote mesh was successful.
+                                format: date-time
+                                type: string
+                              lastDisconnect:
+                                description: LastDisconnect represents the last time the connection with the remote mesh was disconnected.
+                                format: date-time
+                                type: string
+                              lastDisconnectStatus:
+                                description: LastDisconnectStatus is the status returned the last time the connection with the remote mesh was terminated.
+                                type: string
+                              lastEvent:
+                                description: LastEvent represents the last time an event was received from the remote mesh.
+                                format: date-time
+                                type: string
+                              lastFullSync:
+                                description: LastFullSync represents the last time a full sync was performed with the remote mesh.
+                                format: date-time
+                                type: string
+                              source:
+                                description: Source represents the source of the remote watch.
+                                type: string
+                            required:
+                            - connected
+                            - source
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - source
+                          x-kubernetes-list-type: map
+                        watch:
+                          description: Watch represents details related to the outbound connection to the remote mesh.
+                          properties:
+                            connected:
+                              description: Connected identfies an active connection with the remote mesh.
+                              type: boolean
+                            lastConnected:
+                              description: LastConnected represents the last time a connection with the remote mesh was successful.
+                              format: date-time
+                              type: string
+                            lastDisconnect:
+                              description: LastDisconnect represents the last time the connection with the remote mesh was disconnected.
+                              format: date-time
+                              type: string
+                            lastDisconnectStatus:
+                              description: LastDisconnectStatus is the status returned the last time the connection with the remote mesh was terminated.
+                              type: string
+                            lastEvent:
+                              description: LastEvent represents the last time an event was received from the remote mesh.
+                              format: date-time
+                              type: string
+                            lastFullSync:
+                              description: LastFullSync represents the last time a full sync was performed with the remote mesh.
+                              format: date-time
+                              type: string
+                          required:
+                          - connected
+                          type: object
+                      required:
+                      - pod
+                      type: object
+                    nullable: true
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - pod
+                    x-kubernetes-list-type: map
+                  inactive:
+                    description: Inactive represents the pilot/istiod pods not actively watching the other mesh for discovery.
+                    items:
+                      description: PodPeerDiscoveryStatus provides discovery details related to a specific pilot/istiod pod.
+                      properties:
+                        pod:
+                          description: Pod is the pod name to which these details apply.  This maps to a a pilot/istiod pod.
+                          type: string
+                        remotes:
+                          description: Remotes represents details related to the inbound connections from remote meshes.
+                          items:
+                            description: DiscoveryRemoteStatus represents details related to an inbound connection from a remote mesh.
+                            properties:
+                              connected:
+                                description: Connected identfies an active connection with the remote mesh.
+                                type: boolean
+                              lastConnected:
+                                description: LastConnected represents the last time a connection with the remote mesh was successful.
+                                format: date-time
+                                type: string
+                              lastDisconnect:
+                                description: LastDisconnect represents the last time the connection with the remote mesh was disconnected.
+                                format: date-time
+                                type: string
+                              lastDisconnectStatus:
+                                description: LastDisconnectStatus is the status returned the last time the connection with the remote mesh was terminated.
+                                type: string
+                              lastEvent:
+                                description: LastEvent represents the last time an event was received from the remote mesh.
+                                format: date-time
+                                type: string
+                              lastFullSync:
+                                description: LastFullSync represents the last time a full sync was performed with the remote mesh.
+                                format: date-time
+                                type: string
+                              source:
+                                description: Source represents the source of the remote watch.
+                                type: string
+                            required:
+                            - connected
+                            - source
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - source
+                          x-kubernetes-list-type: map
+                        watch:
+                          description: Watch represents details related to the outbound connection to the remote mesh.
+                          properties:
+                            connected:
+                              description: Connected identfies an active connection with the remote mesh.
+                              type: boolean
+                            lastConnected:
+                              description: LastConnected represents the last time a connection with the remote mesh was successful.
+                              format: date-time
+                              type: string
+                            lastDisconnect:
+                              description: LastDisconnect represents the last time the connection with the remote mesh was disconnected.
+                              format: date-time
+                              type: string
+                            lastDisconnectStatus:
+                              description: LastDisconnectStatus is the status returned the last time the connection with the remote mesh was terminated.
+                              type: string
+                            lastEvent:
+                              description: LastEvent represents the last time an event was received from the remote mesh.
+                              format: date-time
+                              type: string
+                            lastFullSync:
+                              description: LastFullSync represents the last time a full sync was performed with the remote mesh.
+                              format: date-time
+                              type: string
+                          required:
+                          - connected
+                          type: object
+                      required:
+                      - pod
+                      type: object
+                    nullable: true
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - pod
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/vendor/maistra.io/api/manifests/maistra.io_servicemeshcontrolplanes.yaml
+++ b/vendor/maistra.io/api/manifests/maistra.io_servicemeshcontrolplanes.yaml
@@ -1,0 +1,8474 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: servicemeshcontrolplanes.maistra.io
+spec:
+  group: maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshControlPlane
+    listKind: ServiceMeshControlPlaneList
+    plural: servicemeshcontrolplanes
+    shortNames:
+    - smcp
+    singular: servicemeshcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: How many of the total number of components are ready
+      jsonPath: .status.annotations.readyComponentCount
+      name: Ready
+      type: string
+    - description: Whether or not the control plane installation is up to date.
+      jsonPath: .status.conditions[?(@.type=="Reconciled")].reason
+      name: Status
+      type: string
+    - description: The configuration template to use as the base.
+      jsonPath: .status.lastAppliedConfiguration.template
+      name: Template
+      type: string
+    - description: The actual current version of the control plane installation.
+      jsonPath: .status.lastAppliedConfiguration.version
+      name: Version
+      type: string
+    - description: The age of the object
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The image hub used as the base for all component images.
+      jsonPath: .status.lastAppliedConfiguration.istio.global.hub
+      name: Image HUB
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ServiceMeshControlPlane represents a deployment of the service mesh control plane. The control plane components are deployed in the namespace in which the ServiceMeshControlPlane resides. The configuration options for the components that comprise the control plane are specified in this object.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The specification of the desired state of this ServiceMeshControlPlane. This includes the configuration options for all components that comprise the control plane.
+            properties:
+              istio:
+                description: 'Specifies the Istio configuration options that are passed to Helm when the Istio charts are rendered. These options are usually populated from the template specified in the spec.template field, but individual values can be overridden here. More info: https://maistra.io/docs/installation/installation-options/'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              networkType:
+                description: 'DEPRECATED: No longer used anywhere. Previously used to specify the NetworkType of the cluster. Defaults to "subnet".'
+                type: string
+              profiles:
+                description: Profiles selects the profile to use for default values. Defaults to "default" when not set.  Takes precedence over Template.
+                items:
+                  type: string
+                type: array
+              template:
+                description: Template selects the template to use for default values. Defaults to "default" when not set. DEPRECATED - use Profiles instead
+                type: string
+              threeScale:
+                description: 'Specifies the 3Scale configuration options that are passed to Helm when the 3Scale charts are rendered. These values are usually populated from the template specified in the spec.template field, but individual values can be overridden here. More info: https://maistra.io/docs/installation/installation-options/#_3scale'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              version:
+                description: Version specifies what Maistra version of the control plane to install. When creating a new ServiceMeshControlPlane with an empty version, the admission webhook sets the version to the latest version supported by the operator. Existing ServiceMeshControlPlanes with an empty version are treated as having the version set to "v1.0"
+                type: string
+            type: object
+          status:
+            description: The current status of this ServiceMeshControlPlane and the components that comprise the control plane. This data may be out of date by some window of time.
+            nullable: true
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations is an unstructured key value map used to store additional, usually redundant status information, such as the number of components deployed by the ServiceMeshControlPlane (number is redundant because you could just as easily count the elements in the ComponentStatus array). The reason to add this redundant information is to make it available to kubectl, which does not yet allow counting objects in JSONPath expressions.
+                type: object
+              components:
+                items:
+                  description: ComponentStatus represents the status of an object with children
+                  properties:
+                    children:
+                      description: 'TODO: can we remove this? it''s not used anywhere The status of each resource that comprises this component.'
+                      items:
+                        description: StatusType represents the status for a control plane, component, or resource
+                        properties:
+                          conditions:
+                            description: Represents the latest available observations of the object's current state.
+                            items:
+                              description: A Condition represents a specific observation of the object's state.
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details about the last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, single-word, CamelCase reason for the condition's last transition.
+                                  type: string
+                                status:
+                                  description: The status of this condition. Can be True, False or Unknown.
+                                  type: string
+                                type:
+                                  description: The type of this condition.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    conditions:
+                      description: Represents the latest available observations of the object's current state.
+                      items:
+                        description: A Condition represents a specific observation of the object's state.
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human-readable message indicating details about the last transition.
+                            type: string
+                          reason:
+                            description: Unique, single-word, CamelCase reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: The status of this condition. Can be True, False or Unknown.
+                            type: string
+                          type:
+                            description: The type of this condition.
+                            type: string
+                        type: object
+                      type: array
+                    resource:
+                      description: The name of the component this status pertains to.
+                      type: string
+                  type: object
+                type: array
+              conditions:
+                description: Represents the latest available observations of the object's current state.
+                items:
+                  description: A Condition represents a specific observation of the object's state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about the last transition.
+                      type: string
+                    reason:
+                      description: Unique, single-word, CamelCase reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: The status of this condition. Can be True, False or Unknown.
+                      type: string
+                    type:
+                      description: The type of this condition.
+                      type: string
+                  type: object
+                type: array
+              lastAppliedConfiguration:
+                description: The full specification of the configuration options that were applied to the components of the control plane during the most recent reconciliation.
+                properties:
+                  istio:
+                    description: 'Specifies the Istio configuration options that are passed to Helm when the Istio charts are rendered. These options are usually populated from the template specified in the spec.template field, but individual values can be overridden here. More info: https://maistra.io/docs/installation/installation-options/'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  networkType:
+                    description: 'DEPRECATED: No longer used anywhere. Previously used to specify the NetworkType of the cluster. Defaults to "subnet".'
+                    type: string
+                  profiles:
+                    description: Profiles selects the profile to use for default values. Defaults to "default" when not set.  Takes precedence over Template.
+                    items:
+                      type: string
+                    type: array
+                  template:
+                    description: Template selects the template to use for default values. Defaults to "default" when not set. DEPRECATED - use Profiles instead
+                    type: string
+                  threeScale:
+                    description: 'Specifies the 3Scale configuration options that are passed to Helm when the 3Scale charts are rendered. These values are usually populated from the template specified in the spec.template field, but individual values can be overridden here. More info: https://maistra.io/docs/installation/installation-options/#_3scale'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  version:
+                    description: Version specifies what Maistra version of the control plane to install. When creating a new ServiceMeshControlPlane with an empty version, the admission webhook sets the version to the latest version supported by the operator. Existing ServiceMeshControlPlanes with an empty version are treated as having the version set to "v1.0"
+                    type: string
+                type: object
+              observedGeneration:
+                description: The generation observed by the controller during the most recent reconciliation. The information in the status pertains to this particular generation of the object.
+                format: int64
+                type: integer
+              reconciledVersion:
+                description: The last version that was reconciled.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: How many of the total number of components are ready
+      jsonPath: .status.annotations.readyComponentCount
+      name: Ready
+      type: string
+    - description: Whether or not the control plane installation is up to date and ready to handle requests.
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Status
+      type: string
+    - description: The configuration profiles applied to the configuration.
+      jsonPath: .status.appliedSpec.profiles
+      name: Profiles
+      type: string
+    - description: The actual current version of the control plane installation.
+      jsonPath: .status.chartVersion
+      name: Version
+      type: string
+    - description: The age of the object
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The image registry used as the base for all component images.
+      jsonPath: .status.appliedSpec.runtime.defaults.container.registry
+      name: Image Registry
+      priority: 1
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: ServiceMeshControlPlane is the Schema for the controlplanes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The specification of the desired state of this ServiceMeshControlPlane. This includes the configuration options for all components that comprise the control plane.
+            properties:
+              addons:
+                description: Addons is used to configure additional features beyond core control plane components, e.g. visualization, metric storage, etc.
+                properties:
+                  3scale:
+                    description: ThreeScale configures the 3scale adapter
+                    properties:
+                      backend:
+                        description: Backend configures backend specific details
+                        properties:
+                          cache_flush_interval:
+                            description: CacheFlushInterval sets the interval at which metrics get reported from the cache to 3scale PARAM_THREESCALE_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS
+                            format: int32
+                            type: integer
+                          enable_cache:
+                            description: EnableCache if true, attempts to create an in-memory apisonator cache for authorization requests PARAM_THREESCALE_USE_CACHED_BACKEND
+                            type: boolean
+                          policy_fail_closed:
+                            description: PolicyFailClosed if true, request will fail if 3scale Apisonator is unreachable PARAM_THREESCALE_BACKEND_CACHE_POLICY_FAIL_CLOSED
+                            type: boolean
+                        type: object
+                      client:
+                        description: Client configures client specific details
+                        properties:
+                          allow_insecure_connections:
+                            description: AllowInsecureConnections skips certificate verification when calling 3scale API's. Enabling is not recommended PARAM_THREESCALE_ALLOW_INSECURE_CONN
+                            type: boolean
+                          timeout:
+                            description: Timeout sets the number of seconds to wait before terminating requests to 3scale System and Backend PARAM_THREESCALE_CLIENT_TIMEOUT_SECONDS
+                            format: int32
+                            type: integer
+                        type: object
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      grpc:
+                        description: GRPC configures gRPC specific details
+                        properties:
+                          max_conn_timeout:
+                            description: MaxConnTimeout sets the maximum amount of seconds (+/-10% jitter) a connection may exist before it will be closed PARAM_THREESCALE_GRPC_CONN_MAX_SECONDS
+                            format: int32
+                            type: integer
+                        type: object
+                      listen_addr:
+                        description: ListenerAddr sets the listen address for the gRPC server. PARAM_THREESCALE_LISTEN_ADDR
+                        format: int32
+                        type: integer
+                      log_grpc:
+                        description: LogGRPC controls whether the log includes gRPC info PARAM_THREESCALE_LOG_GRPC
+                        type: boolean
+                      log_json:
+                        description: LogJSON controls whether the log is formatted as JSON PARAM_THREESCALE_LOG_JSON
+                        type: boolean
+                      log_level:
+                        description: 'LogLevel sets the minimum log output level. Accepted values are one of: debug, info, warn, error, none PARAM_THREESCALE_LOG_LEVEL'
+                        type: string
+                      metrics:
+                        description: Metrics configures metrics specific details
+                        properties:
+                          port:
+                            description: Port sets the port which 3scale /metrics endpoint can be scrapped from PARAM_THREESCALE_METRICS_PORT
+                            format: int32
+                            type: integer
+                          report:
+                            description: Report controls whether 3scale system and backend metrics are collected and reported to Prometheus PARAM_THREESCALE_REPORT_METRICS
+                            type: boolean
+                        type: object
+                      system:
+                        description: System configures system specific details
+                        properties:
+                          cache_max_size:
+                            description: CacheMaxSize is the max number of items that can be stored in the cache at any time. Set to 0 to disable caching PARAM_THREESCALE_CACHE_ENTRIES_MAX
+                            format: int64
+                            type: integer
+                          cache_refresh_interval:
+                            description: CacheRefreshInterval is the time period in seconds, before a background process attempts to refresh cached entries PARAM_THREESCALE_CACHE_REFRESH_SECONDS
+                            format: int32
+                            type: integer
+                          cache_refresh_retries:
+                            description: CacheRefreshRetries sets the number of times unreachable hosts will be retried during a cache update loop PARAM_THREESCALE_CACHE_REFRESH_RETRIES
+                            format: int32
+                            type: integer
+                          cache_ttl:
+                            description: CacheTTL is the time period, in seconds, to wait before purging expired items from the cache PARAM_THREESCALE_CACHE_TTL_SECONDS
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  grafana:
+                    description: Grafana configures a grafana instance to use with the mesh .Values.grafana.enabled, true if not null
+                    properties:
+                      address:
+                        description: Address is the address of an existing grafana installation implies .Values.kiali.dashboard.grafanaURL
+                        type: string
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      install:
+                        description: Install a new grafana instance and manage with control plane
+                        properties:
+                          config:
+                            description: Config configures the behavior of the grafana installation
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                description: 'Env allows specification of various grafana environment variables to be configured on the grafana container. .Values.grafana.env XXX: This is pretty cheesy...'
+                                type: object
+                              envSecrets:
+                                additionalProperties:
+                                  type: string
+                                description: 'EnvSecrets allows specification of secret fields into grafana environment variables to be configured on the grafana container .Values.grafana.envSecrets XXX: This is pretty cheesy...'
+                                type: object
+                            type: object
+                          persistence:
+                            description: 'Persistence configures a PersistentVolume associated with the grafana installation .Values.grafana.persist, true if not null XXX: capacity is not supported in the charts, hard coded to 5Gi'
+                            properties:
+                              accessMode:
+                                description: AccessMode for the PersistentVolumeClaim
+                                type: string
+                              capacity:
+                                description: Resources to request for the PersistentVolumeClaim
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              storageClassName:
+                                description: StorageClassName for the PersistentVolumeClaim
+                                type: string
+                            type: object
+                          security:
+                            description: 'Security is used to secure the grafana service. .Values.grafana.security.enabled, true if not null XXX: unused for maistra, as we use oauth-proxy'
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              passphraseKey:
+                                description: PassphraseKey is the name of the key within the secret identifying the password.
+                                type: string
+                              secretName:
+                                description: SecretName is the name of a secret containing the username/password that should be used to access grafana.
+                                type: string
+                              usernameKey:
+                                description: UsernameKey is the name of the key within the secret identifying the username.
+                                type: string
+                            type: object
+                          selfManaged:
+                            description: SelfManaged, true if the entire install should be managed by Maistra, false if using grafana CR (not supported)
+                            type: boolean
+                          service:
+                            description: 'Service configures the k8s Service associated with the grafana installation XXX: grafana service config does not follow other addon components'' structure'
+                            properties:
+                              ingress:
+                                description: Ingress specifies details for accessing the component's service through a k8s Ingress or OpenShift Route.
+                                properties:
+                                  contextPath:
+                                    description: ContextPath represents the context path to the service.
+                                    type: string
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  hosts:
+                                    description: 'Hosts represents a list of host names to configure.  Note, OpenShift route only supports a single host name per route.  An empty host name implies a default host name for the Route. XXX: is a host name required for k8s Ingress?'
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    description: Metadata represents additional metadata to be applied to the ingress/route.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  tls:
+                                    description: 'TLS is used to configure TLS for the Ingress/Route XXX: should this be something like RawExtension, as the configuration differs between Route and Ingress?'
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              metadata:
+                                description: Metadata represents addtional annotations/labels to be applied to the component's service.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodePort:
+                                description: NodePort specifies a NodePort for the component's Service. .Values.<component>.service.nodePort.port, ...enabled is true if not null
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  jaeger:
+                    description: Jaeger configures Jaeger specific addon capabilities
+                    properties:
+                      install:
+                        description: Install configures a Jaeger installation, which will be created if the named Jaeger resource is not present.  If null, the named Jaeger resource must exist.
+                        properties:
+                          ingress:
+                            description: Ingress configures k8s Ingress or OpenShift Route for Jaeger services .Values.tracing.jaeger.ingress.enabled, false if null
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              metadata:
+                                description: Metadata represents addtional annotations/labels to be applied to the ingress/route.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          storage:
+                            description: Config represents the configuration of Jaeger behavior.
+                            properties:
+                              elasticsearch:
+                                description: Elasticsearch represents configuration of elasticsearch storage implies .Values.tracing.jaeger.template=production-elasticsearch
+                                properties:
+                                  indexCleaner:
+                                    description: 'IndexCleaner represents the configuration for the elasticsearch index cleaner .Values.tracing.jaeger.elasticsearch.esIndexCleaner, raw yaml XXX: RawExtension?'
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  nodeCount:
+                                    description: NodeCount represents the number of elasticsearch nodes to create. .Values.tracing.jaeger.elasticsearch.nodeCount, defaults to 3
+                                    format: int32
+                                    type: integer
+                                  redundancyPolicy:
+                                    description: RedundancyPolicy configures the redundancy policy for elasticsearch .Values.tracing.jaeger.elasticsearch.redundancyPolicy, raw yaml
+                                    type: string
+                                  storage:
+                                    description: 'Storage represents storage configuration for elasticsearch. .Values.tracing.jaeger.elasticsearch.storage, raw yaml XXX: RawExtension?'
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              memory:
+                                description: Memory represents configuration of in-memory storage implies .Values.tracing.jaeger.template=all-in-one
+                                properties:
+                                  maxTraces:
+                                    description: MaxTraces to store .Values.tracing.jaeger.memory.max_traces, defaults to 100000
+                                    format: int64
+                                    type: integer
+                                type: object
+                              type:
+                                description: Type of storage to use
+                                type: string
+                            type: object
+                        type: object
+                      name:
+                        description: Name of Jaeger CR, Namespace must match control plane namespace
+                        type: string
+                    type: object
+                  kiali:
+                    description: Kiali configures a kiali instance to use with the mesh .Values.kiali.enabled, true if not null
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      install:
+                        description: Install a Kiali resource if the named Kiali resource is not present.
+                        properties:
+                          dashboard:
+                            description: Dashboard configures the behavior of the kiali dashboard.
+                            properties:
+                              enableGrafana:
+                                description: 'XXX: should the user have a choice here, or should these be configured automatically if they are enabled for the control plane installation? Grafana endpoint will be configured based on Grafana configuration'
+                                type: boolean
+                              enablePrometheus:
+                                description: Prometheus endpoint will be configured based on Prometheus configuration
+                                type: boolean
+                              enableTracing:
+                                description: Tracing endpoint will be configured based on Tracing configuration
+                                type: boolean
+                              viewOnly:
+                                description: ViewOnly configures view_only_mode for the dashboard .Values.kiali.dashboard.viewOnlyMode
+                                type: boolean
+                            type: object
+                          service:
+                            description: 'Service is used to configure the k8s Service associated with the kiali installation. XXX: provided for upstream support, only ingress is used, and then only for enablement and contextPath'
+                            properties:
+                              ingress:
+                                description: Ingress specifies details for accessing the component's service through a k8s Ingress or OpenShift Route.
+                                properties:
+                                  contextPath:
+                                    description: ContextPath represents the context path to the service.
+                                    type: string
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  hosts:
+                                    description: 'Hosts represents a list of host names to configure.  Note, OpenShift route only supports a single host name per route.  An empty host name implies a default host name for the Route. XXX: is a host name required for k8s Ingress?'
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    description: Metadata represents additional metadata to be applied to the ingress/route.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  tls:
+                                    description: 'TLS is used to configure TLS for the Ingress/Route XXX: should this be something like RawExtension, as the configuration differs between Route and Ingress?'
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              metadata:
+                                description: Metadata represents addtional annotations/labels to be applied to the component's service.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodePort:
+                                description: NodePort specifies a NodePort for the component's Service. .Values.<component>.service.nodePort.port, ...enabled is true if not null
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      name:
+                        description: Name of Kiali CR, Namespace must match control plane namespace
+                        type: string
+                    type: object
+                  prometheus:
+                    description: Prometheus configures Prometheus specific addon capabilities
+                    properties:
+                      address:
+                        description: 'Address of existing prometheus installation implies .Values.kiali.prometheusAddr XXX: do we need to do anything to configure credentials for accessing the prometheus server?'
+                        type: string
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      install:
+                        description: Install configuration if not using an existing prometheus installation. .Values.prometheus.enabled, if not null
+                        properties:
+                          retention:
+                            description: Retention specifies how long metrics should be retained by prometheus. .Values.prometheus.retention, defaults to 6h
+                            type: string
+                          scrapeInterval:
+                            description: ScrapeInterval specifies how frequently prometheus should scrape pods for metrics. .Values.prometheus.scrapeInterval, defaults to 15s
+                            type: string
+                          selfManaged:
+                            description: SelfManaged specifies whether or not the entire install should be managed by Maistra (true) or the Prometheus operator (false, not supported). Governs use of either prometheus charts or prometheusOperator charts.
+                            type: boolean
+                          service:
+                            description: Service allows for customization of the k8s Service associated with the prometheus installation.
+                            properties:
+                              ingress:
+                                description: Ingress specifies details for accessing the component's service through a k8s Ingress or OpenShift Route.
+                                properties:
+                                  contextPath:
+                                    description: ContextPath represents the context path to the service.
+                                    type: string
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  hosts:
+                                    description: 'Hosts represents a list of host names to configure.  Note, OpenShift route only supports a single host name per route.  An empty host name implies a default host name for the Route. XXX: is a host name required for k8s Ingress?'
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    description: Metadata represents additional metadata to be applied to the ingress/route.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  tls:
+                                    description: 'TLS is used to configure TLS for the Ingress/Route XXX: should this be something like RawExtension, as the configuration differs between Route and Ingress?'
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              metadata:
+                                description: Metadata represents addtional annotations/labels to be applied to the component's service.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodePort:
+                                description: NodePort specifies a NodePort for the component's Service. .Values.<component>.service.nodePort.port, ...enabled is true if not null
+                                format: int32
+                                type: integer
+                            type: object
+                          useTLS:
+                            description: UseTLS for the prometheus server .Values.prometheus.provisionPrometheusCert 1.6+ ProvisionCert bool this seems to overlap with provision cert, as this manifests something similar to the above .Values.prometheus.security.enabled, version < 1.6 EnableSecurity bool
+                            type: boolean
+                        type: object
+                      metricsExpiryDuration:
+                        description: MetricsExpiryDuration is the duration to hold metrics. (mixer/v1 only) .Values.mixer.adapters.prometheus.metricsExpiryDuration, defaults to 10m
+                        type: string
+                      scrape:
+                        description: Scrape metrics from the pod if true. (maistra-2.0+) defaults to true .Values.meshConfig.enablePrometheusMerge
+                        type: boolean
+                    type: object
+                  stackdriver:
+                    description: Stackdriver configures Stackdriver specific addon capabilities
+                    properties:
+                      telemetry:
+                        description: Configuration for Stackdriver telemetry plugins.  Applies when telemetry is enabled
+                        properties:
+                          accessLogging:
+                            description: DisableOutbound disables intallation of sidecar outbound filter .Values.telemetry.v2.stackdriver.disableOutbound, defaults to false DisableOutbound bool `json:"disableOutbound,omitempty"` AccessLogging configures access logging for stackdriver
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              logWindowDuration:
+                                description: LogWindowDuration configures the log window duration for access logs. defaults to 43200s To reduce the number of successful logs, default log window duration is set to 12 hours. .Values.telemetry.v2.accessLogPolicy.logWindowDuration
+                                type: string
+                            type: object
+                          auth:
+                            description: Auth configuration for stackdriver adapter (mixer/v1 telemetry only) .Values.mixer.adapters.stackdriver.auth
+                            properties:
+                              apiKey:
+                                description: APIKey use the specified key. .Values.mixer.adapters.stackdriver.auth.apiKey
+                                type: string
+                              appCredentials:
+                                description: AppCredentials if true, use default app credentials. .Values.mixer.adapters.stackdriver.auth.appCredentials, defaults to false
+                                type: boolean
+                              serviceAccountPath:
+                                description: ServiceAccountPath use the path to the service account. .Values.mixer.adapters.stackdriver.auth.serviceAccountPath
+                                type: string
+                            type: object
+                          configOverride:
+                            description: ConfigOverride apply custom configuration to Stackdriver filters (v2 telemetry only) .Values.telemetry.v2.stackdriver.configOverride
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          enableContextGraph:
+                            description: EnableContextGraph for stackdriver adapter (edge reporting) .Values.mixer.adapters.stackdriver.contextGraph.enabled, defaults to false .Values.telemetry.v2.stackdriver.topology, defaults to false
+                            type: boolean
+                          enableLogging:
+                            description: EnableLogging for stackdriver adapter .Values.mixer.adapters.stackdriver.logging.enabled, defaults to true .Values.telemetry.v2.stackdriver.logging, defaults to false
+                            type: boolean
+                          enableMetrics:
+                            description: EnableMetrics for stackdriver adapter .Values.mixer.adapters.stackdriver.metrics.enabled, defaults to true .Values.telemetry.v2.stackdriver.monitoring??? defaults to false
+                            type: boolean
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                        type: object
+                      tracer:
+                        description: Configuration for Stackdriver tracer.  Applies when Addons.Tracer.Type=Stackdriver
+                        properties:
+                          debug:
+                            description: .Values.global.tracer.stackdriver.debug
+                            type: boolean
+                          maxNumberOfAnnotations:
+                            description: .Values.global.tracer.stackdriver.maxNumberOfAnnotations
+                            format: int64
+                            type: integer
+                          maxNumberOfAttributes:
+                            description: .Values.global.tracer.stackdriver.maxNumberOfAttributes
+                            format: int64
+                            type: integer
+                          maxNumberOfMessageEvents:
+                            description: .Values.global.tracer.stackdriver.maxNumberOfMessageEvents
+                            format: int64
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              cluster:
+                description: Cluster is the general configuration of the cluster (cluster name, network name, multi-cluster, mesh expansion, etc.)
+                properties:
+                  meshExpansion:
+                    description: '.Values.global.meshExpansion.enabled, if not null XXX: it''s not clear whether or not there is any overlap with MultiCluster, i.e. does MultiCluster require mesh expansion ports to be configured on the ingress gateway?'
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      ilbGateway:
+                        description: .Values.global.meshExpansion.useILB, true if not null, otherwise uses ingress gateway
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          namespace:
+                            description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                            type: string
+                          routerMode:
+                            description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                            type: string
+                          runtime:
+                            description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                            properties:
+                              container:
+                                description: .Values.*.resource, imagePullPolicy, etc.
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    description: PullPolicy describes a policy for if/when to pull a container image
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    description: ResourceRequirements describes the compute resource requirements.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                type: object
+                              deployment:
+                                description: Deployment specific overrides
+                                properties:
+                                  autoScaling:
+                                    description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                    properties:
+                                      enabled:
+                                        description: Enabled specifies whether or not this feature is enabled
+                                        type: boolean
+                                      maxReplicas:
+                                        description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                        format: int32
+                                        type: integer
+                                      minReplicas:
+                                        description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                        format: int32
+                                        type: integer
+                                      targetCPUUtilizationPercentage:
+                                        description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  replicas:
+                                    description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                    format: int32
+                                    type: integer
+                                  strategy:
+                                    description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                    properties:
+                                      rollingUpdate:
+                                        properties:
+                                          maxSurge:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                            x-kubernetes-int-or-string: true
+                                          maxUnavailable:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      type:
+                                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                        type: string
+                                    type: object
+                                type: object
+                              pod:
+                                description: Pod specific overrides
+                                properties:
+                                  affinity:
+                                    description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                    properties:
+                                      podAntiAffinity:
+                                        description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                        properties:
+                                          preferredDuringScheduling:
+                                            items:
+                                              description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                topologyKey:
+                                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          requiredDuringScheduling:
+                                            items:
+                                              description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                topologyKey:
+                                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  metadata:
+                                    description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                    type: object
+                                  priorityClassName:
+                                    description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                    type: string
+                                  tolerations:
+                                    description: If specified, the pod's tolerations. .Values.tolerations
+                                    items:
+                                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          service:
+                            description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                            properties:
+                              allocateLoadBalancerNodePorts:
+                                description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                                type: boolean
+                              clusterIP:
+                                description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                type: string
+                              clusterIPs:
+                                description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              externalIPs:
+                                description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                                type: string
+                              externalTrafficPolicy:
+                                description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                                type: string
+                              healthCheckNodePort:
+                                description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                                format: int32
+                                type: integer
+                              ipFamilies:
+                                description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                                items:
+                                  description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ipFamilyPolicy:
+                                description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                                type: string
+                              loadBalancerIP:
+                                description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                                type: string
+                              loadBalancerSourceRanges:
+                                description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                description: metadata to be applied to the gateway's service (annotations and labels)
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              ports:
+                                description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                items:
+                                  description: ServicePort contains information on service's port.
+                                  properties:
+                                    appProtocol:
+                                      description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                      type: string
+                                    name:
+                                      description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                      type: string
+                                    nodePort:
+                                      description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      description: The port that will be exposed by this service.
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      default: TCP
+                                      description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                                type: object
+                              sessionAffinity:
+                                description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                type: string
+                              sessionAffinityConfig:
+                                description: sessionAffinityConfig contains the configurations of session affinity.
+                                properties:
+                                  clientIP:
+                                    description: clientIP contains the configurations of Client IP based session affinity.
+                                    properties:
+                                      timeoutSeconds:
+                                        description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              topologyKeys:
+                                description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                                items:
+                                  type: string
+                                type: array
+                              type:
+                                description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                                type: string
+                            type: object
+                          volumes:
+                            description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                            items:
+                              description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                              properties:
+                                volume:
+                                  description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap represents a configMap that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    secret:
+                                      description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: Specify whether the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                  type: object
+                                volumeMount:
+                                  description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                  properties:
+                                    mountPath:
+                                      description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                      type: boolean
+                                    subPath:
+                                      description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  multiCluster:
+                    description: .Values.global.multiCluster.enabled, if not null
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      meshNetworks:
+                        additionalProperties:
+                          description: MeshNetworkConfig configures mesh networks for a multi-cluster mesh.
+                          properties:
+                            endpoints:
+                              items:
+                                description: MeshEndpointConfig specifies the endpoint of a mesh network.  Only one of FromRegistry or FromCIDR may be specified
+                                properties:
+                                  fromCIDR:
+                                    type: string
+                                  fromRegistry:
+                                    type: string
+                                type: object
+                              type: array
+                            gateways:
+                              items:
+                                description: MeshGatewayConfig specifies the gateway which should be used for accessing the network
+                                properties:
+                                  address:
+                                    type: string
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  registryServiceName:
+                                    type: string
+                                  service:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        description: '.Values.global.meshNetworks XXX: if non-empty, local cluster network should be configured as:  <spec.cluster.network>:      endpoints:      - fromRegistry: <spec.cluster.name>      gateways:      - service: <ingress-gateway-service-name>        port: 443 # mtls port'
+                        type: object
+                    type: object
+                  name:
+                    description: .Values.global.multiCluster.clusterName, defaults to Kubernetes
+                    type: string
+                  network:
+                    description: '.Values.global.network XXX: not sure what the difference is between this and cluster name'
+                    type: string
+                type: object
+              gateways:
+                description: Gateways configures gateways for the mesh .Values.gateways.*
+                properties:
+                  additionalEgress:
+                    additionalProperties:
+                      description: EgressGatewayConfig represents gateway configuration for egress
+                      properties:
+                        enabled:
+                          description: Enabled specifies whether or not this feature is enabled
+                          type: boolean
+                        namespace:
+                          description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                          type: string
+                        requestedNetworkView:
+                          description: 'RequestedNetworkView is a list of networks whose services should be made available to the gateway.  This is used primarily for mesh expansion/multi-cluster. .Values.gateways.<gateway-name>.env.ISTIO_META_REQUESTED_NETWORK_VIEW env, defaults to empty list XXX: I think this is only applicable to egress gateways'
+                          items:
+                            type: string
+                          type: array
+                        routerMode:
+                          description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                          type: string
+                        runtime:
+                          description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                          properties:
+                            container:
+                              description: .Values.*.resource, imagePullPolicy, etc.
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  description: PullPolicy describes a policy for if/when to pull a container image
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  description: ResourceRequirements describes the compute resource requirements.
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                              type: object
+                            deployment:
+                              description: Deployment specific overrides
+                              properties:
+                                autoScaling:
+                                  description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                  properties:
+                                    enabled:
+                                      description: Enabled specifies whether or not this feature is enabled
+                                      type: boolean
+                                    maxReplicas:
+                                      description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                      format: int32
+                                      type: integer
+                                    minReplicas:
+                                      description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                      format: int32
+                                      type: integer
+                                    targetCPUUtilizationPercentage:
+                                      description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                replicas:
+                                  description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                  format: int32
+                                  type: integer
+                                strategy:
+                                  description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                  properties:
+                                    rollingUpdate:
+                                      properties:
+                                        maxSurge:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                          x-kubernetes-int-or-string: true
+                                        maxUnavailable:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    type:
+                                      description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                      type: string
+                                  type: object
+                              type: object
+                            pod:
+                              description: Pod specific overrides
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                  properties:
+                                    podAntiAffinity:
+                                      description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                      properties:
+                                        preferredDuringScheduling:
+                                          items:
+                                            description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        requiredDuringScheduling:
+                                          items:
+                                            description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                metadata:
+                                  description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                  type: object
+                                priorityClassName:
+                                  description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                  type: string
+                                tolerations:
+                                  description: If specified, the pod's tolerations. .Values.tolerations
+                                  items:
+                                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                    properties:
+                                      effect:
+                                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        service:
+                          description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                          properties:
+                            allocateLoadBalancerNodePorts:
+                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                              type: boolean
+                            clusterIP:
+                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              type: string
+                            clusterIPs:
+                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            externalIPs:
+                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                              type: string
+                            externalTrafficPolicy:
+                              description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                              type: string
+                            healthCheckNodePort:
+                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                              format: int32
+                              type: integer
+                            ipFamilies:
+                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              items:
+                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ipFamilyPolicy:
+                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                              type: string
+                            loadBalancerIP:
+                              description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                              type: string
+                            loadBalancerSourceRanges:
+                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                              items:
+                                type: string
+                              type: array
+                            metadata:
+                              description: metadata to be applied to the gateway's service (annotations and labels)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            ports:
+                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              items:
+                                description: ServicePort contains information on service's port.
+                                properties:
+                                  appProtocol:
+                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                    type: string
+                                  name:
+                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    type: string
+                                  nodePort:
+                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    description: The port that will be exposed by this service.
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    default: TCP
+                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - port
+                              - protocol
+                              x-kubernetes-list-type: map
+                            publishNotReadyAddresses:
+                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              type: object
+                            sessionAffinity:
+                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              type: string
+                            sessionAffinityConfig:
+                              description: sessionAffinityConfig contains the configurations of session affinity.
+                              properties:
+                                clientIP:
+                                  description: clientIP contains the configurations of Client IP based session affinity.
+                                  properties:
+                                    timeoutSeconds:
+                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            topologyKeys:
+                              description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              type: string
+                          type: object
+                        volumes:
+                          description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                          items:
+                            description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                            properties:
+                              volume:
+                                description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                properties:
+                                  configMap:
+                                    description: ConfigMap represents a configMap that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  secret:
+                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: Specify whether the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                type: object
+                              volumeMount:
+                                description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    description: Other user defined egress gateways .Values.gateways.<key>
+                    type: object
+                  additionalIngress:
+                    additionalProperties:
+                      description: IngressGatewayConfig represents gateway configuration for ingress
+                      properties:
+                        enabled:
+                          description: Enabled specifies whether or not this feature is enabled
+                          type: boolean
+                        namespace:
+                          description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                          type: string
+                        routerMode:
+                          description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                          type: string
+                        runtime:
+                          description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                          properties:
+                            container:
+                              description: .Values.*.resource, imagePullPolicy, etc.
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  description: PullPolicy describes a policy for if/when to pull a container image
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  description: ResourceRequirements describes the compute resource requirements.
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                              type: object
+                            deployment:
+                              description: Deployment specific overrides
+                              properties:
+                                autoScaling:
+                                  description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                  properties:
+                                    enabled:
+                                      description: Enabled specifies whether or not this feature is enabled
+                                      type: boolean
+                                    maxReplicas:
+                                      description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                      format: int32
+                                      type: integer
+                                    minReplicas:
+                                      description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                      format: int32
+                                      type: integer
+                                    targetCPUUtilizationPercentage:
+                                      description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                replicas:
+                                  description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                  format: int32
+                                  type: integer
+                                strategy:
+                                  description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                  properties:
+                                    rollingUpdate:
+                                      properties:
+                                        maxSurge:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                          x-kubernetes-int-or-string: true
+                                        maxUnavailable:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    type:
+                                      description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                      type: string
+                                  type: object
+                              type: object
+                            pod:
+                              description: Pod specific overrides
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                  properties:
+                                    podAntiAffinity:
+                                      description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                      properties:
+                                        preferredDuringScheduling:
+                                          items:
+                                            description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        requiredDuringScheduling:
+                                          items:
+                                            description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                metadata:
+                                  description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                  type: object
+                                priorityClassName:
+                                  description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                  type: string
+                                tolerations:
+                                  description: If specified, the pod's tolerations. .Values.tolerations
+                                  items:
+                                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                    properties:
+                                      effect:
+                                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        sds:
+                          description: EnableSDS for the gateway. .Values.gateways.<gateway-name>.sds.enabled
+                          properties:
+                            enabled:
+                              description: Enabled specifies whether or not this feature is enabled
+                              type: boolean
+                            runtime:
+                              description: Runtime configuration for sds sidecar
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  description: PullPolicy describes a policy for if/when to pull a container image
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  description: ResourceRequirements describes the compute resource requirements.
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        service:
+                          description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                          properties:
+                            allocateLoadBalancerNodePorts:
+                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                              type: boolean
+                            clusterIP:
+                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              type: string
+                            clusterIPs:
+                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            externalIPs:
+                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              items:
+                                type: string
+                              type: array
+                            externalName:
+                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                              type: string
+                            externalTrafficPolicy:
+                              description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                              type: string
+                            healthCheckNodePort:
+                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                              format: int32
+                              type: integer
+                            ipFamilies:
+                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              items:
+                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ipFamilyPolicy:
+                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                              type: string
+                            loadBalancerIP:
+                              description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                              type: string
+                            loadBalancerSourceRanges:
+                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                              items:
+                                type: string
+                              type: array
+                            metadata:
+                              description: metadata to be applied to the gateway's service (annotations and labels)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            ports:
+                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              items:
+                                description: ServicePort contains information on service's port.
+                                properties:
+                                  appProtocol:
+                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                    type: string
+                                  name:
+                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    type: string
+                                  nodePort:
+                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    description: The port that will be exposed by this service.
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    default: TCP
+                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - port
+                              - protocol
+                              x-kubernetes-list-type: map
+                            publishNotReadyAddresses:
+                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              type: object
+                            sessionAffinity:
+                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              type: string
+                            sessionAffinityConfig:
+                              description: sessionAffinityConfig contains the configurations of session affinity.
+                              properties:
+                                clientIP:
+                                  description: clientIP contains the configurations of Client IP based session affinity.
+                                  properties:
+                                    timeoutSeconds:
+                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            topologyKeys:
+                              description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              type: string
+                          type: object
+                        volumes:
+                          description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                          items:
+                            description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                            properties:
+                              volume:
+                                description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                properties:
+                                  configMap:
+                                    description: ConfigMap represents a configMap that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  secret:
+                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: Specify whether the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                type: object
+                              volumeMount:
+                                description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    description: Other user defined ingress gateways .Values.gateways.<key>
+                    type: object
+                  egress:
+                    description: ClusterEgress configures the istio-egressgateway for the mesh. .Values.gateways.istio-egressgateway
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      namespace:
+                        description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                        type: string
+                      requestedNetworkView:
+                        description: 'RequestedNetworkView is a list of networks whose services should be made available to the gateway.  This is used primarily for mesh expansion/multi-cluster. .Values.gateways.<gateway-name>.env.ISTIO_META_REQUESTED_NETWORK_VIEW env, defaults to empty list XXX: I think this is only applicable to egress gateways'
+                        items:
+                          type: string
+                        type: array
+                      routerMode:
+                        description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                        type: string
+                      runtime:
+                        description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                        properties:
+                          container:
+                            description: .Values.*.resource, imagePullPolicy, etc.
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when to pull a container image
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute resource requirements.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                            type: object
+                          deployment:
+                            description: Deployment specific overrides
+                            properties:
+                              autoScaling:
+                                description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  maxReplicas:
+                                    description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                    format: int32
+                                    type: integer
+                                  minReplicas:
+                                    description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                    format: int32
+                                    type: integer
+                                  targetCPUUtilizationPercentage:
+                                    description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              replicas:
+                                description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                format: int32
+                                type: integer
+                              strategy:
+                                description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                properties:
+                                  rollingUpdate:
+                                    properties:
+                                      maxSurge:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                        x-kubernetes-int-or-string: true
+                                      maxUnavailable:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  type:
+                                    description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                    type: string
+                                type: object
+                            type: object
+                          pod:
+                            description: Pod specific overrides
+                            properties:
+                              affinity:
+                                description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                properties:
+                                  podAntiAffinity:
+                                    description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                    properties:
+                                      preferredDuringScheduling:
+                                        items:
+                                          description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      requiredDuringScheduling:
+                                        items:
+                                          description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              metadata:
+                                description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                type: object
+                              priorityClassName:
+                                description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                type: string
+                              tolerations:
+                                description: If specified, the pod's tolerations. .Values.tolerations
+                                items:
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      service:
+                        description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                            type: boolean
+                          clusterIP:
+                            description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          clusterIPs:
+                            description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                            format: int32
+                            type: integer
+                          ipFamilies:
+                            description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                            items:
+                              description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            description: metadata to be applied to the gateway's service (annotations and labels)
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          ports:
+                            description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            items:
+                              description: ServicePort contains information on service's port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                  type: string
+                                nodePort:
+                                  description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                            type: object
+                          sessionAffinity:
+                            description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          topologyKeys:
+                            description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                            items:
+                              type: string
+                            type: array
+                          type:
+                            description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                            type: string
+                        type: object
+                      volumes:
+                        description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                        items:
+                          description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                          properties:
+                            volume:
+                              description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                              properties:
+                                configMap:
+                                  description: ConfigMap represents a configMap that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                secret:
+                                  description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    optional:
+                                      description: Specify whether the Secret or its keys must be defined
+                                      type: boolean
+                                    secretName:
+                                      description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMount:
+                              description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  enabled:
+                    description: Enabled specifies whether or not this feature is enabled
+                    type: boolean
+                  ingress:
+                    description: ClusterIngress configures the istio-ingressgateway for the mesh works in conjunction with cluster.meshExpansion.ingress configuration (for enabling ILB gateway and mesh expansion ports) .Values.gateways.istio-ingressgateway
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      ingress:
+                        description: '.Values.global.k8sIngress.enabled implies the following: .Values.global.k8sIngress.gatewayName will match the ingress gateway .Values.global.k8sIngress.enableHttps will be true if gateway service exposes port 443 XXX: not sure whether or not this is specific to multicluster, mesh expansion, or both'
+                        type: boolean
+                      meshExpansionPorts:
+                        description: MeshExpansionPorts define the port set used with multi-cluster/mesh expansion
+                        items:
+                          description: ServicePort contains information on service's port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                              type: string
+                            name:
+                              description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                      namespace:
+                        description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                        type: string
+                      routerMode:
+                        description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                        type: string
+                      runtime:
+                        description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                        properties:
+                          container:
+                            description: .Values.*.resource, imagePullPolicy, etc.
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when to pull a container image
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute resource requirements.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                            type: object
+                          deployment:
+                            description: Deployment specific overrides
+                            properties:
+                              autoScaling:
+                                description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  maxReplicas:
+                                    description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                    format: int32
+                                    type: integer
+                                  minReplicas:
+                                    description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                    format: int32
+                                    type: integer
+                                  targetCPUUtilizationPercentage:
+                                    description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              replicas:
+                                description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                format: int32
+                                type: integer
+                              strategy:
+                                description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                properties:
+                                  rollingUpdate:
+                                    properties:
+                                      maxSurge:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                        x-kubernetes-int-or-string: true
+                                      maxUnavailable:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  type:
+                                    description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                    type: string
+                                type: object
+                            type: object
+                          pod:
+                            description: Pod specific overrides
+                            properties:
+                              affinity:
+                                description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                properties:
+                                  podAntiAffinity:
+                                    description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                    properties:
+                                      preferredDuringScheduling:
+                                        items:
+                                          description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      requiredDuringScheduling:
+                                        items:
+                                          description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            topologyKey:
+                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              metadata:
+                                description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                type: object
+                              priorityClassName:
+                                description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                type: string
+                              tolerations:
+                                description: If specified, the pod's tolerations. .Values.tolerations
+                                items:
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      sds:
+                        description: EnableSDS for the gateway. .Values.gateways.<gateway-name>.sds.enabled
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          runtime:
+                            description: Runtime configuration for sds sidecar
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when to pull a container image
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute resource requirements.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      service:
+                        description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                            type: boolean
+                          clusterIP:
+                            description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          clusterIPs:
+                            description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                            format: int32
+                            type: integer
+                          ipFamilies:
+                            description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                            items:
+                              description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                            items:
+                              type: string
+                            type: array
+                          metadata:
+                            description: metadata to be applied to the gateway's service (annotations and labels)
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          ports:
+                            description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            items:
+                              description: ServicePort contains information on service's port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                  type: string
+                                nodePort:
+                                  description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                            type: object
+                          sessionAffinity:
+                            description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          topologyKeys:
+                            description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                            items:
+                              type: string
+                            type: array
+                          type:
+                            description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                            type: string
+                        type: object
+                      volumes:
+                        description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                        items:
+                          description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                          properties:
+                            volume:
+                              description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                              properties:
+                                configMap:
+                                  description: ConfigMap represents a configMap that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                secret:
+                                  description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  properties:
+                                    defaultMode:
+                                      description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    optional:
+                                      description: Specify whether the Secret or its keys must be defined
+                                      type: boolean
+                                    secretName:
+                                      description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      type: string
+                                  type: object
+                              type: object
+                            volumeMount:
+                              description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  openshiftRoute:
+                    description: Route configures the Gateway ↔ OpenShift Route integration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                    type: object
+                type: object
+              general:
+                description: General represents general control plane configuration that does not logically fit in another area.
+                properties:
+                  logging:
+                    description: 'Logging represents the logging configuration for the control plane components XXX: Should this be separate from Proxy.Logging?'
+                    properties:
+                      componentLevels:
+                        additionalProperties:
+                          description: LogLevel represents the logging level
+                          type: string
+                        description: ComponentLevels configures log level for specific envoy components .Values.global.proxy.componentLogLevel, overridden by sidecar.istio.io/componentLogLevel map of <component>:<level>
+                        type: object
+                      logAsJSON:
+                        description: LogAsJSON enables JSON logging .Values.global.logAsJson
+                        type: boolean
+                    type: object
+                  validationMessages:
+                    description: ValidationMessages configures the control plane to add validationMessages to the status fields of istio.io resources.  This can be usefule for detecting configuration errors in resources. .Values.galley.enableAnalysis (<v2.0) .Values.global.istiod.enableAnalysis (>=v2.0)
+                    type: boolean
+                type: object
+              policy:
+                description: Policy configures policy checking for the control plane. .Values.policy.enabled, true if not null
+                properties:
+                  mixer:
+                    description: Mixer configuration (legacy, v1) .Values.mixer.policy.enabled
+                    properties:
+                      adapters:
+                        description: Adapters configures available adapters.
+                        properties:
+                          kubernetesenv:
+                            description: Kubernetesenv configures the use of the kubernetesenv adapter. .Values.mixer.policy.adapters.kubernetesenv.enabled, defaults to true
+                            type: boolean
+                          useAdapterCRDs:
+                            description: UseAdapterCRDs configures mixer to support deprecated mixer CRDs. .Values.mixer.policy.adapters.useAdapterCRDs, removed in istio 1.4, defaults to false Only supported in v1.0, where it defaulted to true
+                            type: boolean
+                        type: object
+                      enableChecks:
+                        description: EnableChecks configures whether or not policy checks should be enabled. .Values.global.disablePolicyChecks | default "true" (false, inverted logic) Set the following variable to false to disable policy checks by the Mixer. Note that metrics will still be reported to the Mixer.
+                        type: boolean
+                      failOpen:
+                        description: FailOpen configures policy checks to fail if mixer cannot be reached. .Values.global.policyCheckFailOpen, maps to MeshConfig.policyCheckFailOpen policyCheckFailOpen allows traffic in cases when the mixer policy service cannot be reached. Default is false which means the traffic is denied when the client is unable to connect to Mixer.
+                        type: boolean
+                      sessionAffinity:
+                        description: SessionAffinity configures session affinity for sidecar policy connections. .Values.mixer.policy.sessionAffinityEnabled
+                        type: boolean
+                    type: object
+                  remote:
+                    description: Remote mixer configuration (legacy, v1) .Values.global.remotePolicyAddress
+                    properties:
+                      address:
+                        description: Address represents the address of the mixer server. .Values.global.remotePolicyAddress, maps to MeshConfig.mixerCheckServer
+                        type: string
+                      createService:
+                        description: CreateServices specifies whether or not a k8s Service should be created for the remote policy server. .Values.global.createRemoteSvcEndpoints
+                        type: boolean
+                      enableChecks:
+                        description: EnableChecks configures whether or not policy checks should be enabled. .Values.global.disablePolicyChecks | default "true" (false, inverted logic) Set the following variable to false to disable policy checks by the Mixer. Note that metrics will still be reported to the Mixer.
+                        type: boolean
+                      failOpen:
+                        description: FailOpen configures policy checks to fail if mixer cannot be reached. .Values.global.policyCheckFailOpen, maps to MeshConfig.policyCheckFailOpen policyCheckFailOpen allows traffic in cases when the mixer policy service cannot be reached. Default is false which means the traffic is denied when the client is unable to connect to Mixer.
+                        type: boolean
+                    type: object
+                  type:
+                    description: Required, the policy implementation defaults to Istiod 1.6+, Mixer pre-1.6
+                    type: string
+                type: object
+              profiles:
+                description: Profiles selects the profile to use for default values. Defaults to "default" when not set.
+                items:
+                  type: string
+                type: array
+              proxy:
+                description: Proxy configures the default behavior for sidecars.  Many values were previously exposed through .Values.global.proxy
+                properties:
+                  accessLogging:
+                    description: AccessLogging configures access logging for proxies.
+                    properties:
+                      envoyService:
+                        description: File configures access logging to an envoy service .Values.global.proxy.envoyAccessLogService
+                        properties:
+                          address:
+                            description: Address of the service specified as host:port. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).host .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).port
+                            type: string
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          tcpKeepalive:
+                            description: TCPKeepalive configures keepalive settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tcpKeepalive
+                            properties:
+                              interval:
+                                description: Interval represents the interval between probes.
+                                type: string
+                              probes:
+                                description: Probes represents the number of successive probe failures after which the connection should be considered "dead."
+                                format: int32
+                                type: integer
+                              time:
+                                description: Time represents the length of idle time that must elapse before a probe is sent.
+                                type: string
+                            type: object
+                          tlsSettings:
+                            description: TLSSettings configures TLS settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tlsSettings
+                            properties:
+                              caCertificates:
+                                description: CACertificates represents the file name containing the root certificates for the CA, e.g. /etc/istio/als/root-cert.pem
+                                type: string
+                              clientCertificate:
+                                description: ClientCertificate represents the file name containing the client certificate to show to the Envoy service, e.g. /etc/istio/als/cert-chain.pem
+                                type: string
+                              mode:
+                                description: 'Mode represents the TLS mode to apply to the connection.  The following values are supported: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL'
+                                type: string
+                              privateKey:
+                                description: PrivateKey represents the file name containing the private key used by the client, e.g. /etc/istio/als/key.pem
+                                type: string
+                              sni:
+                                description: SNIHost represents the host name presented to the server during TLS handshake, e.g. als.somedomain
+                                type: string
+                              subjectAltNames:
+                                description: SubjectAltNames represents the list of alternative names that may be used to verify the servers identity, e.g. [als.someotherdomain]
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      file:
+                        description: File configures access logging to the file system
+                        properties:
+                          encoding:
+                            description: Encoding to use when writing access log entries.  Currently, JSON or TEXT may be specified. .Values.global.proxy.accessLogEncoding
+                            type: string
+                          format:
+                            description: Format to use when writing access log entries. .Values.global.proxy.accessLogFormat
+                            type: string
+                          name:
+                            description: Name is the name of the file to which access log entries will be written. If Name is not specified, no log entries will be written to a file. .Values.global.proxy.accessLogFile
+                            type: string
+                        type: object
+                    type: object
+                  adminPort:
+                    description: 'AdminPort configures the admin port exposed by the sidecar. maps to defaultConfig.proxyAdminPort, defaults to 15000 XXX: currently not configurable in charts'
+                    format: int32
+                    type: integer
+                  concurrency:
+                    description: 'Concurrency configures the number of threads that should be run by the sidecar. .Values.global.proxy.concurrency, maps to defaultConfig.concurrency XXX: removed in 1.7 XXX: this is defaulted to 2 in our values.yaml, but should probably be 0'
+                    format: int32
+                    type: integer
+                  envoyMetricsService:
+                    description: EnvoyMetricsService configures reporting of Envoy metrics to an external service. .Values.global.proxy.envoyMetricsService
+                    properties:
+                      address:
+                        description: Address of the service specified as host:port. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).host .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).port
+                        type: string
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      tcpKeepalive:
+                        description: TCPKeepalive configures keepalive settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tcpKeepalive
+                        properties:
+                          interval:
+                            description: Interval represents the interval between probes.
+                            type: string
+                          probes:
+                            description: Probes represents the number of successive probe failures after which the connection should be considered "dead."
+                            format: int32
+                            type: integer
+                          time:
+                            description: Time represents the length of idle time that must elapse before a probe is sent.
+                            type: string
+                        type: object
+                      tlsSettings:
+                        description: TLSSettings configures TLS settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tlsSettings
+                        properties:
+                          caCertificates:
+                            description: CACertificates represents the file name containing the root certificates for the CA, e.g. /etc/istio/als/root-cert.pem
+                            type: string
+                          clientCertificate:
+                            description: ClientCertificate represents the file name containing the client certificate to show to the Envoy service, e.g. /etc/istio/als/cert-chain.pem
+                            type: string
+                          mode:
+                            description: 'Mode represents the TLS mode to apply to the connection.  The following values are supported: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL'
+                            type: string
+                          privateKey:
+                            description: PrivateKey represents the file name containing the private key used by the client, e.g. /etc/istio/als/key.pem
+                            type: string
+                          sni:
+                            description: SNIHost represents the host name presented to the server during TLS handshake, e.g. als.somedomain
+                            type: string
+                          subjectAltNames:
+                            description: SubjectAltNames represents the list of alternative names that may be used to verify the servers identity, e.g. [als.someotherdomain]
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  injection:
+                    description: Injection is used to customize sidecar injection for the mesh.
+                    properties:
+                      alwaysInjectSelector:
+                        description: AlwaysInjectSelector allows specification of a label selector that when matched will always inject a sidecar into the pod. .Values.sidecarInjectorWebhook.alwaysInjectSelector
+                        items:
+                          description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
+                      autoInject:
+                        description: AutoInject configures automatic injection of sidecar proxies .Values.global.proxy.autoInject .Values.sidecarInjectorWebhook.enableNamespacesByDefault
+                        type: boolean
+                      injectedAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: InjectedAnnotations allows specification of additional annotations to be added to pods that have sidecars injected in them. .Values.sidecarInjectorWebhook.injectedAnnotations
+                        type: object
+                      neverInjectSelector:
+                        description: NeverInjectSelector allows specification of a label selector that when matched will never inject a sidecar into the pod.  This takes precendence over AlwaysInjectSelector. .Values.sidecarInjectorWebhook.neverInjectSelector
+                        items:
+                          description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  logging:
+                    description: Logging configures logging for the sidecar. e.g. .Values.global.proxy.logLevel
+                    properties:
+                      componentLevels:
+                        additionalProperties:
+                          description: LogLevel represents the logging level
+                          type: string
+                        description: ComponentLevels configures log level for specific envoy components .Values.global.proxy.componentLogLevel, overridden by sidecar.istio.io/componentLogLevel map of <component>:<level>
+                        type: object
+                      level:
+                        description: Level the log level .Values.global.proxy.logLevel, overridden by sidecar.istio.io/logLevel
+                        type: string
+                    type: object
+                  networking:
+                    description: Networking represents network settings to be configured for the sidecars.
+                    properties:
+                      clusterDomain:
+                        description: ClusterDomain represents the domain for the cluster, defaults to cluster.local .Values.global.proxy.clusterDomain
+                        type: string
+                      connectionTimeout:
+                        description: 'maps to meshConfig.defaultConfig.connectionTimeout, defaults to 10s XXX: currently not exposed through values.yaml'
+                        type: string
+                      dns:
+                        description: DNS configures aspects of the sidecar's usage of DNS
+                        properties:
+                          refreshRate:
+                            description: RefreshRate configures the DNS refresh rate for Envoy cluster of type STRICT_DNS This must be given it terms of seconds. For example, 300s is valid but 5m is invalid. .Values.global.proxy.dnsRefreshRate, default 300s
+                            type: string
+                          searchSuffixes:
+                            description: 'SearchSuffixes are additional search suffixes to be used when resolving names. .Values.global.podDNSSearchNamespaces Custom DNS config for the pod to resolve names of services in other clusters. Use this to add additional search domains, and other settings. see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#dns-config This does not apply to gateway pods as they typically need a different set of DNS settings than the normal application pods (e.g., in multicluster scenarios). NOTE: If using templates, follow the pattern in the commented example below.    podDNSSearchNamespaces:    - global    - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"'
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      initialization:
+                        description: Initialization is used to specify how the pod's networking through the proxy is initialized.  This configures the use of CNI or an init container.
+                        properties:
+                          initContainer:
+                            description: InitContainer configures the use of a pod init container for initializing the pod's networking. istio_cni.enabled = false, if InitContainer is used
+                            properties:
+                              runtime:
+                                description: Runtime configures customization of the init container (e.g. resources)
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    description: PullPolicy describes a policy for if/when to pull a container image
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    description: ResourceRequirements describes the compute resource requirements.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                type: object
+                            type: object
+                          type:
+                            description: Type of the network initialization implementation.
+                            type: string
+                        type: object
+                      maxConnectionAge:
+                        description: MaxConnectionAge limits how long a sidecar can be connected to pilot. This may be used to balance load across pilot instances, at the cost of system churn. .Values.pilot.keepaliveMaxServerConnectionAge
+                        type: string
+                      protocol:
+                        description: Protocol configures how the sidecar works with applicaiton protocols.
+                        properties:
+                          autoDetect:
+                            description: AutoDetect configures automatic detection of connection protocols.
+                            properties:
+                              inbound:
+                                description: EnableInboundSniffing enables protocol sniffing on inbound traffic. .Values.pilot.enableProtocolSniffingForInbound only supported for v1.1
+                                type: boolean
+                              outbound:
+                                description: EnableOutboundSniffing enables protocol sniffing on outbound traffic. .Values.pilot.enableProtocolSniffingForOutbound only supported for v1.1
+                                type: boolean
+                              timeout:
+                                description: DetectionTimeout specifies how much time the sidecar will spend determining the protocol being used for the connection before reverting to raw TCP. .Values.global.proxy.protocolDetectionTimeout, maps to protocolDetectionTimeout
+                                type: string
+                            type: object
+                        type: object
+                      trafficControl:
+                        description: TrafficControl configures what network traffic is routed through the proxy.
+                        properties:
+                          inbound:
+                            description: Inbound configures what inbound traffic is routed through the sidecar traffic.sidecar.istio.io/includeInboundPorts defaults to * (all ports)
+                            properties:
+                              excludedPorts:
+                                description: ExcludedPorts to be routed around the sidecar. .Values.global.proxy.excludeInboundPorts, defaults to empty list, overridden by traffic.sidecar.istio.io/excludeInboundPorts
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                              includedPorts:
+                                description: IncludedPorts to be routed through the sidecar. * or comma separated list of integers .Values.global.proxy.includeInboundPorts, defaults to * (all ports), overridden by traffic.sidecar.istio.io/includeInboundPorts
+                                items:
+                                  type: string
+                                type: array
+                              interceptionMode:
+                                description: 'InterceptionMode specifies how traffic is directed through the sidecar. maps to meshConfig.defaultConfig.interceptionMode, overridden by sidecar.istio.io/interceptionMode XXX: currently not configurable through values.yaml'
+                                type: string
+                            type: object
+                          outbound:
+                            description: Outbound configures what outbound traffic is routed through the sidecar.
+                            properties:
+                              excludedIPRanges:
+                                description: ExcludedIPRanges specifies which outbound IP ranges should _not_ be routed through the sidecar. .Values.global.proxy.excludeIPRanges, overridden by traffic.sidecar.istio.io/excludeOutboundIPRanges * or comma separated list of CIDR
+                                items:
+                                  type: string
+                                type: array
+                              excludedPorts:
+                                description: ExcludedPorts specifies which outbound ports should _not_ be routed through the sidecar. .Values.global.proxy.excludeOutboundPorts, overridden by traffic.sidecar.istio.io/excludeOutboundPorts comma separated list of integers
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                              includedIPRanges:
+                                description: IncludedIPRanges specifies which outbound IP ranges should be routed through the sidecar. .Values.global.proxy.includeIPRanges, overridden by traffic.sidecar.istio.io/includeOutboundIPRanges * or comma separated list of CIDR
+                                items:
+                                  type: string
+                                type: array
+                              policy:
+                                description: Policy specifies what outbound traffic is allowed through the sidecar. .Values.global.outboundTrafficPolicy.mode
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  runtime:
+                    description: Runtime is used to customize runtime configuration for the sidecar container.
+                    properties:
+                      container:
+                        description: Container configures the sidecar container.
+                        properties:
+                          env:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          imageName:
+                            type: string
+                          imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when to pull a container image
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                              type: object
+                            type: array
+                          imageRegistry:
+                            type: string
+                          imageTag:
+                            type: string
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        type: object
+                      readiness:
+                        description: Readiness configures the readiness probe behavior for the injected pod.
+                        properties:
+                          failureThreshold:
+                            description: FailureThreshold represents the number of consecutive failures before the container is marked as not ready. .Values.global.proxy.readinessFailureThreshold, overridden by readiness.status.sidecar.istio.io/failureThreshold, defaults to 30
+                            format: int32
+                            type: integer
+                          initialDelaySeconds:
+                            description: InitialDelaySeconds specifies the initial delay for the readiness probe .Values.global.proxy.readinessInitialDelaySeconds, overridden by readiness.status.sidecar.istio.io/initialDelaySeconds, defaults to 1
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: PeriodSeconds specifies the period over which the probe is checked. .Values.global.proxy.readinessPeriodSeconds, overridden by readiness.status.sidecar.istio.io/periodSeconds, defaults to 2
+                            format: int32
+                            type: integer
+                          rewriteApplicationProbes:
+                            description: RewriteApplicationProbes specifies whether or not the injector should rewrite application container probes to be routed through the sidecar. .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe, defaults to false rewrite probes for application pods to route through sidecar
+                            type: boolean
+                          statusPort:
+                            description: 'StatusPort specifies the port number to be used for status. .Values.global.proxy.statusPort, overridden by status.sidecar.istio.io/port, defaults to 15020 Default port for Pilot agent health checks. A value of 0 will disable health checking. XXX: this has no affect on which port is actually used for status.'
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              runtime:
+                description: Runtime configuration for pilot (and galley, etc., pre 2.0)
+                properties:
+                  components:
+                    additionalProperties:
+                      description: ComponentRuntimeConfig allows for partial customization of a component's runtime configuration (Deployment, PodTemplate, auto scaling, pod disruption, etc.)
+                      properties:
+                        container:
+                          description: .Values.*.resource, imagePullPolicy, etc.
+                          properties:
+                            env:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            imageName:
+                              type: string
+                            imagePullPolicy:
+                              description: PullPolicy describes a policy for if/when to pull a container image
+                              type: string
+                            imagePullSecrets:
+                              items:
+                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                type: object
+                              type: array
+                            imageRegistry:
+                              type: string
+                            imageTag:
+                              type: string
+                            resources:
+                              description: ResourceRequirements describes the compute resource requirements.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                          type: object
+                        deployment:
+                          description: Deployment specific overrides
+                          properties:
+                            autoScaling:
+                              description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                              properties:
+                                enabled:
+                                  description: Enabled specifies whether or not this feature is enabled
+                                  type: boolean
+                                maxReplicas:
+                                  description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                  format: int32
+                                  type: integer
+                                minReplicas:
+                                  description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                  format: int32
+                                  type: integer
+                                targetCPUUtilizationPercentage:
+                                  description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                  format: int32
+                                  type: integer
+                              type: object
+                            replicas:
+                              description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                              format: int32
+                              type: integer
+                            strategy:
+                              description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                              properties:
+                                rollingUpdate:
+                                  properties:
+                                    maxSurge:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                      x-kubernetes-int-or-string: true
+                                    maxUnavailable:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                type:
+                                  description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                  type: string
+                              type: object
+                          type: object
+                        pod:
+                          description: Pod specific overrides
+                          properties:
+                            affinity:
+                              description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                              properties:
+                                podAntiAffinity:
+                                  description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                  properties:
+                                    preferredDuringScheduling:
+                                      items:
+                                        description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          topologyKey:
+                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    requiredDuringScheduling:
+                                      items:
+                                        description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          topologyKey:
+                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            metadata:
+                              description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                              type: object
+                            priorityClassName:
+                              description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                              type: string
+                            tolerations:
+                              description: If specified, the pod's tolerations. .Values.tolerations
+                              items:
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    description: Components allows specifying execution parameters for specific control plane componets.  The key of the map is the component name to which the settings should be applied.
+                    type: object
+                  defaults:
+                    description: Defaults will be merged into specific component config. .Values.global.defaultResources, e.g.
+                    properties:
+                      container:
+                        description: Container overrides to be merged with component specific overrides.
+                        properties:
+                          imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when to pull a container image
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                              type: object
+                            type: array
+                          imageRegistry:
+                            type: string
+                          imageTag:
+                            type: string
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        type: object
+                      deployment:
+                        description: Deployment defaults
+                        properties:
+                          podDisruption:
+                            description: '.Values.global.podDisruptionBudget.enabled, if not null XXX: this is currently a global setting, not per component.  perhaps this should only be available on the defaults?'
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              minAvailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      pod:
+                        description: Pod defaults
+                        properties:
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                            type: object
+                          priorityClassName:
+                            description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                            type: string
+                          tolerations:
+                            description: If specified, the pod's tolerations. .Values.tolerations
+                            items:
+                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              security:
+                description: Security configures aspects of security for the control plane.
+                properties:
+                  certificateAuthority:
+                    description: CertificateAuthority configures the certificate authority used by the control plane to create and sign client certs and server keys.
+                    properties:
+                      custom:
+                        description: Custom is the configuration for a custom certificate authority.
+                        properties:
+                          address:
+                            description: 'Address is the grpc address for an Istio compatible certificate authority endpoint. .Values.global.caAddress XXX: assumption is this is a grpc endpoint that provides methods like istio.v1.auth.IstioCertificateService/CreateCertificate'
+                            type: string
+                        type: object
+                      istiod:
+                        description: Istiod is the configuration for Istio's internal certificate authority implementation. each of these produces a CAEndpoint, i.e. CA_ADDR
+                        properties:
+                          privateKey:
+                            description: PrivateKey configures istiod to use a user specified private key/cert when signing certificates.
+                            properties:
+                              rootCADir:
+                                description: 'hard coded to use a secret named cacerts EncryptionSecret string `json:"encryptionSecret,omitempty"` ROOT_CA_DIR, defaults to /etc/cacerts Mount directory for encryption secret XXX: currently, not configurable in the charts'
+                                type: string
+                            type: object
+                          selfSigned:
+                            description: SelfSigned configures istiod to generate and use a self-signed certificate for the root.
+                            properties:
+                              checkPeriod:
+                                description: CheckPeriod is the interval with which certificate is checked for rotation env CITADEL_SELF_SIGNED_ROOT_CERT_CHECK_INTERVAL default is 1 hour, zero or negative value disables cert rotation
+                                type: string
+                              enableJitter:
+                                description: EnableJitter to use jitter for cert rotation env CITADEL_ENABLE_JITTER_FOR_ROOT_CERT_ROTATOR defaults to true
+                                type: boolean
+                              gracePeriod:
+                                description: GracePeriod percentile for self-signed cert env CITADEL_SELF_SIGNED_ROOT_CERT_GRACE_PERIOD_PERCENTILE default is 20%
+                                type: string
+                              ttl:
+                                description: TTL for self-signed root certificate env CITADEL_SELF_SIGNED_CA_CERT_TTL default is 10 years
+                                type: string
+                            type: object
+                          type:
+                            description: Type of certificate signer to use.
+                            type: string
+                          workloadCertTTLDefault:
+                            description: WorkloadCertTTLDefault is the default TTL for generated workload certificates.  Used if not specified in CSR (<= 0) env DEFAULT_WORKLOAD_CERT_TTL, 1.6 --workload-cert-ttl, citadel, pre-1.6 defaults to 24 hours
+                            type: string
+                          workloadCertTTLMax:
+                            description: WorkloadCertTTLMax is the maximum TTL for generated workload certificates. env MAX_WORKLOAD_CERT_TTL --max-workload-cert-ttl, citadel, pre-1.6 defaults to 90 days
+                            type: string
+                        type: object
+                      type:
+                        description: Type is the certificate authority to use.
+                        type: string
+                    type: object
+                  controlPlane:
+                    description: ControlPlane configures mutual TLS for control plane communication.
+                    properties:
+                      certProvider:
+                        description: CertProvider is the certificate authority used to generate the serving certificates for the control plane components. .Values.global.pilotCertProvider Provider used to generate serving certs for istiod (pilot)
+                        type: string
+                      mtls:
+                        description: Enable mutual TLS for the control plane components. .Values.global.controlPlaneSecurityEnabled
+                        type: boolean
+                      tls:
+                        description: TLS configures aspects of TLS listeners created by control plane components.
+                        properties:
+                          cipherSuites:
+                            description: CipherSuites configures the cipher suites that are available for use by TLS listeners. .Values.global.tls.cipherSuites
+                            items:
+                              type: string
+                            type: array
+                          ecdhCurves:
+                            description: ECDHCurves configures the ECDH curves that are available for use by TLS listeners. .Values.global.tls.ecdhCurves
+                            items:
+                              type: string
+                            type: array
+                          maxProtocolVersion:
+                            description: MaxProtocolVersion the maximum TLS version that should be supported by the listeners. .Values.global.tls.maxProtocolVersion
+                            type: string
+                          minProtocolVersion:
+                            description: MinProtocolVersion the minimum TLS version that should be supported by the listeners. .Values.global.tls.minProtocolVersion
+                            type: string
+                        type: object
+                    type: object
+                  dataPlane:
+                    description: DataPlane configures mutual TLS for data plane communication.
+                    properties:
+                      automtls:
+                        description: Auto configures the mesh to automatically detect whether or not mutual TLS is required for a specific connection. .Values.global.mtls.auto
+                        type: boolean
+                      mtls:
+                        description: Enable mutual TLS by default. .Values.global.mtls.enabled
+                        type: boolean
+                    type: object
+                  identity:
+                    description: Identity configures the types of user tokens used by clients.
+                    properties:
+                      thirdParty:
+                        description: 'ThirdParty configures istiod to use a third-party token provider for identifying users. (basically uses a custom audience, e.g. istio-ca) XXX: this is only supported on OCP 4.4+'
+                        properties:
+                          audience:
+                            description: Audience is the audience for whom the token is intended. env AUDIENCE .Values.global.sds.token.aud, defaults to istio-ca
+                            type: string
+                          issuer:
+                            description: Issuer is the URL of the issuer. env TOKEN_ISSUER, defaults to iss in specified token only supported in 1.6+
+                            type: string
+                        type: object
+                      type:
+                        description: Type is the type of identity tokens being used. .Values.global.jwtPolicy
+                        type: string
+                    type: object
+                  trust:
+                    description: Trust configures trust aspects associated with mutual TLS clients.
+                    properties:
+                      additionalDomains:
+                        description: AdditionalDomains are additional SPIFFE trust domains that are accepted as trusted. .Values.global.trustDomainAliases, maps to trustDomainAliases  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+                        items:
+                          type: string
+                        type: array
+                      domain:
+                        description: Domain specifies the trust domain to be used by the mesh. .Values.global.trustDomain, maps to trustDomain The trust domain corresponds to the trust root of a system. Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
+                        type: string
+                    type: object
+                type: object
+              techPreview:
+                description: TechPreview contains switches for features that are not GA yet.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              telemetry:
+                description: Telemetry configures telemetry for the mesh. .Values.mixer.telemetry.enabled, true if not null.  1.6, .Values.telemetry.enabled
+                properties:
+                  mixer:
+                    description: Mixer represents legacy, v1 telemetry. implies .Values.telemetry.v1.enabled, if not null
+                    properties:
+                      adapters:
+                        description: Adapters configures the adapters used by mixer telemetry.
+                        properties:
+                          kubernetesenv:
+                            description: KubernetesEnv enables support for the kubernetesenv adapter. .Values.mixer.adapters.kubernetesenv.enabled, defaults to true
+                            type: boolean
+                          stdio:
+                            description: Stdio enables and configures the stdio adapter.
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              outputAsJSON:
+                                description: OutputAsJSON if true. .Values.mixer.adapters.stdio.outputAsJson, defaults to false
+                                type: boolean
+                            type: object
+                          useAdapterCRDs:
+                            description: 'UseAdapterCRDs specifies whether or not mixer should support deprecated CRDs. .Values.mixer.adapters.useAdapterCRDs, removed in istio 1.4, defaults to false XXX: i think this can be removed completely'
+                            type: boolean
+                        type: object
+                      batching:
+                        description: Batching settings used when sending telemetry.
+                        properties:
+                          maxEntries:
+                            description: MaxEntries represents the maximum number of entries to collect before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxEntries, maps to MeshConfig.reportBatchMaxEntries Set reportBatchMaxEntries to 0 to use the default batching behavior (i.e., every 100 requests). A positive value indicates the number of requests that are batched before telemetry data is sent to the mixer server
+                            format: int32
+                            type: integer
+                          maxTime:
+                            description: MaxTime represents the maximum amount of time to hold entries before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxTime, maps to MeshConfig.reportBatchMaxTime Set reportBatchMaxTime to 0 to use the default batching behavior (i.e., every 1 second). A positive time value indicates the maximum wait time since the last request will telemetry data be batched before being sent to the mixer server
+                            type: string
+                        type: object
+                      loadshedding:
+                        description: Loadshedding configuration for telemetry .Values.mixer.telemetry.loadshedding
+                        properties:
+                          latencyThreshold:
+                            description: LatencyThreshold -- .Values.mixer.telemetry.loadshedding.latencyThreshold
+                            type: string
+                          mode:
+                            description: 'Mode represents the loadshedding mode applied to mixer when it becomes overloaded.  Valid values: disabled, logonly or enforce .Values.mixer.telemetry.loadshedding.mode'
+                            type: string
+                        type: object
+                      sessionAffinity:
+                        description: SessionAffinity configures session affinity for sidecar telemetry connections. .Values.mixer.telemetry.sessionAffinityEnabled, maps to MeshConfig.sidecarToTelemetrySessionAffinity
+                        type: boolean
+                    type: object
+                  remote:
+                    description: Remote represents a remote, legacy, v1 telemetry.
+                    properties:
+                      address:
+                        description: Address is the address of the remote telemetry server .Values.global.remoteTelemetryAddress, maps to MeshConfig.mixerReportServer
+                        type: string
+                      batching:
+                        description: Batching settings used when sending telemetry.
+                        properties:
+                          maxEntries:
+                            description: MaxEntries represents the maximum number of entries to collect before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxEntries, maps to MeshConfig.reportBatchMaxEntries Set reportBatchMaxEntries to 0 to use the default batching behavior (i.e., every 100 requests). A positive value indicates the number of requests that are batched before telemetry data is sent to the mixer server
+                            format: int32
+                            type: integer
+                          maxTime:
+                            description: MaxTime represents the maximum amount of time to hold entries before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxTime, maps to MeshConfig.reportBatchMaxTime Set reportBatchMaxTime to 0 to use the default batching behavior (i.e., every 1 second). A positive time value indicates the maximum wait time since the last request will telemetry data be batched before being sent to the mixer server
+                            type: string
+                        type: object
+                      createService:
+                        description: CreateService for the remote server. .Values.global.createRemoteSvcEndpoints
+                        type: boolean
+                    type: object
+                  type:
+                    description: Type of telemetry implementation to use.
+                    type: string
+                type: object
+              tracing:
+                description: Tracing configures tracing for the mesh.
+                properties:
+                  sampling:
+                    description: 'Sampling sets the mesh-wide trace sampling percentage. Should be between 0.0 - 100.0. Precision to 0.01, scaled as 0 to 10000, e.g.: 100% = 10000, 1% = 100 .Values.pilot.traceSampling'
+                    format: int32
+                    maximum: 10000
+                    minimum: 0
+                    type: integer
+                  type:
+                    description: Type represents the type of tracer to be installed.
+                    type: string
+                type: object
+              version:
+                description: Version specifies what Maistra version of the control plane to install. When creating a new ServiceMeshControlPlane with an empty version, the admission webhook sets the version to the current version. Existing ServiceMeshControlPlanes with an empty version are treated as having the version set to "v1.0"
+                type: string
+            type: object
+          status:
+            description: The current status of this ServiceMeshControlPlane and the components that comprise the control plane. This data may be out of date by some window of time.
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations is an unstructured key value map used to store additional, usually redundant status information, such as the number of components deployed by the ServiceMeshControlPlane (number is redundant because you could just as easily count the elements in the ComponentStatus array). The reason to add this redundant information is to make it available to kubectl, which does not yet allow counting objects in JSONPath expressions.
+                type: object
+              appliedSpec:
+                description: The resulting specification of the configuration options after all profiles have been applied.
+                properties:
+                  addons:
+                    description: Addons is used to configure additional features beyond core control plane components, e.g. visualization, metric storage, etc.
+                    properties:
+                      3scale:
+                        description: ThreeScale configures the 3scale adapter
+                        properties:
+                          backend:
+                            description: Backend configures backend specific details
+                            properties:
+                              cache_flush_interval:
+                                description: CacheFlushInterval sets the interval at which metrics get reported from the cache to 3scale PARAM_THREESCALE_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS
+                                format: int32
+                                type: integer
+                              enable_cache:
+                                description: EnableCache if true, attempts to create an in-memory apisonator cache for authorization requests PARAM_THREESCALE_USE_CACHED_BACKEND
+                                type: boolean
+                              policy_fail_closed:
+                                description: PolicyFailClosed if true, request will fail if 3scale Apisonator is unreachable PARAM_THREESCALE_BACKEND_CACHE_POLICY_FAIL_CLOSED
+                                type: boolean
+                            type: object
+                          client:
+                            description: Client configures client specific details
+                            properties:
+                              allow_insecure_connections:
+                                description: AllowInsecureConnections skips certificate verification when calling 3scale API's. Enabling is not recommended PARAM_THREESCALE_ALLOW_INSECURE_CONN
+                                type: boolean
+                              timeout:
+                                description: Timeout sets the number of seconds to wait before terminating requests to 3scale System and Backend PARAM_THREESCALE_CLIENT_TIMEOUT_SECONDS
+                                format: int32
+                                type: integer
+                            type: object
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          grpc:
+                            description: GRPC configures gRPC specific details
+                            properties:
+                              max_conn_timeout:
+                                description: MaxConnTimeout sets the maximum amount of seconds (+/-10% jitter) a connection may exist before it will be closed PARAM_THREESCALE_GRPC_CONN_MAX_SECONDS
+                                format: int32
+                                type: integer
+                            type: object
+                          listen_addr:
+                            description: ListenerAddr sets the listen address for the gRPC server. PARAM_THREESCALE_LISTEN_ADDR
+                            format: int32
+                            type: integer
+                          log_grpc:
+                            description: LogGRPC controls whether the log includes gRPC info PARAM_THREESCALE_LOG_GRPC
+                            type: boolean
+                          log_json:
+                            description: LogJSON controls whether the log is formatted as JSON PARAM_THREESCALE_LOG_JSON
+                            type: boolean
+                          log_level:
+                            description: 'LogLevel sets the minimum log output level. Accepted values are one of: debug, info, warn, error, none PARAM_THREESCALE_LOG_LEVEL'
+                            type: string
+                          metrics:
+                            description: Metrics configures metrics specific details
+                            properties:
+                              port:
+                                description: Port sets the port which 3scale /metrics endpoint can be scrapped from PARAM_THREESCALE_METRICS_PORT
+                                format: int32
+                                type: integer
+                              report:
+                                description: Report controls whether 3scale system and backend metrics are collected and reported to Prometheus PARAM_THREESCALE_REPORT_METRICS
+                                type: boolean
+                            type: object
+                          system:
+                            description: System configures system specific details
+                            properties:
+                              cache_max_size:
+                                description: CacheMaxSize is the max number of items that can be stored in the cache at any time. Set to 0 to disable caching PARAM_THREESCALE_CACHE_ENTRIES_MAX
+                                format: int64
+                                type: integer
+                              cache_refresh_interval:
+                                description: CacheRefreshInterval is the time period in seconds, before a background process attempts to refresh cached entries PARAM_THREESCALE_CACHE_REFRESH_SECONDS
+                                format: int32
+                                type: integer
+                              cache_refresh_retries:
+                                description: CacheRefreshRetries sets the number of times unreachable hosts will be retried during a cache update loop PARAM_THREESCALE_CACHE_REFRESH_RETRIES
+                                format: int32
+                                type: integer
+                              cache_ttl:
+                                description: CacheTTL is the time period, in seconds, to wait before purging expired items from the cache PARAM_THREESCALE_CACHE_TTL_SECONDS
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      grafana:
+                        description: Grafana configures a grafana instance to use with the mesh .Values.grafana.enabled, true if not null
+                        properties:
+                          address:
+                            description: Address is the address of an existing grafana installation implies .Values.kiali.dashboard.grafanaURL
+                            type: string
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          install:
+                            description: Install a new grafana instance and manage with control plane
+                            properties:
+                              config:
+                                description: Config configures the behavior of the grafana installation
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'Env allows specification of various grafana environment variables to be configured on the grafana container. .Values.grafana.env XXX: This is pretty cheesy...'
+                                    type: object
+                                  envSecrets:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'EnvSecrets allows specification of secret fields into grafana environment variables to be configured on the grafana container .Values.grafana.envSecrets XXX: This is pretty cheesy...'
+                                    type: object
+                                type: object
+                              persistence:
+                                description: 'Persistence configures a PersistentVolume associated with the grafana installation .Values.grafana.persist, true if not null XXX: capacity is not supported in the charts, hard coded to 5Gi'
+                                properties:
+                                  accessMode:
+                                    description: AccessMode for the PersistentVolumeClaim
+                                    type: string
+                                  capacity:
+                                    description: Resources to request for the PersistentVolumeClaim
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  storageClassName:
+                                    description: StorageClassName for the PersistentVolumeClaim
+                                    type: string
+                                type: object
+                              security:
+                                description: 'Security is used to secure the grafana service. .Values.grafana.security.enabled, true if not null XXX: unused for maistra, as we use oauth-proxy'
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  passphraseKey:
+                                    description: PassphraseKey is the name of the key within the secret identifying the password.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of a secret containing the username/password that should be used to access grafana.
+                                    type: string
+                                  usernameKey:
+                                    description: UsernameKey is the name of the key within the secret identifying the username.
+                                    type: string
+                                type: object
+                              selfManaged:
+                                description: SelfManaged, true if the entire install should be managed by Maistra, false if using grafana CR (not supported)
+                                type: boolean
+                              service:
+                                description: 'Service configures the k8s Service associated with the grafana installation XXX: grafana service config does not follow other addon components'' structure'
+                                properties:
+                                  ingress:
+                                    description: Ingress specifies details for accessing the component's service through a k8s Ingress or OpenShift Route.
+                                    properties:
+                                      contextPath:
+                                        description: ContextPath represents the context path to the service.
+                                        type: string
+                                      enabled:
+                                        description: Enabled specifies whether or not this feature is enabled
+                                        type: boolean
+                                      hosts:
+                                        description: 'Hosts represents a list of host names to configure.  Note, OpenShift route only supports a single host name per route.  An empty host name implies a default host name for the Route. XXX: is a host name required for k8s Ingress?'
+                                        items:
+                                          type: string
+                                        type: array
+                                      metadata:
+                                        description: Metadata represents additional metadata to be applied to the ingress/route.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      tls:
+                                        description: 'TLS is used to configure TLS for the Ingress/Route XXX: should this be something like RawExtension, as the configuration differs between Route and Ingress?'
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  metadata:
+                                    description: Metadata represents addtional annotations/labels to be applied to the component's service.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodePort:
+                                    description: NodePort specifies a NodePort for the component's Service. .Values.<component>.service.nodePort.port, ...enabled is true if not null
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                        type: object
+                      jaeger:
+                        description: Jaeger configures Jaeger specific addon capabilities
+                        properties:
+                          install:
+                            description: Install configures a Jaeger installation, which will be created if the named Jaeger resource is not present.  If null, the named Jaeger resource must exist.
+                            properties:
+                              ingress:
+                                description: Ingress configures k8s Ingress or OpenShift Route for Jaeger services .Values.tracing.jaeger.ingress.enabled, false if null
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  metadata:
+                                    description: Metadata represents addtional annotations/labels to be applied to the ingress/route.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              storage:
+                                description: Config represents the configuration of Jaeger behavior.
+                                properties:
+                                  elasticsearch:
+                                    description: Elasticsearch represents configuration of elasticsearch storage implies .Values.tracing.jaeger.template=production-elasticsearch
+                                    properties:
+                                      indexCleaner:
+                                        description: 'IndexCleaner represents the configuration for the elasticsearch index cleaner .Values.tracing.jaeger.elasticsearch.esIndexCleaner, raw yaml XXX: RawExtension?'
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      nodeCount:
+                                        description: NodeCount represents the number of elasticsearch nodes to create. .Values.tracing.jaeger.elasticsearch.nodeCount, defaults to 3
+                                        format: int32
+                                        type: integer
+                                      redundancyPolicy:
+                                        description: RedundancyPolicy configures the redundancy policy for elasticsearch .Values.tracing.jaeger.elasticsearch.redundancyPolicy, raw yaml
+                                        type: string
+                                      storage:
+                                        description: 'Storage represents storage configuration for elasticsearch. .Values.tracing.jaeger.elasticsearch.storage, raw yaml XXX: RawExtension?'
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  memory:
+                                    description: Memory represents configuration of in-memory storage implies .Values.tracing.jaeger.template=all-in-one
+                                    properties:
+                                      maxTraces:
+                                        description: MaxTraces to store .Values.tracing.jaeger.memory.max_traces, defaults to 100000
+                                        format: int64
+                                        type: integer
+                                    type: object
+                                  type:
+                                    description: Type of storage to use
+                                    type: string
+                                type: object
+                            type: object
+                          name:
+                            description: Name of Jaeger CR, Namespace must match control plane namespace
+                            type: string
+                        type: object
+                      kiali:
+                        description: Kiali configures a kiali instance to use with the mesh .Values.kiali.enabled, true if not null
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          install:
+                            description: Install a Kiali resource if the named Kiali resource is not present.
+                            properties:
+                              dashboard:
+                                description: Dashboard configures the behavior of the kiali dashboard.
+                                properties:
+                                  enableGrafana:
+                                    description: 'XXX: should the user have a choice here, or should these be configured automatically if they are enabled for the control plane installation? Grafana endpoint will be configured based on Grafana configuration'
+                                    type: boolean
+                                  enablePrometheus:
+                                    description: Prometheus endpoint will be configured based on Prometheus configuration
+                                    type: boolean
+                                  enableTracing:
+                                    description: Tracing endpoint will be configured based on Tracing configuration
+                                    type: boolean
+                                  viewOnly:
+                                    description: ViewOnly configures view_only_mode for the dashboard .Values.kiali.dashboard.viewOnlyMode
+                                    type: boolean
+                                type: object
+                              service:
+                                description: 'Service is used to configure the k8s Service associated with the kiali installation. XXX: provided for upstream support, only ingress is used, and then only for enablement and contextPath'
+                                properties:
+                                  ingress:
+                                    description: Ingress specifies details for accessing the component's service through a k8s Ingress or OpenShift Route.
+                                    properties:
+                                      contextPath:
+                                        description: ContextPath represents the context path to the service.
+                                        type: string
+                                      enabled:
+                                        description: Enabled specifies whether or not this feature is enabled
+                                        type: boolean
+                                      hosts:
+                                        description: 'Hosts represents a list of host names to configure.  Note, OpenShift route only supports a single host name per route.  An empty host name implies a default host name for the Route. XXX: is a host name required for k8s Ingress?'
+                                        items:
+                                          type: string
+                                        type: array
+                                      metadata:
+                                        description: Metadata represents additional metadata to be applied to the ingress/route.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      tls:
+                                        description: 'TLS is used to configure TLS for the Ingress/Route XXX: should this be something like RawExtension, as the configuration differs between Route and Ingress?'
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  metadata:
+                                    description: Metadata represents addtional annotations/labels to be applied to the component's service.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodePort:
+                                    description: NodePort specifies a NodePort for the component's Service. .Values.<component>.service.nodePort.port, ...enabled is true if not null
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          name:
+                            description: Name of Kiali CR, Namespace must match control plane namespace
+                            type: string
+                        type: object
+                      prometheus:
+                        description: Prometheus configures Prometheus specific addon capabilities
+                        properties:
+                          address:
+                            description: 'Address of existing prometheus installation implies .Values.kiali.prometheusAddr XXX: do we need to do anything to configure credentials for accessing the prometheus server?'
+                            type: string
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          install:
+                            description: Install configuration if not using an existing prometheus installation. .Values.prometheus.enabled, if not null
+                            properties:
+                              retention:
+                                description: Retention specifies how long metrics should be retained by prometheus. .Values.prometheus.retention, defaults to 6h
+                                type: string
+                              scrapeInterval:
+                                description: ScrapeInterval specifies how frequently prometheus should scrape pods for metrics. .Values.prometheus.scrapeInterval, defaults to 15s
+                                type: string
+                              selfManaged:
+                                description: SelfManaged specifies whether or not the entire install should be managed by Maistra (true) or the Prometheus operator (false, not supported). Governs use of either prometheus charts or prometheusOperator charts.
+                                type: boolean
+                              service:
+                                description: Service allows for customization of the k8s Service associated with the prometheus installation.
+                                properties:
+                                  ingress:
+                                    description: Ingress specifies details for accessing the component's service through a k8s Ingress or OpenShift Route.
+                                    properties:
+                                      contextPath:
+                                        description: ContextPath represents the context path to the service.
+                                        type: string
+                                      enabled:
+                                        description: Enabled specifies whether or not this feature is enabled
+                                        type: boolean
+                                      hosts:
+                                        description: 'Hosts represents a list of host names to configure.  Note, OpenShift route only supports a single host name per route.  An empty host name implies a default host name for the Route. XXX: is a host name required for k8s Ingress?'
+                                        items:
+                                          type: string
+                                        type: array
+                                      metadata:
+                                        description: Metadata represents additional metadata to be applied to the ingress/route.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      tls:
+                                        description: 'TLS is used to configure TLS for the Ingress/Route XXX: should this be something like RawExtension, as the configuration differs between Route and Ingress?'
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  metadata:
+                                    description: Metadata represents addtional annotations/labels to be applied to the component's service.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodePort:
+                                    description: NodePort specifies a NodePort for the component's Service. .Values.<component>.service.nodePort.port, ...enabled is true if not null
+                                    format: int32
+                                    type: integer
+                                type: object
+                              useTLS:
+                                description: UseTLS for the prometheus server .Values.prometheus.provisionPrometheusCert 1.6+ ProvisionCert bool this seems to overlap with provision cert, as this manifests something similar to the above .Values.prometheus.security.enabled, version < 1.6 EnableSecurity bool
+                                type: boolean
+                            type: object
+                          metricsExpiryDuration:
+                            description: MetricsExpiryDuration is the duration to hold metrics. (mixer/v1 only) .Values.mixer.adapters.prometheus.metricsExpiryDuration, defaults to 10m
+                            type: string
+                          scrape:
+                            description: Scrape metrics from the pod if true. (maistra-2.0+) defaults to true .Values.meshConfig.enablePrometheusMerge
+                            type: boolean
+                        type: object
+                      stackdriver:
+                        description: Stackdriver configures Stackdriver specific addon capabilities
+                        properties:
+                          telemetry:
+                            description: Configuration for Stackdriver telemetry plugins.  Applies when telemetry is enabled
+                            properties:
+                              accessLogging:
+                                description: DisableOutbound disables intallation of sidecar outbound filter .Values.telemetry.v2.stackdriver.disableOutbound, defaults to false DisableOutbound bool `json:"disableOutbound,omitempty"` AccessLogging configures access logging for stackdriver
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  logWindowDuration:
+                                    description: LogWindowDuration configures the log window duration for access logs. defaults to 43200s To reduce the number of successful logs, default log window duration is set to 12 hours. .Values.telemetry.v2.accessLogPolicy.logWindowDuration
+                                    type: string
+                                type: object
+                              auth:
+                                description: Auth configuration for stackdriver adapter (mixer/v1 telemetry only) .Values.mixer.adapters.stackdriver.auth
+                                properties:
+                                  apiKey:
+                                    description: APIKey use the specified key. .Values.mixer.adapters.stackdriver.auth.apiKey
+                                    type: string
+                                  appCredentials:
+                                    description: AppCredentials if true, use default app credentials. .Values.mixer.adapters.stackdriver.auth.appCredentials, defaults to false
+                                    type: boolean
+                                  serviceAccountPath:
+                                    description: ServiceAccountPath use the path to the service account. .Values.mixer.adapters.stackdriver.auth.serviceAccountPath
+                                    type: string
+                                type: object
+                              configOverride:
+                                description: ConfigOverride apply custom configuration to Stackdriver filters (v2 telemetry only) .Values.telemetry.v2.stackdriver.configOverride
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              enableContextGraph:
+                                description: EnableContextGraph for stackdriver adapter (edge reporting) .Values.mixer.adapters.stackdriver.contextGraph.enabled, defaults to false .Values.telemetry.v2.stackdriver.topology, defaults to false
+                                type: boolean
+                              enableLogging:
+                                description: EnableLogging for stackdriver adapter .Values.mixer.adapters.stackdriver.logging.enabled, defaults to true .Values.telemetry.v2.stackdriver.logging, defaults to false
+                                type: boolean
+                              enableMetrics:
+                                description: EnableMetrics for stackdriver adapter .Values.mixer.adapters.stackdriver.metrics.enabled, defaults to true .Values.telemetry.v2.stackdriver.monitoring??? defaults to false
+                                type: boolean
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                            type: object
+                          tracer:
+                            description: Configuration for Stackdriver tracer.  Applies when Addons.Tracer.Type=Stackdriver
+                            properties:
+                              debug:
+                                description: .Values.global.tracer.stackdriver.debug
+                                type: boolean
+                              maxNumberOfAnnotations:
+                                description: .Values.global.tracer.stackdriver.maxNumberOfAnnotations
+                                format: int64
+                                type: integer
+                              maxNumberOfAttributes:
+                                description: .Values.global.tracer.stackdriver.maxNumberOfAttributes
+                                format: int64
+                                type: integer
+                              maxNumberOfMessageEvents:
+                                description: .Values.global.tracer.stackdriver.maxNumberOfMessageEvents
+                                format: int64
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  cluster:
+                    description: Cluster is the general configuration of the cluster (cluster name, network name, multi-cluster, mesh expansion, etc.)
+                    properties:
+                      meshExpansion:
+                        description: '.Values.global.meshExpansion.enabled, if not null XXX: it''s not clear whether or not there is any overlap with MultiCluster, i.e. does MultiCluster require mesh expansion ports to be configured on the ingress gateway?'
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          ilbGateway:
+                            description: .Values.global.meshExpansion.useILB, true if not null, otherwise uses ingress gateway
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              namespace:
+                                description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                                type: string
+                              routerMode:
+                                description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                                type: string
+                              runtime:
+                                description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                                properties:
+                                  container:
+                                    description: .Values.*.resource, imagePullPolicy, etc.
+                                    properties:
+                                      env:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      imageName:
+                                        type: string
+                                      imagePullPolicy:
+                                        description: PullPolicy describes a policy for if/when to pull a container image
+                                        type: string
+                                      imagePullSecrets:
+                                        items:
+                                          description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        type: array
+                                      imageRegistry:
+                                        type: string
+                                      imageTag:
+                                        type: string
+                                      resources:
+                                        description: ResourceRequirements describes the compute resource requirements.
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                        type: object
+                                    type: object
+                                  deployment:
+                                    description: Deployment specific overrides
+                                    properties:
+                                      autoScaling:
+                                        description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                        properties:
+                                          enabled:
+                                            description: Enabled specifies whether or not this feature is enabled
+                                            type: boolean
+                                          maxReplicas:
+                                            description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                            format: int32
+                                            type: integer
+                                          minReplicas:
+                                            description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                            format: int32
+                                            type: integer
+                                          targetCPUUtilizationPercentage:
+                                            description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      replicas:
+                                        description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                        format: int32
+                                        type: integer
+                                      strategy:
+                                        description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                        properties:
+                                          rollingUpdate:
+                                            properties:
+                                              maxSurge:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                                x-kubernetes-int-or-string: true
+                                              maxUnavailable:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          type:
+                                            description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  pod:
+                                    description: Pod specific overrides
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                        properties:
+                                          podAntiAffinity:
+                                            description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                            properties:
+                                              preferredDuringScheduling:
+                                                items:
+                                                  description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    topologyKey:
+                                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              requiredDuringScheduling:
+                                                items:
+                                                  description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    topologyKey:
+                                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      metadata:
+                                        description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                        type: object
+                                      priorityClassName:
+                                        description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                        type: string
+                                      tolerations:
+                                        description: If specified, the pod's tolerations. .Values.tolerations
+                                        items:
+                                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              service:
+                                description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                                properties:
+                                  allocateLoadBalancerNodePorts:
+                                    description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                                    type: boolean
+                                  clusterIP:
+                                    description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                    type: string
+                                  clusterIPs:
+                                    description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  externalIPs:
+                                    description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                                    items:
+                                      type: string
+                                    type: array
+                                  externalName:
+                                    description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                                    type: string
+                                  externalTrafficPolicy:
+                                    description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                                    type: string
+                                  healthCheckNodePort:
+                                    description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                                    format: int32
+                                    type: integer
+                                  ipFamilies:
+                                    description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                                    items:
+                                      description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  ipFamilyPolicy:
+                                    description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                                    type: string
+                                  loadBalancerIP:
+                                    description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                                    type: string
+                                  loadBalancerSourceRanges:
+                                    description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                                    items:
+                                      type: string
+                                    type: array
+                                  metadata:
+                                    description: metadata to be applied to the gateway's service (annotations and labels)
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  ports:
+                                    description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                    items:
+                                      description: ServicePort contains information on service's port.
+                                      properties:
+                                        appProtocol:
+                                          description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                          type: string
+                                        name:
+                                          description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                          type: string
+                                        nodePort:
+                                          description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                          format: int32
+                                          type: integer
+                                        port:
+                                          description: The port that will be exposed by this service.
+                                          format: int32
+                                          type: integer
+                                        protocol:
+                                          default: TCP
+                                          description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                          type: string
+                                        targetPort:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - port
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  publishNotReadyAddresses:
+                                    description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                    type: boolean
+                                  selector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                                    type: object
+                                  sessionAffinity:
+                                    description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                    type: string
+                                  sessionAffinityConfig:
+                                    description: sessionAffinityConfig contains the configurations of session affinity.
+                                    properties:
+                                      clientIP:
+                                        description: clientIP contains the configurations of Client IP based session affinity.
+                                        properties:
+                                          timeoutSeconds:
+                                            description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  topologyKeys:
+                                    description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                                    items:
+                                      type: string
+                                    type: array
+                                  type:
+                                    description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                                    type: string
+                                type: object
+                              volumes:
+                                description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                                items:
+                                  description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                                  properties:
+                                    volume:
+                                      description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap represents a configMap that should populate this volume
+                                          properties:
+                                            defaultMode:
+                                              description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: The key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its keys must be defined
+                                              type: boolean
+                                          type: object
+                                        secret:
+                                          description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          properties:
+                                            defaultMode:
+                                              description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: The key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            optional:
+                                              description: Specify whether the Secret or its keys must be defined
+                                              type: boolean
+                                            secretName:
+                                              description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                              type: string
+                                          type: object
+                                      type: object
+                                    volumeMount:
+                                      description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      multiCluster:
+                        description: .Values.global.multiCluster.enabled, if not null
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          meshNetworks:
+                            additionalProperties:
+                              description: MeshNetworkConfig configures mesh networks for a multi-cluster mesh.
+                              properties:
+                                endpoints:
+                                  items:
+                                    description: MeshEndpointConfig specifies the endpoint of a mesh network.  Only one of FromRegistry or FromCIDR may be specified
+                                    properties:
+                                      fromCIDR:
+                                        type: string
+                                      fromRegistry:
+                                        type: string
+                                    type: object
+                                  type: array
+                                gateways:
+                                  items:
+                                    description: MeshGatewayConfig specifies the gateway which should be used for accessing the network
+                                    properties:
+                                      address:
+                                        type: string
+                                      port:
+                                        format: int32
+                                        type: integer
+                                      registryServiceName:
+                                        type: string
+                                      service:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            description: '.Values.global.meshNetworks XXX: if non-empty, local cluster network should be configured as:  <spec.cluster.network>:      endpoints:      - fromRegistry: <spec.cluster.name>      gateways:      - service: <ingress-gateway-service-name>        port: 443 # mtls port'
+                            type: object
+                        type: object
+                      name:
+                        description: .Values.global.multiCluster.clusterName, defaults to Kubernetes
+                        type: string
+                      network:
+                        description: '.Values.global.network XXX: not sure what the difference is between this and cluster name'
+                        type: string
+                    type: object
+                  gateways:
+                    description: Gateways configures gateways for the mesh .Values.gateways.*
+                    properties:
+                      additionalEgress:
+                        additionalProperties:
+                          description: EgressGatewayConfig represents gateway configuration for egress
+                          properties:
+                            enabled:
+                              description: Enabled specifies whether or not this feature is enabled
+                              type: boolean
+                            namespace:
+                              description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                              type: string
+                            requestedNetworkView:
+                              description: 'RequestedNetworkView is a list of networks whose services should be made available to the gateway.  This is used primarily for mesh expansion/multi-cluster. .Values.gateways.<gateway-name>.env.ISTIO_META_REQUESTED_NETWORK_VIEW env, defaults to empty list XXX: I think this is only applicable to egress gateways'
+                              items:
+                                type: string
+                              type: array
+                            routerMode:
+                              description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                              type: string
+                            runtime:
+                              description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                              properties:
+                                container:
+                                  description: .Values.*.resource, imagePullPolicy, etc.
+                                  properties:
+                                    env:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    imageName:
+                                      type: string
+                                    imagePullPolicy:
+                                      description: PullPolicy describes a policy for if/when to pull a container image
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    imageRegistry:
+                                      type: string
+                                    imageTag:
+                                      type: string
+                                    resources:
+                                      description: ResourceRequirements describes the compute resource requirements.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          type: object
+                                      type: object
+                                  type: object
+                                deployment:
+                                  description: Deployment specific overrides
+                                  properties:
+                                    autoScaling:
+                                      description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                      properties:
+                                        enabled:
+                                          description: Enabled specifies whether or not this feature is enabled
+                                          type: boolean
+                                        maxReplicas:
+                                          description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                          format: int32
+                                          type: integer
+                                        minReplicas:
+                                          description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                          format: int32
+                                          type: integer
+                                        targetCPUUtilizationPercentage:
+                                          description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    replicas:
+                                      description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                      format: int32
+                                      type: integer
+                                    strategy:
+                                      description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                      properties:
+                                        rollingUpdate:
+                                          properties:
+                                            maxSurge:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                              x-kubernetes-int-or-string: true
+                                            maxUnavailable:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        type:
+                                          description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                          type: string
+                                      type: object
+                                  type: object
+                                pod:
+                                  description: Pod specific overrides
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                      properties:
+                                        podAntiAffinity:
+                                          description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                          properties:
+                                            preferredDuringScheduling:
+                                              items:
+                                                description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            requiredDuringScheduling:
+                                              items:
+                                                description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    metadata:
+                                      description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                      type: object
+                                    priorityClassName:
+                                      description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations. .Values.tolerations
+                                      items:
+                                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            service:
+                              description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                              properties:
+                                allocateLoadBalancerNodePorts:
+                                  description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                                  type: boolean
+                                clusterIP:
+                                  description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                  type: string
+                                clusterIPs:
+                                  description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                externalIPs:
+                                  description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                                  items:
+                                    type: string
+                                  type: array
+                                externalName:
+                                  description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                                  type: string
+                                externalTrafficPolicy:
+                                  description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                                  type: string
+                                healthCheckNodePort:
+                                  description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                                  format: int32
+                                  type: integer
+                                ipFamilies:
+                                  description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                                  items:
+                                    description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                ipFamilyPolicy:
+                                  description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                                  type: string
+                                loadBalancerIP:
+                                  description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                                  type: string
+                                loadBalancerSourceRanges:
+                                  description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                                  items:
+                                    type: string
+                                  type: array
+                                metadata:
+                                  description: metadata to be applied to the gateway's service (annotations and labels)
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                ports:
+                                  description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                  items:
+                                    description: ServicePort contains information on service's port.
+                                    properties:
+                                      appProtocol:
+                                        description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                        type: string
+                                      name:
+                                        description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                        type: string
+                                      nodePort:
+                                        description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                        format: int32
+                                        type: integer
+                                      port:
+                                        description: The port that will be exposed by this service.
+                                        format: int32
+                                        type: integer
+                                      protocol:
+                                        default: TCP
+                                        description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                        type: string
+                                      targetPort:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - port
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                publishNotReadyAddresses:
+                                  description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                  type: boolean
+                                selector:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                                  type: object
+                                sessionAffinity:
+                                  description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                  type: string
+                                sessionAffinityConfig:
+                                  description: sessionAffinityConfig contains the configurations of session affinity.
+                                  properties:
+                                    clientIP:
+                                      description: clientIP contains the configurations of Client IP based session affinity.
+                                      properties:
+                                        timeoutSeconds:
+                                          description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                topologyKeys:
+                                  description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                                  items:
+                                    type: string
+                                  type: array
+                                type:
+                                  description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                                  type: string
+                              type: object
+                            volumes:
+                              description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                              items:
+                                description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                                properties:
+                                  volume:
+                                    description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap represents a configMap that should populate this volume
+                                        properties:
+                                          defaultMode:
+                                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      secret:
+                                        description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        properties:
+                                          defaultMode:
+                                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          optional:
+                                            description: Specify whether the Secret or its keys must be defined
+                                            type: boolean
+                                          secretName:
+                                            description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                            type: string
+                                        type: object
+                                    type: object
+                                  volumeMount:
+                                    description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                    properties:
+                                      mountPath:
+                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                        type: string
+                                      mountPropagation:
+                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                        type: string
+                                      name:
+                                        description: This must match the Name of a Volume.
+                                        type: string
+                                      readOnly:
+                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                        type: boolean
+                                      subPath:
+                                        description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                        type: string
+                                      subPathExpr:
+                                        description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        description: Other user defined egress gateways .Values.gateways.<key>
+                        type: object
+                      additionalIngress:
+                        additionalProperties:
+                          description: IngressGatewayConfig represents gateway configuration for ingress
+                          properties:
+                            enabled:
+                              description: Enabled specifies whether or not this feature is enabled
+                              type: boolean
+                            namespace:
+                              description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                              type: string
+                            routerMode:
+                              description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                              type: string
+                            runtime:
+                              description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                              properties:
+                                container:
+                                  description: .Values.*.resource, imagePullPolicy, etc.
+                                  properties:
+                                    env:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    imageName:
+                                      type: string
+                                    imagePullPolicy:
+                                      description: PullPolicy describes a policy for if/when to pull a container image
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    imageRegistry:
+                                      type: string
+                                    imageTag:
+                                      type: string
+                                    resources:
+                                      description: ResourceRequirements describes the compute resource requirements.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          type: object
+                                      type: object
+                                  type: object
+                                deployment:
+                                  description: Deployment specific overrides
+                                  properties:
+                                    autoScaling:
+                                      description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                      properties:
+                                        enabled:
+                                          description: Enabled specifies whether or not this feature is enabled
+                                          type: boolean
+                                        maxReplicas:
+                                          description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                          format: int32
+                                          type: integer
+                                        minReplicas:
+                                          description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                          format: int32
+                                          type: integer
+                                        targetCPUUtilizationPercentage:
+                                          description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    replicas:
+                                      description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                      format: int32
+                                      type: integer
+                                    strategy:
+                                      description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                      properties:
+                                        rollingUpdate:
+                                          properties:
+                                            maxSurge:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                              x-kubernetes-int-or-string: true
+                                            maxUnavailable:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        type:
+                                          description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                          type: string
+                                      type: object
+                                  type: object
+                                pod:
+                                  description: Pod specific overrides
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                      properties:
+                                        podAntiAffinity:
+                                          description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                          properties:
+                                            preferredDuringScheduling:
+                                              items:
+                                                description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            requiredDuringScheduling:
+                                              items:
+                                                description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    metadata:
+                                      description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                      type: object
+                                    priorityClassName:
+                                      description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations. .Values.tolerations
+                                      items:
+                                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            sds:
+                              description: EnableSDS for the gateway. .Values.gateways.<gateway-name>.sds.enabled
+                              properties:
+                                enabled:
+                                  description: Enabled specifies whether or not this feature is enabled
+                                  type: boolean
+                                runtime:
+                                  description: Runtime configuration for sds sidecar
+                                  properties:
+                                    env:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    imageName:
+                                      type: string
+                                    imagePullPolicy:
+                                      description: PullPolicy describes a policy for if/when to pull a container image
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    imageRegistry:
+                                      type: string
+                                    imageTag:
+                                      type: string
+                                    resources:
+                                      description: ResourceRequirements describes the compute resource requirements.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          type: object
+                                      type: object
+                                  type: object
+                              type: object
+                            service:
+                              description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                              properties:
+                                allocateLoadBalancerNodePorts:
+                                  description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                                  type: boolean
+                                clusterIP:
+                                  description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                  type: string
+                                clusterIPs:
+                                  description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                externalIPs:
+                                  description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                                  items:
+                                    type: string
+                                  type: array
+                                externalName:
+                                  description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                                  type: string
+                                externalTrafficPolicy:
+                                  description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                                  type: string
+                                healthCheckNodePort:
+                                  description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                                  format: int32
+                                  type: integer
+                                ipFamilies:
+                                  description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                                  items:
+                                    description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                ipFamilyPolicy:
+                                  description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                                  type: string
+                                loadBalancerIP:
+                                  description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                                  type: string
+                                loadBalancerSourceRanges:
+                                  description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                                  items:
+                                    type: string
+                                  type: array
+                                metadata:
+                                  description: metadata to be applied to the gateway's service (annotations and labels)
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                ports:
+                                  description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                  items:
+                                    description: ServicePort contains information on service's port.
+                                    properties:
+                                      appProtocol:
+                                        description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                        type: string
+                                      name:
+                                        description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                        type: string
+                                      nodePort:
+                                        description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                        format: int32
+                                        type: integer
+                                      port:
+                                        description: The port that will be exposed by this service.
+                                        format: int32
+                                        type: integer
+                                      protocol:
+                                        default: TCP
+                                        description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                        type: string
+                                      targetPort:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - port
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                publishNotReadyAddresses:
+                                  description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                  type: boolean
+                                selector:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                                  type: object
+                                sessionAffinity:
+                                  description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                  type: string
+                                sessionAffinityConfig:
+                                  description: sessionAffinityConfig contains the configurations of session affinity.
+                                  properties:
+                                    clientIP:
+                                      description: clientIP contains the configurations of Client IP based session affinity.
+                                      properties:
+                                        timeoutSeconds:
+                                          description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                  type: object
+                                topologyKeys:
+                                  description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                                  items:
+                                    type: string
+                                  type: array
+                                type:
+                                  description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                                  type: string
+                              type: object
+                            volumes:
+                              description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                              items:
+                                description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                                properties:
+                                  volume:
+                                    description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap represents a configMap that should populate this volume
+                                        properties:
+                                          defaultMode:
+                                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      secret:
+                                        description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        properties:
+                                          defaultMode:
+                                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          optional:
+                                            description: Specify whether the Secret or its keys must be defined
+                                            type: boolean
+                                          secretName:
+                                            description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                            type: string
+                                        type: object
+                                    type: object
+                                  volumeMount:
+                                    description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                    properties:
+                                      mountPath:
+                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                        type: string
+                                      mountPropagation:
+                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                        type: string
+                                      name:
+                                        description: This must match the Name of a Volume.
+                                        type: string
+                                      readOnly:
+                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                        type: boolean
+                                      subPath:
+                                        description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                        type: string
+                                      subPathExpr:
+                                        description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        description: Other user defined ingress gateways .Values.gateways.<key>
+                        type: object
+                      egress:
+                        description: ClusterEgress configures the istio-egressgateway for the mesh. .Values.gateways.istio-egressgateway
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          namespace:
+                            description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                            type: string
+                          requestedNetworkView:
+                            description: 'RequestedNetworkView is a list of networks whose services should be made available to the gateway.  This is used primarily for mesh expansion/multi-cluster. .Values.gateways.<gateway-name>.env.ISTIO_META_REQUESTED_NETWORK_VIEW env, defaults to empty list XXX: I think this is only applicable to egress gateways'
+                            items:
+                              type: string
+                            type: array
+                          routerMode:
+                            description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                            type: string
+                          runtime:
+                            description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                            properties:
+                              container:
+                                description: .Values.*.resource, imagePullPolicy, etc.
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    description: PullPolicy describes a policy for if/when to pull a container image
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    description: ResourceRequirements describes the compute resource requirements.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                type: object
+                              deployment:
+                                description: Deployment specific overrides
+                                properties:
+                                  autoScaling:
+                                    description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                    properties:
+                                      enabled:
+                                        description: Enabled specifies whether or not this feature is enabled
+                                        type: boolean
+                                      maxReplicas:
+                                        description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                        format: int32
+                                        type: integer
+                                      minReplicas:
+                                        description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                        format: int32
+                                        type: integer
+                                      targetCPUUtilizationPercentage:
+                                        description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  replicas:
+                                    description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                    format: int32
+                                    type: integer
+                                  strategy:
+                                    description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                    properties:
+                                      rollingUpdate:
+                                        properties:
+                                          maxSurge:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                            x-kubernetes-int-or-string: true
+                                          maxUnavailable:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      type:
+                                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                        type: string
+                                    type: object
+                                type: object
+                              pod:
+                                description: Pod specific overrides
+                                properties:
+                                  affinity:
+                                    description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                    properties:
+                                      podAntiAffinity:
+                                        description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                        properties:
+                                          preferredDuringScheduling:
+                                            items:
+                                              description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                topologyKey:
+                                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          requiredDuringScheduling:
+                                            items:
+                                              description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                topologyKey:
+                                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  metadata:
+                                    description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                    type: object
+                                  priorityClassName:
+                                    description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                    type: string
+                                  tolerations:
+                                    description: If specified, the pod's tolerations. .Values.tolerations
+                                    items:
+                                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          service:
+                            description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                            properties:
+                              allocateLoadBalancerNodePorts:
+                                description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                                type: boolean
+                              clusterIP:
+                                description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                type: string
+                              clusterIPs:
+                                description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              externalIPs:
+                                description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                                type: string
+                              externalTrafficPolicy:
+                                description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                                type: string
+                              healthCheckNodePort:
+                                description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                                format: int32
+                                type: integer
+                              ipFamilies:
+                                description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                                items:
+                                  description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ipFamilyPolicy:
+                                description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                                type: string
+                              loadBalancerIP:
+                                description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                                type: string
+                              loadBalancerSourceRanges:
+                                description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                description: metadata to be applied to the gateway's service (annotations and labels)
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              ports:
+                                description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                items:
+                                  description: ServicePort contains information on service's port.
+                                  properties:
+                                    appProtocol:
+                                      description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                      type: string
+                                    name:
+                                      description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                      type: string
+                                    nodePort:
+                                      description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      description: The port that will be exposed by this service.
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      default: TCP
+                                      description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                                type: object
+                              sessionAffinity:
+                                description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                type: string
+                              sessionAffinityConfig:
+                                description: sessionAffinityConfig contains the configurations of session affinity.
+                                properties:
+                                  clientIP:
+                                    description: clientIP contains the configurations of Client IP based session affinity.
+                                    properties:
+                                      timeoutSeconds:
+                                        description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              topologyKeys:
+                                description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                                items:
+                                  type: string
+                                type: array
+                              type:
+                                description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                                type: string
+                            type: object
+                          volumes:
+                            description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                            items:
+                              description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                              properties:
+                                volume:
+                                  description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap represents a configMap that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    secret:
+                                      description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: Specify whether the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                  type: object
+                                volumeMount:
+                                  description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                  properties:
+                                    mountPath:
+                                      description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                      type: boolean
+                                    subPath:
+                                      description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      enabled:
+                        description: Enabled specifies whether or not this feature is enabled
+                        type: boolean
+                      ingress:
+                        description: ClusterIngress configures the istio-ingressgateway for the mesh works in conjunction with cluster.meshExpansion.ingress configuration (for enabling ILB gateway and mesh expansion ports) .Values.gateways.istio-ingressgateway
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          ingress:
+                            description: '.Values.global.k8sIngress.enabled implies the following: .Values.global.k8sIngress.gatewayName will match the ingress gateway .Values.global.k8sIngress.enableHttps will be true if gateway service exposes port 443 XXX: not sure whether or not this is specific to multicluster, mesh expansion, or both'
+                            type: boolean
+                          meshExpansionPorts:
+                            description: MeshExpansionPorts define the port set used with multi-cluster/mesh expansion
+                            items:
+                              description: ServicePort contains information on service's port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                  type: string
+                                nodePort:
+                                  description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                          namespace:
+                            description: 'Namespace is the namespace within which the gateway will be installed, defaults to control plane namespace. .Values.gateways.<gateway-name>.namespace XXX: for the standard gateways, it might be possible that related resources could be installed in control plane namespace instead of the gateway namespace.  not sure if this is a problem or not.'
+                            type: string
+                          routerMode:
+                            description: The router mode to be used by the gateway. .Values.gateways.<gateway-name>.env.ISTIO_META_ROUTER_MODE, defaults to sni-dnat
+                            type: string
+                          runtime:
+                            description: Runtime is used to configure execution parameters for the pod/containers e.g. resources, replicas, etc.
+                            properties:
+                              container:
+                                description: .Values.*.resource, imagePullPolicy, etc.
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    description: PullPolicy describes a policy for if/when to pull a container image
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    description: ResourceRequirements describes the compute resource requirements.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                type: object
+                              deployment:
+                                description: Deployment specific overrides
+                                properties:
+                                  autoScaling:
+                                    description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                    properties:
+                                      enabled:
+                                        description: Enabled specifies whether or not this feature is enabled
+                                        type: boolean
+                                      maxReplicas:
+                                        description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                        format: int32
+                                        type: integer
+                                      minReplicas:
+                                        description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                        format: int32
+                                        type: integer
+                                      targetCPUUtilizationPercentage:
+                                        description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  replicas:
+                                    description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                    format: int32
+                                    type: integer
+                                  strategy:
+                                    description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                    properties:
+                                      rollingUpdate:
+                                        properties:
+                                          maxSurge:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                            x-kubernetes-int-or-string: true
+                                          maxUnavailable:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      type:
+                                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                        type: string
+                                    type: object
+                                type: object
+                              pod:
+                                description: Pod specific overrides
+                                properties:
+                                  affinity:
+                                    description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                    properties:
+                                      podAntiAffinity:
+                                        description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                        properties:
+                                          preferredDuringScheduling:
+                                            items:
+                                              description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                topologyKey:
+                                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          requiredDuringScheduling:
+                                            items:
+                                              description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                topologyKey:
+                                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  metadata:
+                                    description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                    type: object
+                                  priorityClassName:
+                                    description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                    type: string
+                                  tolerations:
+                                    description: If specified, the pod's tolerations. .Values.tolerations
+                                    items:
+                                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          sds:
+                            description: EnableSDS for the gateway. .Values.gateways.<gateway-name>.sds.enabled
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              runtime:
+                                description: Runtime configuration for sds sidecar
+                                properties:
+                                  env:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  imageName:
+                                    type: string
+                                  imagePullPolicy:
+                                    description: PullPolicy describes a policy for if/when to pull a container image
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                      type: object
+                                    type: array
+                                  imageRegistry:
+                                    type: string
+                                  imageTag:
+                                    type: string
+                                  resources:
+                                    description: ResourceRequirements describes the compute resource requirements.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                type: object
+                            type: object
+                          service:
+                            description: 'Service configures the service associated with the gateway, e.g. port mappings, service type, annotations/labels, etc. .Values.gateways.<gateway-name>.ports, .Values.gateways.<gateway-name>.type, .Values.gateways.<gateway-name>.loadBalancerIP, .Values.gateways.<gateway-name>.serviceAnnotations, .Values.gateways.<gateway-name>.serviceLabels XXX: currently there is no distinction between labels and serviceLabels'
+                            properties:
+                              allocateLoadBalancerNodePorts:
+                                description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                                type: boolean
+                              clusterIP:
+                                description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                type: string
+                              clusterIPs:
+                                description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              externalIPs:
+                                description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be
+                                type: string
+                              externalTrafficPolicy:
+                                description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                                type: string
+                              healthCheckNodePort:
+                                description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                                format: int32
+                                type: integer
+                              ipFamilies:
+                                description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                                items:
+                                  description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ipFamilyPolicy:
+                                description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                                type: string
+                              loadBalancerIP:
+                                description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                                type: string
+                              loadBalancerSourceRanges:
+                                description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                                items:
+                                  type: string
+                                type: array
+                              metadata:
+                                description: metadata to be applied to the gateway's service (annotations and labels)
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              ports:
+                                description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                items:
+                                  description: ServicePort contains information on service's port.
+                                  properties:
+                                    appProtocol:
+                                      description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                      type: string
+                                    name:
+                                      description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                      type: string
+                                    nodePort:
+                                      description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      description: The port that will be exposed by this service.
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      default: TCP
+                                      description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                                type: object
+                              sessionAffinity:
+                                description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                                type: string
+                              sessionAffinityConfig:
+                                description: sessionAffinityConfig contains the configurations of session affinity.
+                                properties:
+                                  clientIP:
+                                    description: clientIP contains the configurations of Client IP based session affinity.
+                                    properties:
+                                      timeoutSeconds:
+                                        description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              topologyKeys:
+                                description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature.
+                                items:
+                                  type: string
+                                type: array
+                              type:
+                                description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                                type: string
+                            type: object
+                          volumes:
+                            description: Volumes is used to configure additional Secret and ConfigMap volumes that should be mounted for the gateway's pod. .Values.gateways.<gateway-name>.secretVolumes, .Values.gateways.<gateway-name>.configMapVolumes
+                            items:
+                              description: VolumeConfig is used to specify volumes that should be mounted on the pod.
+                              properties:
+                                volume:
+                                  description: Volume.Name maps to .Values.gateways.<gateway-name>.<type>.<type-name> (type-name is configMapName or secretName) .configVolumes -> .configMapName = volume.name .secretVolumes -> .secretName = volume.name Only ConfigMap and Secret fields are supported
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap represents a configMap that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    secret:
+                                      description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: Specify whether the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                  type: object
+                                volumeMount:
+                                  description: Mount.Name maps to .Values.gateways.<gateway-name>.<type>.name .configVolumes -> .name = mount.name, .mountPath = mount.mountPath .secretVolumes -> .name = mount.name, .mountPath = mount.mountPath Only Name and MountPath fields are supported
+                                  properties:
+                                    mountPath:
+                                      description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                      type: boolean
+                                    subPath:
+                                      description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      openshiftRoute:
+                        description: Route configures the Gateway ↔ OpenShift Route integration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                        type: object
+                    type: object
+                  general:
+                    description: General represents general control plane configuration that does not logically fit in another area.
+                    properties:
+                      logging:
+                        description: 'Logging represents the logging configuration for the control plane components XXX: Should this be separate from Proxy.Logging?'
+                        properties:
+                          componentLevels:
+                            additionalProperties:
+                              description: LogLevel represents the logging level
+                              type: string
+                            description: ComponentLevels configures log level for specific envoy components .Values.global.proxy.componentLogLevel, overridden by sidecar.istio.io/componentLogLevel map of <component>:<level>
+                            type: object
+                          logAsJSON:
+                            description: LogAsJSON enables JSON logging .Values.global.logAsJson
+                            type: boolean
+                        type: object
+                      validationMessages:
+                        description: ValidationMessages configures the control plane to add validationMessages to the status fields of istio.io resources.  This can be usefule for detecting configuration errors in resources. .Values.galley.enableAnalysis (<v2.0) .Values.global.istiod.enableAnalysis (>=v2.0)
+                        type: boolean
+                    type: object
+                  policy:
+                    description: Policy configures policy checking for the control plane. .Values.policy.enabled, true if not null
+                    properties:
+                      mixer:
+                        description: Mixer configuration (legacy, v1) .Values.mixer.policy.enabled
+                        properties:
+                          adapters:
+                            description: Adapters configures available adapters.
+                            properties:
+                              kubernetesenv:
+                                description: Kubernetesenv configures the use of the kubernetesenv adapter. .Values.mixer.policy.adapters.kubernetesenv.enabled, defaults to true
+                                type: boolean
+                              useAdapterCRDs:
+                                description: UseAdapterCRDs configures mixer to support deprecated mixer CRDs. .Values.mixer.policy.adapters.useAdapterCRDs, removed in istio 1.4, defaults to false Only supported in v1.0, where it defaulted to true
+                                type: boolean
+                            type: object
+                          enableChecks:
+                            description: EnableChecks configures whether or not policy checks should be enabled. .Values.global.disablePolicyChecks | default "true" (false, inverted logic) Set the following variable to false to disable policy checks by the Mixer. Note that metrics will still be reported to the Mixer.
+                            type: boolean
+                          failOpen:
+                            description: FailOpen configures policy checks to fail if mixer cannot be reached. .Values.global.policyCheckFailOpen, maps to MeshConfig.policyCheckFailOpen policyCheckFailOpen allows traffic in cases when the mixer policy service cannot be reached. Default is false which means the traffic is denied when the client is unable to connect to Mixer.
+                            type: boolean
+                          sessionAffinity:
+                            description: SessionAffinity configures session affinity for sidecar policy connections. .Values.mixer.policy.sessionAffinityEnabled
+                            type: boolean
+                        type: object
+                      remote:
+                        description: Remote mixer configuration (legacy, v1) .Values.global.remotePolicyAddress
+                        properties:
+                          address:
+                            description: Address represents the address of the mixer server. .Values.global.remotePolicyAddress, maps to MeshConfig.mixerCheckServer
+                            type: string
+                          createService:
+                            description: CreateServices specifies whether or not a k8s Service should be created for the remote policy server. .Values.global.createRemoteSvcEndpoints
+                            type: boolean
+                          enableChecks:
+                            description: EnableChecks configures whether or not policy checks should be enabled. .Values.global.disablePolicyChecks | default "true" (false, inverted logic) Set the following variable to false to disable policy checks by the Mixer. Note that metrics will still be reported to the Mixer.
+                            type: boolean
+                          failOpen:
+                            description: FailOpen configures policy checks to fail if mixer cannot be reached. .Values.global.policyCheckFailOpen, maps to MeshConfig.policyCheckFailOpen policyCheckFailOpen allows traffic in cases when the mixer policy service cannot be reached. Default is false which means the traffic is denied when the client is unable to connect to Mixer.
+                            type: boolean
+                        type: object
+                      type:
+                        description: Required, the policy implementation defaults to Istiod 1.6+, Mixer pre-1.6
+                        type: string
+                    type: object
+                  profiles:
+                    description: Profiles selects the profile to use for default values. Defaults to "default" when not set.
+                    items:
+                      type: string
+                    type: array
+                  proxy:
+                    description: Proxy configures the default behavior for sidecars.  Many values were previously exposed through .Values.global.proxy
+                    properties:
+                      accessLogging:
+                        description: AccessLogging configures access logging for proxies.
+                        properties:
+                          envoyService:
+                            description: File configures access logging to an envoy service .Values.global.proxy.envoyAccessLogService
+                            properties:
+                              address:
+                                description: Address of the service specified as host:port. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).host .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).port
+                                type: string
+                              enabled:
+                                description: Enabled specifies whether or not this feature is enabled
+                                type: boolean
+                              tcpKeepalive:
+                                description: TCPKeepalive configures keepalive settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tcpKeepalive
+                                properties:
+                                  interval:
+                                    description: Interval represents the interval between probes.
+                                    type: string
+                                  probes:
+                                    description: Probes represents the number of successive probe failures after which the connection should be considered "dead."
+                                    format: int32
+                                    type: integer
+                                  time:
+                                    description: Time represents the length of idle time that must elapse before a probe is sent.
+                                    type: string
+                                type: object
+                              tlsSettings:
+                                description: TLSSettings configures TLS settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tlsSettings
+                                properties:
+                                  caCertificates:
+                                    description: CACertificates represents the file name containing the root certificates for the CA, e.g. /etc/istio/als/root-cert.pem
+                                    type: string
+                                  clientCertificate:
+                                    description: ClientCertificate represents the file name containing the client certificate to show to the Envoy service, e.g. /etc/istio/als/cert-chain.pem
+                                    type: string
+                                  mode:
+                                    description: 'Mode represents the TLS mode to apply to the connection.  The following values are supported: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL'
+                                    type: string
+                                  privateKey:
+                                    description: PrivateKey represents the file name containing the private key used by the client, e.g. /etc/istio/als/key.pem
+                                    type: string
+                                  sni:
+                                    description: SNIHost represents the host name presented to the server during TLS handshake, e.g. als.somedomain
+                                    type: string
+                                  subjectAltNames:
+                                    description: SubjectAltNames represents the list of alternative names that may be used to verify the servers identity, e.g. [als.someotherdomain]
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          file:
+                            description: File configures access logging to the file system
+                            properties:
+                              encoding:
+                                description: Encoding to use when writing access log entries.  Currently, JSON or TEXT may be specified. .Values.global.proxy.accessLogEncoding
+                                type: string
+                              format:
+                                description: Format to use when writing access log entries. .Values.global.proxy.accessLogFormat
+                                type: string
+                              name:
+                                description: Name is the name of the file to which access log entries will be written. If Name is not specified, no log entries will be written to a file. .Values.global.proxy.accessLogFile
+                                type: string
+                            type: object
+                        type: object
+                      adminPort:
+                        description: 'AdminPort configures the admin port exposed by the sidecar. maps to defaultConfig.proxyAdminPort, defaults to 15000 XXX: currently not configurable in charts'
+                        format: int32
+                        type: integer
+                      concurrency:
+                        description: 'Concurrency configures the number of threads that should be run by the sidecar. .Values.global.proxy.concurrency, maps to defaultConfig.concurrency XXX: removed in 1.7 XXX: this is defaulted to 2 in our values.yaml, but should probably be 0'
+                        format: int32
+                        type: integer
+                      envoyMetricsService:
+                        description: EnvoyMetricsService configures reporting of Envoy metrics to an external service. .Values.global.proxy.envoyMetricsService
+                        properties:
+                          address:
+                            description: Address of the service specified as host:port. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).host .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).port
+                            type: string
+                          enabled:
+                            description: Enabled specifies whether or not this feature is enabled
+                            type: boolean
+                          tcpKeepalive:
+                            description: TCPKeepalive configures keepalive settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tcpKeepalive
+                            properties:
+                              interval:
+                                description: Interval represents the interval between probes.
+                                type: string
+                              probes:
+                                description: Probes represents the number of successive probe failures after which the connection should be considered "dead."
+                                format: int32
+                                type: integer
+                              time:
+                                description: Time represents the length of idle time that must elapse before a probe is sent.
+                                type: string
+                            type: object
+                          tlsSettings:
+                            description: TLSSettings configures TLS settings to use when connecting to the service. .Values.global.proxy.(envoyAccessLogService|envoyMetricsService).tlsSettings
+                            properties:
+                              caCertificates:
+                                description: CACertificates represents the file name containing the root certificates for the CA, e.g. /etc/istio/als/root-cert.pem
+                                type: string
+                              clientCertificate:
+                                description: ClientCertificate represents the file name containing the client certificate to show to the Envoy service, e.g. /etc/istio/als/cert-chain.pem
+                                type: string
+                              mode:
+                                description: 'Mode represents the TLS mode to apply to the connection.  The following values are supported: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL'
+                                type: string
+                              privateKey:
+                                description: PrivateKey represents the file name containing the private key used by the client, e.g. /etc/istio/als/key.pem
+                                type: string
+                              sni:
+                                description: SNIHost represents the host name presented to the server during TLS handshake, e.g. als.somedomain
+                                type: string
+                              subjectAltNames:
+                                description: SubjectAltNames represents the list of alternative names that may be used to verify the servers identity, e.g. [als.someotherdomain]
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      injection:
+                        description: Injection is used to customize sidecar injection for the mesh.
+                        properties:
+                          alwaysInjectSelector:
+                            description: AlwaysInjectSelector allows specification of a label selector that when matched will always inject a sidecar into the pod. .Values.sidecarInjectorWebhook.alwaysInjectSelector
+                            items:
+                              description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            type: array
+                          autoInject:
+                            description: AutoInject configures automatic injection of sidecar proxies .Values.global.proxy.autoInject .Values.sidecarInjectorWebhook.enableNamespacesByDefault
+                            type: boolean
+                          injectedAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: InjectedAnnotations allows specification of additional annotations to be added to pods that have sidecars injected in them. .Values.sidecarInjectorWebhook.injectedAnnotations
+                            type: object
+                          neverInjectSelector:
+                            description: NeverInjectSelector allows specification of a label selector that when matched will never inject a sidecar into the pod.  This takes precendence over AlwaysInjectSelector. .Values.sidecarInjectorWebhook.neverInjectSelector
+                            items:
+                              description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      logging:
+                        description: Logging configures logging for the sidecar. e.g. .Values.global.proxy.logLevel
+                        properties:
+                          componentLevels:
+                            additionalProperties:
+                              description: LogLevel represents the logging level
+                              type: string
+                            description: ComponentLevels configures log level for specific envoy components .Values.global.proxy.componentLogLevel, overridden by sidecar.istio.io/componentLogLevel map of <component>:<level>
+                            type: object
+                          level:
+                            description: Level the log level .Values.global.proxy.logLevel, overridden by sidecar.istio.io/logLevel
+                            type: string
+                        type: object
+                      networking:
+                        description: Networking represents network settings to be configured for the sidecars.
+                        properties:
+                          clusterDomain:
+                            description: ClusterDomain represents the domain for the cluster, defaults to cluster.local .Values.global.proxy.clusterDomain
+                            type: string
+                          connectionTimeout:
+                            description: 'maps to meshConfig.defaultConfig.connectionTimeout, defaults to 10s XXX: currently not exposed through values.yaml'
+                            type: string
+                          dns:
+                            description: DNS configures aspects of the sidecar's usage of DNS
+                            properties:
+                              refreshRate:
+                                description: RefreshRate configures the DNS refresh rate for Envoy cluster of type STRICT_DNS This must be given it terms of seconds. For example, 300s is valid but 5m is invalid. .Values.global.proxy.dnsRefreshRate, default 300s
+                                type: string
+                              searchSuffixes:
+                                description: 'SearchSuffixes are additional search suffixes to be used when resolving names. .Values.global.podDNSSearchNamespaces Custom DNS config for the pod to resolve names of services in other clusters. Use this to add additional search domains, and other settings. see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#dns-config This does not apply to gateway pods as they typically need a different set of DNS settings than the normal application pods (e.g., in multicluster scenarios). NOTE: If using templates, follow the pattern in the commented example below.    podDNSSearchNamespaces:    - global    - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          initialization:
+                            description: Initialization is used to specify how the pod's networking through the proxy is initialized.  This configures the use of CNI or an init container.
+                            properties:
+                              initContainer:
+                                description: InitContainer configures the use of a pod init container for initializing the pod's networking. istio_cni.enabled = false, if InitContainer is used
+                                properties:
+                                  runtime:
+                                    description: Runtime configures customization of the init container (e.g. resources)
+                                    properties:
+                                      env:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      imageName:
+                                        type: string
+                                      imagePullPolicy:
+                                        description: PullPolicy describes a policy for if/when to pull a container image
+                                        type: string
+                                      imagePullSecrets:
+                                        items:
+                                          description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                          type: object
+                                        type: array
+                                      imageRegistry:
+                                        type: string
+                                      imageTag:
+                                        type: string
+                                      resources:
+                                        description: ResourceRequirements describes the compute resource requirements.
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                        type: object
+                                    type: object
+                                type: object
+                              type:
+                                description: Type of the network initialization implementation.
+                                type: string
+                            type: object
+                          maxConnectionAge:
+                            description: MaxConnectionAge limits how long a sidecar can be connected to pilot. This may be used to balance load across pilot instances, at the cost of system churn. .Values.pilot.keepaliveMaxServerConnectionAge
+                            type: string
+                          protocol:
+                            description: Protocol configures how the sidecar works with applicaiton protocols.
+                            properties:
+                              autoDetect:
+                                description: AutoDetect configures automatic detection of connection protocols.
+                                properties:
+                                  inbound:
+                                    description: EnableInboundSniffing enables protocol sniffing on inbound traffic. .Values.pilot.enableProtocolSniffingForInbound only supported for v1.1
+                                    type: boolean
+                                  outbound:
+                                    description: EnableOutboundSniffing enables protocol sniffing on outbound traffic. .Values.pilot.enableProtocolSniffingForOutbound only supported for v1.1
+                                    type: boolean
+                                  timeout:
+                                    description: DetectionTimeout specifies how much time the sidecar will spend determining the protocol being used for the connection before reverting to raw TCP. .Values.global.proxy.protocolDetectionTimeout, maps to protocolDetectionTimeout
+                                    type: string
+                                type: object
+                            type: object
+                          trafficControl:
+                            description: TrafficControl configures what network traffic is routed through the proxy.
+                            properties:
+                              inbound:
+                                description: Inbound configures what inbound traffic is routed through the sidecar traffic.sidecar.istio.io/includeInboundPorts defaults to * (all ports)
+                                properties:
+                                  excludedPorts:
+                                    description: ExcludedPorts to be routed around the sidecar. .Values.global.proxy.excludeInboundPorts, defaults to empty list, overridden by traffic.sidecar.istio.io/excludeInboundPorts
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                  includedPorts:
+                                    description: IncludedPorts to be routed through the sidecar. * or comma separated list of integers .Values.global.proxy.includeInboundPorts, defaults to * (all ports), overridden by traffic.sidecar.istio.io/includeInboundPorts
+                                    items:
+                                      type: string
+                                    type: array
+                                  interceptionMode:
+                                    description: 'InterceptionMode specifies how traffic is directed through the sidecar. maps to meshConfig.defaultConfig.interceptionMode, overridden by sidecar.istio.io/interceptionMode XXX: currently not configurable through values.yaml'
+                                    type: string
+                                type: object
+                              outbound:
+                                description: Outbound configures what outbound traffic is routed through the sidecar.
+                                properties:
+                                  excludedIPRanges:
+                                    description: ExcludedIPRanges specifies which outbound IP ranges should _not_ be routed through the sidecar. .Values.global.proxy.excludeIPRanges, overridden by traffic.sidecar.istio.io/excludeOutboundIPRanges * or comma separated list of CIDR
+                                    items:
+                                      type: string
+                                    type: array
+                                  excludedPorts:
+                                    description: ExcludedPorts specifies which outbound ports should _not_ be routed through the sidecar. .Values.global.proxy.excludeOutboundPorts, overridden by traffic.sidecar.istio.io/excludeOutboundPorts comma separated list of integers
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                  includedIPRanges:
+                                    description: IncludedIPRanges specifies which outbound IP ranges should be routed through the sidecar. .Values.global.proxy.includeIPRanges, overridden by traffic.sidecar.istio.io/includeOutboundIPRanges * or comma separated list of CIDR
+                                    items:
+                                      type: string
+                                    type: array
+                                  policy:
+                                    description: Policy specifies what outbound traffic is allowed through the sidecar. .Values.global.outboundTrafficPolicy.mode
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      runtime:
+                        description: Runtime is used to customize runtime configuration for the sidecar container.
+                        properties:
+                          container:
+                            description: Container configures the sidecar container.
+                            properties:
+                              env:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              imageName:
+                                type: string
+                              imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when to pull a container image
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute resource requirements.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                            type: object
+                          readiness:
+                            description: Readiness configures the readiness probe behavior for the injected pod.
+                            properties:
+                              failureThreshold:
+                                description: FailureThreshold represents the number of consecutive failures before the container is marked as not ready. .Values.global.proxy.readinessFailureThreshold, overridden by readiness.status.sidecar.istio.io/failureThreshold, defaults to 30
+                                format: int32
+                                type: integer
+                              initialDelaySeconds:
+                                description: InitialDelaySeconds specifies the initial delay for the readiness probe .Values.global.proxy.readinessInitialDelaySeconds, overridden by readiness.status.sidecar.istio.io/initialDelaySeconds, defaults to 1
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: PeriodSeconds specifies the period over which the probe is checked. .Values.global.proxy.readinessPeriodSeconds, overridden by readiness.status.sidecar.istio.io/periodSeconds, defaults to 2
+                                format: int32
+                                type: integer
+                              rewriteApplicationProbes:
+                                description: RewriteApplicationProbes specifies whether or not the injector should rewrite application container probes to be routed through the sidecar. .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe, defaults to false rewrite probes for application pods to route through sidecar
+                                type: boolean
+                              statusPort:
+                                description: 'StatusPort specifies the port number to be used for status. .Values.global.proxy.statusPort, overridden by status.sidecar.istio.io/port, defaults to 15020 Default port for Pilot agent health checks. A value of 0 will disable health checking. XXX: this has no affect on which port is actually used for status.'
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  runtime:
+                    description: Runtime configuration for pilot (and galley, etc., pre 2.0)
+                    properties:
+                      components:
+                        additionalProperties:
+                          description: ComponentRuntimeConfig allows for partial customization of a component's runtime configuration (Deployment, PodTemplate, auto scaling, pod disruption, etc.)
+                          properties:
+                            container:
+                              description: .Values.*.resource, imagePullPolicy, etc.
+                              properties:
+                                env:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                imageName:
+                                  type: string
+                                imagePullPolicy:
+                                  description: PullPolicy describes a policy for if/when to pull a container image
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                    type: object
+                                  type: array
+                                imageRegistry:
+                                  type: string
+                                imageTag:
+                                  type: string
+                                resources:
+                                  description: ResourceRequirements describes the compute resource requirements.
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                              type: object
+                            deployment:
+                              description: Deployment specific overrides
+                              properties:
+                                autoScaling:
+                                  description: Autoscaling specifies the configuration for a HorizontalPodAutoscaler to be applied to this deployment.  Null indicates no auto scaling. .Values.*.autoscale* fields
+                                  properties:
+                                    enabled:
+                                      description: Enabled specifies whether or not this feature is enabled
+                                      type: boolean
+                                    maxReplicas:
+                                      description: upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+                                      format: int32
+                                      type: integer
+                                    minReplicas:
+                                      description: lower limit for the number of pods that can be set by the autoscaler, default 1.
+                                      format: int32
+                                      type: integer
+                                    targetCPUUtilizationPercentage:
+                                      description: target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                replicas:
+                                  description: Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. .Values.*.replicaCount
+                                  format: int32
+                                  type: integer
+                                strategy:
+                                  description: The deployment strategy to use to replace existing pods with new ones. .Values.*.rollingMaxSurge, rollingMaxUnavailable, etc.
+                                  properties:
+                                    rollingUpdate:
+                                      properties:
+                                        maxSurge:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                                          x-kubernetes-int-or-string: true
+                                        maxUnavailable:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    type:
+                                      description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                      type: string
+                                  type: object
+                              type: object
+                            pod:
+                              description: Pod specific overrides
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling constraints .Values.podAntiAffinityLabelSelector, podAntiAffinityTermLabelSelector, nodeSelector NodeAffinity is not supported at this time PodAffinity is not supported at this time
+                                  properties:
+                                    podAntiAffinity:
+                                      description: 'XXX: use corev1.PodAntiAffinity instead, the only things not supported are namespaces and weighting'
+                                      properties:
+                                        preferredDuringScheduling:
+                                          items:
+                                            description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        requiredDuringScheduling:
+                                          items:
+                                            description: PodAntiAffinityTerm is a simplified version of corev1.PodAntiAffinityTerm
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                metadata:
+                                  description: 'Metadata allows additional annotations/labels to be applied to the pod .Values.*.podAnnotations XXX: currently, additional lables are not supported'
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                  type: object
+                                priorityClassName:
+                                  description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                  type: string
+                                tolerations:
+                                  description: If specified, the pod's tolerations. .Values.tolerations
+                                  items:
+                                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                    properties:
+                                      effect:
+                                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        description: Components allows specifying execution parameters for specific control plane componets.  The key of the map is the component name to which the settings should be applied.
+                        type: object
+                      defaults:
+                        description: Defaults will be merged into specific component config. .Values.global.defaultResources, e.g.
+                        properties:
+                          container:
+                            description: Container overrides to be merged with component specific overrides.
+                            properties:
+                              imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when to pull a container image
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                  type: object
+                                type: array
+                              imageRegistry:
+                                type: string
+                              imageTag:
+                                type: string
+                              resources:
+                                description: ResourceRequirements describes the compute resource requirements.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                            type: object
+                          deployment:
+                            description: Deployment defaults
+                            properties:
+                              podDisruption:
+                                description: '.Values.global.podDisruptionBudget.enabled, if not null XXX: this is currently a global setting, not per component.  perhaps this should only be available on the defaults?'
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  minAvailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          pod:
+                            description: Pod defaults
+                            properties:
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ .Values.nodeSelector'
+                                type: object
+                              priorityClassName:
+                                description: '.Values.global.priorityClassName XXX: currently, this is only a global setting.  maybe only allow setting in global runtime defaults?'
+                                type: string
+                              tolerations:
+                                description: If specified, the pod's tolerations. .Values.tolerations
+                                items:
+                                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  security:
+                    description: Security configures aspects of security for the control plane.
+                    properties:
+                      certificateAuthority:
+                        description: CertificateAuthority configures the certificate authority used by the control plane to create and sign client certs and server keys.
+                        properties:
+                          custom:
+                            description: Custom is the configuration for a custom certificate authority.
+                            properties:
+                              address:
+                                description: 'Address is the grpc address for an Istio compatible certificate authority endpoint. .Values.global.caAddress XXX: assumption is this is a grpc endpoint that provides methods like istio.v1.auth.IstioCertificateService/CreateCertificate'
+                                type: string
+                            type: object
+                          istiod:
+                            description: Istiod is the configuration for Istio's internal certificate authority implementation. each of these produces a CAEndpoint, i.e. CA_ADDR
+                            properties:
+                              privateKey:
+                                description: PrivateKey configures istiod to use a user specified private key/cert when signing certificates.
+                                properties:
+                                  rootCADir:
+                                    description: 'hard coded to use a secret named cacerts EncryptionSecret string `json:"encryptionSecret,omitempty"` ROOT_CA_DIR, defaults to /etc/cacerts Mount directory for encryption secret XXX: currently, not configurable in the charts'
+                                    type: string
+                                type: object
+                              selfSigned:
+                                description: SelfSigned configures istiod to generate and use a self-signed certificate for the root.
+                                properties:
+                                  checkPeriod:
+                                    description: CheckPeriod is the interval with which certificate is checked for rotation env CITADEL_SELF_SIGNED_ROOT_CERT_CHECK_INTERVAL default is 1 hour, zero or negative value disables cert rotation
+                                    type: string
+                                  enableJitter:
+                                    description: EnableJitter to use jitter for cert rotation env CITADEL_ENABLE_JITTER_FOR_ROOT_CERT_ROTATOR defaults to true
+                                    type: boolean
+                                  gracePeriod:
+                                    description: GracePeriod percentile for self-signed cert env CITADEL_SELF_SIGNED_ROOT_CERT_GRACE_PERIOD_PERCENTILE default is 20%
+                                    type: string
+                                  ttl:
+                                    description: TTL for self-signed root certificate env CITADEL_SELF_SIGNED_CA_CERT_TTL default is 10 years
+                                    type: string
+                                type: object
+                              type:
+                                description: Type of certificate signer to use.
+                                type: string
+                              workloadCertTTLDefault:
+                                description: WorkloadCertTTLDefault is the default TTL for generated workload certificates.  Used if not specified in CSR (<= 0) env DEFAULT_WORKLOAD_CERT_TTL, 1.6 --workload-cert-ttl, citadel, pre-1.6 defaults to 24 hours
+                                type: string
+                              workloadCertTTLMax:
+                                description: WorkloadCertTTLMax is the maximum TTL for generated workload certificates. env MAX_WORKLOAD_CERT_TTL --max-workload-cert-ttl, citadel, pre-1.6 defaults to 90 days
+                                type: string
+                            type: object
+                          type:
+                            description: Type is the certificate authority to use.
+                            type: string
+                        type: object
+                      controlPlane:
+                        description: ControlPlane configures mutual TLS for control plane communication.
+                        properties:
+                          certProvider:
+                            description: CertProvider is the certificate authority used to generate the serving certificates for the control plane components. .Values.global.pilotCertProvider Provider used to generate serving certs for istiod (pilot)
+                            type: string
+                          mtls:
+                            description: Enable mutual TLS for the control plane components. .Values.global.controlPlaneSecurityEnabled
+                            type: boolean
+                          tls:
+                            description: TLS configures aspects of TLS listeners created by control plane components.
+                            properties:
+                              cipherSuites:
+                                description: CipherSuites configures the cipher suites that are available for use by TLS listeners. .Values.global.tls.cipherSuites
+                                items:
+                                  type: string
+                                type: array
+                              ecdhCurves:
+                                description: ECDHCurves configures the ECDH curves that are available for use by TLS listeners. .Values.global.tls.ecdhCurves
+                                items:
+                                  type: string
+                                type: array
+                              maxProtocolVersion:
+                                description: MaxProtocolVersion the maximum TLS version that should be supported by the listeners. .Values.global.tls.maxProtocolVersion
+                                type: string
+                              minProtocolVersion:
+                                description: MinProtocolVersion the minimum TLS version that should be supported by the listeners. .Values.global.tls.minProtocolVersion
+                                type: string
+                            type: object
+                        type: object
+                      dataPlane:
+                        description: DataPlane configures mutual TLS for data plane communication.
+                        properties:
+                          automtls:
+                            description: Auto configures the mesh to automatically detect whether or not mutual TLS is required for a specific connection. .Values.global.mtls.auto
+                            type: boolean
+                          mtls:
+                            description: Enable mutual TLS by default. .Values.global.mtls.enabled
+                            type: boolean
+                        type: object
+                      identity:
+                        description: Identity configures the types of user tokens used by clients.
+                        properties:
+                          thirdParty:
+                            description: 'ThirdParty configures istiod to use a third-party token provider for identifying users. (basically uses a custom audience, e.g. istio-ca) XXX: this is only supported on OCP 4.4+'
+                            properties:
+                              audience:
+                                description: Audience is the audience for whom the token is intended. env AUDIENCE .Values.global.sds.token.aud, defaults to istio-ca
+                                type: string
+                              issuer:
+                                description: Issuer is the URL of the issuer. env TOKEN_ISSUER, defaults to iss in specified token only supported in 1.6+
+                                type: string
+                            type: object
+                          type:
+                            description: Type is the type of identity tokens being used. .Values.global.jwtPolicy
+                            type: string
+                        type: object
+                      trust:
+                        description: Trust configures trust aspects associated with mutual TLS clients.
+                        properties:
+                          additionalDomains:
+                            description: AdditionalDomains are additional SPIFFE trust domains that are accepted as trusted. .Values.global.trustDomainAliases, maps to trustDomainAliases  Any service with the identity "td1/ns/foo/sa/a-service-account", "td2/ns/foo/sa/a-service-account",  or "td3/ns/foo/sa/a-service-account" will be treated the same in the Istio mesh.
+                            items:
+                              type: string
+                            type: array
+                          domain:
+                            description: Domain specifies the trust domain to be used by the mesh. .Values.global.trustDomain, maps to trustDomain The trust domain corresponds to the trust root of a system. Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
+                            type: string
+                        type: object
+                    type: object
+                  techPreview:
+                    description: TechPreview contains switches for features that are not GA yet.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  telemetry:
+                    description: Telemetry configures telemetry for the mesh. .Values.mixer.telemetry.enabled, true if not null.  1.6, .Values.telemetry.enabled
+                    properties:
+                      mixer:
+                        description: Mixer represents legacy, v1 telemetry. implies .Values.telemetry.v1.enabled, if not null
+                        properties:
+                          adapters:
+                            description: Adapters configures the adapters used by mixer telemetry.
+                            properties:
+                              kubernetesenv:
+                                description: KubernetesEnv enables support for the kubernetesenv adapter. .Values.mixer.adapters.kubernetesenv.enabled, defaults to true
+                                type: boolean
+                              stdio:
+                                description: Stdio enables and configures the stdio adapter.
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether or not this feature is enabled
+                                    type: boolean
+                                  outputAsJSON:
+                                    description: OutputAsJSON if true. .Values.mixer.adapters.stdio.outputAsJson, defaults to false
+                                    type: boolean
+                                type: object
+                              useAdapterCRDs:
+                                description: 'UseAdapterCRDs specifies whether or not mixer should support deprecated CRDs. .Values.mixer.adapters.useAdapterCRDs, removed in istio 1.4, defaults to false XXX: i think this can be removed completely'
+                                type: boolean
+                            type: object
+                          batching:
+                            description: Batching settings used when sending telemetry.
+                            properties:
+                              maxEntries:
+                                description: MaxEntries represents the maximum number of entries to collect before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxEntries, maps to MeshConfig.reportBatchMaxEntries Set reportBatchMaxEntries to 0 to use the default batching behavior (i.e., every 100 requests). A positive value indicates the number of requests that are batched before telemetry data is sent to the mixer server
+                                format: int32
+                                type: integer
+                              maxTime:
+                                description: MaxTime represents the maximum amount of time to hold entries before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxTime, maps to MeshConfig.reportBatchMaxTime Set reportBatchMaxTime to 0 to use the default batching behavior (i.e., every 1 second). A positive time value indicates the maximum wait time since the last request will telemetry data be batched before being sent to the mixer server
+                                type: string
+                            type: object
+                          loadshedding:
+                            description: Loadshedding configuration for telemetry .Values.mixer.telemetry.loadshedding
+                            properties:
+                              latencyThreshold:
+                                description: LatencyThreshold -- .Values.mixer.telemetry.loadshedding.latencyThreshold
+                                type: string
+                              mode:
+                                description: 'Mode represents the loadshedding mode applied to mixer when it becomes overloaded.  Valid values: disabled, logonly or enforce .Values.mixer.telemetry.loadshedding.mode'
+                                type: string
+                            type: object
+                          sessionAffinity:
+                            description: SessionAffinity configures session affinity for sidecar telemetry connections. .Values.mixer.telemetry.sessionAffinityEnabled, maps to MeshConfig.sidecarToTelemetrySessionAffinity
+                            type: boolean
+                        type: object
+                      remote:
+                        description: Remote represents a remote, legacy, v1 telemetry.
+                        properties:
+                          address:
+                            description: Address is the address of the remote telemetry server .Values.global.remoteTelemetryAddress, maps to MeshConfig.mixerReportServer
+                            type: string
+                          batching:
+                            description: Batching settings used when sending telemetry.
+                            properties:
+                              maxEntries:
+                                description: MaxEntries represents the maximum number of entries to collect before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxEntries, maps to MeshConfig.reportBatchMaxEntries Set reportBatchMaxEntries to 0 to use the default batching behavior (i.e., every 100 requests). A positive value indicates the number of requests that are batched before telemetry data is sent to the mixer server
+                                format: int32
+                                type: integer
+                              maxTime:
+                                description: MaxTime represents the maximum amount of time to hold entries before sending them to mixer. .Values.mixer.telemetry.reportBatchMaxTime, maps to MeshConfig.reportBatchMaxTime Set reportBatchMaxTime to 0 to use the default batching behavior (i.e., every 1 second). A positive time value indicates the maximum wait time since the last request will telemetry data be batched before being sent to the mixer server
+                                type: string
+                            type: object
+                          createService:
+                            description: CreateService for the remote server. .Values.global.createRemoteSvcEndpoints
+                            type: boolean
+                        type: object
+                      type:
+                        description: Type of telemetry implementation to use.
+                        type: string
+                    type: object
+                  tracing:
+                    description: Tracing configures tracing for the mesh.
+                    properties:
+                      sampling:
+                        description: 'Sampling sets the mesh-wide trace sampling percentage. Should be between 0.0 - 100.0. Precision to 0.01, scaled as 0 to 10000, e.g.: 100% = 10000, 1% = 100 .Values.pilot.traceSampling'
+                        format: int32
+                        maximum: 10000
+                        minimum: 0
+                        type: integer
+                      type:
+                        description: Type represents the type of tracer to be installed.
+                        type: string
+                    type: object
+                  version:
+                    description: Version specifies what Maistra version of the control plane to install. When creating a new ServiceMeshControlPlane with an empty version, the admission webhook sets the version to the current version. Existing ServiceMeshControlPlanes with an empty version are treated as having the version set to "v1.0"
+                    type: string
+                type: object
+              appliedValues:
+                description: The resulting values.yaml used to generate the charts.
+                properties:
+                  istio:
+                    description: 'Specifies the Istio configuration options that are passed to Helm when the Istio charts are rendered. These options are usually populated from the template specified in the spec.template field, but individual values can be overridden here. More info: https://maistra.io/docs/installation/installation-options/'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  networkType:
+                    description: 'DEPRECATED: No longer used anywhere. Previously used to specify the NetworkType of the cluster. Defaults to "subnet".'
+                    type: string
+                  profiles:
+                    description: Profiles selects the profile to use for default values. Defaults to "default" when not set.  Takes precedence over Template.
+                    items:
+                      type: string
+                    type: array
+                  template:
+                    description: Template selects the template to use for default values. Defaults to "default" when not set. DEPRECATED - use Profiles instead
+                    type: string
+                  threeScale:
+                    description: 'Specifies the 3Scale configuration options that are passed to Helm when the 3Scale charts are rendered. These values are usually populated from the template specified in the spec.template field, but individual values can be overridden here. More info: https://maistra.io/docs/installation/installation-options/#_3scale'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  version:
+                    description: Version specifies what Maistra version of the control plane to install. When creating a new ServiceMeshControlPlane with an empty version, the admission webhook sets the version to the latest version supported by the operator. Existing ServiceMeshControlPlanes with an empty version are treated as having the version set to "v1.0"
+                    type: string
+                type: object
+              chartVersion:
+                description: The version of the charts that were last processed for this resource.
+                type: string
+              components:
+                items:
+                  description: ComponentStatus represents the status of an object with children
+                  properties:
+                    children:
+                      description: 'TODO: can we remove this? it''s not used anywhere The status of each resource that comprises this component.'
+                      items:
+                        description: StatusType represents the status for a control plane, component, or resource
+                        properties:
+                          conditions:
+                            description: Represents the latest available observations of the object's current state.
+                            items:
+                              description: A Condition represents a specific observation of the object's state.
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details about the last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, single-word, CamelCase reason for the condition's last transition.
+                                  type: string
+                                status:
+                                  description: The status of this condition. Can be True, False or Unknown.
+                                  type: string
+                                type:
+                                  description: The type of this condition.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    conditions:
+                      description: Represents the latest available observations of the object's current state.
+                      items:
+                        description: A Condition represents a specific observation of the object's state.
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human-readable message indicating details about the last transition.
+                            type: string
+                          reason:
+                            description: Unique, single-word, CamelCase reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: The status of this condition. Can be True, False or Unknown.
+                            type: string
+                          type:
+                            description: The type of this condition.
+                            type: string
+                        type: object
+                      type: array
+                    resource:
+                      description: The name of the component this status pertains to.
+                      type: string
+                  type: object
+                type: array
+              conditions:
+                description: Represents the latest available observations of the object's current state.
+                items:
+                  description: A Condition represents a specific observation of the object's state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about the last transition.
+                      type: string
+                    reason:
+                      description: Unique, single-word, CamelCase reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: The status of this condition. Can be True, False or Unknown.
+                      type: string
+                    type:
+                      description: The type of this condition.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the controller during the most recent reconciliation. The information in the status pertains to this particular generation of the object.
+                format: int64
+                type: integer
+              operatorVersion:
+                description: The version of the operator that last processed this resource.
+                type: string
+              readiness:
+                description: The readiness status of components & owned resources
+                properties:
+                  components:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: The readiness status of components
+                    type: object
+                type: object
+            required:
+            - readiness
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/vendor/maistra.io/api/manifests/maistra.io_servicemeshextensions.yaml
+++ b/vendor/maistra.io/api/manifests/maistra.io_servicemeshextensions.yaml
@@ -1,0 +1,193 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: servicemeshextensions.maistra.io
+spec:
+  group: maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshExtension
+    listKind: ServiceMeshExtensionList
+    plural: servicemeshextensions
+    shortNames:
+    - sme
+    singular: servicemeshextension
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Whether this extension is ready to be consumed
+      jsonPath: .status.deployment.ready
+      name: Ready
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ServiceMeshExtension is the Schema for the servicemeshextensions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceMeshExtensionSpec defines the desired state of ServiceMeshExtension
+            properties:
+              config:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              image:
+                type: string
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                type: string
+              imagePullSecrets:
+                items:
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
+              phase:
+                description: FilterPhase defines point of injection of Envoy filter
+                type: string
+              priority:
+                type: integer
+              workloadSelector:
+                description: WorkloadSelector is used to match workloads based on pod labels
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - labels
+                type: object
+            required:
+            - phase
+            type: object
+          status:
+            description: ServiceMeshExtensionStatus defines the observed state of ServiceMeshExtension
+            properties:
+              deployment:
+                properties:
+                  containerSha256:
+                    type: string
+                  message:
+                    type: string
+                  ready:
+                    type: boolean
+                  sha256:
+                    type: string
+                  url:
+                    type: string
+                type: object
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                description: FilterPhase defines point of injection of Envoy filter
+                type: string
+              priority:
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceMeshExtension is the Schema for the servicemeshextensions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceMeshExtensionSpec defines the desired state of ServiceMeshExtension
+            properties:
+              config:
+                type: string
+              image:
+                type: string
+              imagePullPolicy:
+                description: PullPolicy describes a policy for if/when to pull a container image
+                type: string
+              imagePullSecrets:
+                items:
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
+              phase:
+                description: FilterPhase defines point of injection of Envoy filter
+                type: string
+              priority:
+                type: integer
+              workloadSelector:
+                description: WorkloadSelector is used to match workloads based on pod labels
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - labels
+                type: object
+            required:
+            - phase
+            type: object
+          status:
+            description: ServiceMeshExtensionStatus defines the observed state of ServiceMeshExtension
+            properties:
+              deployment:
+                properties:
+                  containerSha256:
+                    type: string
+                  message:
+                    type: string
+                  ready:
+                    type: boolean
+                  sha256:
+                    type: string
+                  url:
+                    type: string
+                type: object
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                description: FilterPhase defines point of injection of Envoy filter
+                type: string
+              priority:
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/vendor/maistra.io/api/manifests/maistra.io_servicemeshmemberrolls.yaml
+++ b/vendor/maistra.io/api/manifests/maistra.io_servicemeshmemberrolls.yaml
@@ -1,0 +1,170 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: servicemeshmemberrolls.maistra.io
+spec:
+  group: maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshMemberRoll
+    listKind: ServiceMeshMemberRollList
+    plural: servicemeshmemberrolls
+    shortNames:
+    - smmr
+    singular: servicemeshmemberroll
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: How many of the total number of member namespaces are configured
+      jsonPath: .status.annotations.configuredMemberCount
+      name: Ready
+      type: string
+    - description: Whether all member namespaces have been configured or why that's not the case
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Status
+      type: string
+    - description: The age of the object
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Namespaces that are members of this Control Plane
+      jsonPath: .status.members
+      name: Members
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: The ServiceMeshMemberRoll object configures which namespaces belong to a service mesh. Only namespaces listed in the ServiceMeshMemberRoll will be affected by the control plane. Any number of namespaces can be added, but a namespace may not exist in more than one service mesh. The ServiceMeshMemberRoll object must be created in the same namespace as the ServiceMeshControlPlane object and must be named "default".
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired list of members of the service mesh.
+            properties:
+              members:
+                description: ' List of namespaces that should be members of the service mesh.'
+                items:
+                  type: string
+                nullable: true
+                type: array
+            type: object
+          status:
+            description: The current status of this ServiceMeshMemberRoll. This data may be out of date by some window of time.
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations is an unstructured key value map used to store additional, usually redundant status information, such as the number of components deployed by the ServiceMeshControlPlane (number is redundant because you could just as easily count the elements in the ComponentStatus array). The reason to add this redundant information is to make it available to kubectl, which does not yet allow counting objects in JSONPath expressions.
+                type: object
+              conditions:
+                description: Represents the latest available observations of this ServiceMeshMemberRoll's current state.
+                items:
+                  description: Condition represents a specific condition on a resource
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: 'ServiceMeshMemberRollConditionType represents the type of the condition.  Condition types are: Reconciled, NamespaceConfigured'
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              configuredMembers:
+                description: List of namespaces that are configured as members of the service mesh.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              memberStatuses:
+                description: Represents the latest available observations of each member's current state.
+                items:
+                  description: ServiceMeshMemberStatusSummary represents a summary status of a ServiceMeshMember.
+                  properties:
+                    conditions:
+                      items:
+                        description: Condition represents a specific condition on a resource
+                        properties:
+                          lastTransitionTime:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            description: 'ServiceMeshMemberConditionType represents the type of the condition.  Condition types are: Reconciled, NamespaceConfigured'
+                            type: string
+                        type: object
+                      type: array
+                    namespace:
+                      type: string
+                  required:
+                  - conditions
+                  - namespace
+                  type: object
+                nullable: true
+                type: array
+              members:
+                description: "Complete list of namespaces that are configured as members of the service mesh\t- this includes namespaces specified in spec.members and those that contain a ServiceMeshMember object"
+                items:
+                  type: string
+                nullable: true
+                type: array
+              meshGeneration:
+                description: The generation of the ServiceMeshControlPlane object observed by the controller during the most recent reconciliation of this ServiceMeshMemberRoll.
+                format: int64
+                type: integer
+              meshReconciledVersion:
+                description: The reconciled version of the ServiceMeshControlPlane object observed by the controller during the most recent reconciliation of this ServiceMeshMemberRoll.
+                type: string
+              observedGeneration:
+                description: The generation observed by the controller during the most recent reconciliation. The information in the status pertains to this particular generation of the object.
+                format: int64
+                type: integer
+              pendingMembers:
+                description: List of namespaces that haven't been configured as members of the service mesh yet.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              terminatingMembers:
+                description: List of namespaces that are being removed as members of the service mesh.
+                items:
+                  type: string
+                nullable: true
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/vendor/maistra.io/api/manifests/maistra.io_servicemeshmembers.yaml
+++ b/vendor/maistra.io/api/manifests/maistra.io_servicemeshmembers.yaml
@@ -1,0 +1,121 @@
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: servicemeshmembers.maistra.io
+spec:
+  group: maistra.io
+  names:
+    categories:
+    - maistra-io
+    kind: ServiceMeshMember
+    listKind: ServiceMeshMemberList
+    plural: servicemeshmembers
+    shortNames:
+    - smm
+    singular: servicemeshmember
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The ServiceMeshControlPlane this namespace belongs to
+      jsonPath: .status.annotations.controlPlaneRef
+      name: Control Plane
+      type: string
+    - description: Whether or not namespace is configured as a member of the mesh.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: The age of the object
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "A ServiceMeshMember object marks the namespace in which it lives as a member of the Service Mesh Control Plane referenced in the object. The ServiceMeshMember object should be created in each application namespace that must be part of the service mesh and must be named \"default\". \n When the ServiceMeshMember object is created, it causes the namespace to be added to the ServiceMeshMemberRoll within the namespace of the ServiceMeshControlPlane object the ServiceMeshMember references. \n To reference a ServiceMeshControlPlane, the user creating the ServiceMeshMember object must have the \"use\" permission on the referenced ServiceMeshControlPlane object. This permission is given via the mesh-users RoleBinding (and mesh-user Role) in the namespace of the referenced ServiceMeshControlPlane object."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The desired state of this ServiceMeshMember.
+            properties:
+              controlPlaneRef:
+                description: A reference to the ServiceMeshControlPlane object.
+                properties:
+                  name:
+                    description: The name of the referenced ServiceMeshControlPlane object.
+                    type: string
+                  namespace:
+                    description: The namespace of the referenced ServiceMeshControlPlane object.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - controlPlaneRef
+            type: object
+          status:
+            description: The current status of this ServiceMeshMember. This data may be out of date by some window of time.
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations is an unstructured key value map used to store additional, usually redundant status information, such as the number of components deployed by the ServiceMeshControlPlane (number is redundant because you could just as easily count the elements in the ComponentStatus array). The reason to add this redundant information is to make it available to kubectl, which does not yet allow counting objects in JSONPath expressions.
+                type: object
+              conditions:
+                description: Represents the latest available observations of a ServiceMeshMember's current state.
+                items:
+                  description: Condition represents a specific condition on a resource
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: 'ServiceMeshMemberConditionType represents the type of the condition.  Condition types are: Reconciled, NamespaceConfigured'
+                      type: string
+                  type: object
+                type: array
+              meshGeneration:
+                description: The generation of the ServiceMeshControlPlane object observed by the controller during the most recent reconciliation of this ServiceMeshMember.
+                format: int64
+                type: integer
+              meshReconciledVersion:
+                description: The reconciled version of the ServiceMeshControlPlane object observed by the controller during the most recent reconciliation of this ServiceMeshMember.
+                type: string
+              observedGeneration:
+                description: The generation observed by the controller during the most recent reconciliation. The information in the status pertains to this particular generation of the object.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            - observedGeneration
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/vendor/maistra.io/api/manifests/pkg.go
+++ b/vendor/maistra.io/api/manifests/pkg.go
@@ -1,0 +1,6 @@
+// DO NOT DELETE THIS FILE
+//
+// This file is needed because it allows other projects to
+// import the generated CRD manifests located in this folder
+// through the go module system.
+package manifests

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1753,7 +1753,7 @@ k8s.io/utils/exec
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# maistra.io/api v0.0.0-20210823191737-259bd5854df6
+# maistra.io/api v0.0.0-20211119171546-348bbce3ca27
 ## explicit
 maistra.io/api/client/informers/externalversions
 maistra.io/api/client/informers/externalversions/core
@@ -1790,6 +1790,7 @@ maistra.io/api/core/v1
 maistra.io/api/core/v1alpha1
 maistra.io/api/core/v2
 maistra.io/api/federation/v1
+maistra.io/api/manifests
 maistra.io/api/security/v1
 # sigs.k8s.io/controller-runtime v0.7.0
 ## explicit


### PR DESCRIPTION
This is a first `servicemesh` integration test. It covers setting up a federation that spans two clusters, exporting a service in one with an alias (ratings service), importing it in the second cluster, and then calling it from a `sleep` pod that lives in that second, importing cluster.

Depends on https://github.com/maistra/api/pull/26 which provides the CRD manifests through the go module system. That'll allow us to write more tests that require any of our CRDs (e.g. ServiceMeshExtension).