### PR TITLE
Disable failing integration tests (until OSSM-755 is fixed)

### DIFF
--- a/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
+++ b/tests/integration/security/file_mounted_certs/p2p_mtls_test.go
@@ -46,6 +46,8 @@ const (
 )
 
 func TestClientToServiceTls(t *testing.T) {
+	// https://issues.redhat.com/browse/OSSM-755
+	t.Skip("https://github.com/istio/istio/issues/0")
 	framework.NewTest(t).
 		Features("security.peer.file-mounted-certs").
 		Run(func(ctx framework.TestContext) {

--- a/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
+++ b/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
@@ -43,6 +43,8 @@ func mustReadFile(t *testing.T, f string) string {
 // TestDestinationRuleTls tests that MUTUAL tls mode is respected in DestinationRule.
 // This sets up a client and server with appropriate cert config and ensures we can successfully send a message.
 func TestDestinationRuleTls(t *testing.T) {
+	// https://issues.redhat.com/browse/OSSM-755
+	t.Skip("https://github.com/istio/istio/issues/0")
 	framework.
 		NewTest(t).
 		Features("security.egress.tls.filebased").

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -54,6 +54,8 @@ func mustReadCert(t *testing.T, f string) string {
 // This test brings up an egress gateway to originate TLS connection. The test will ensure that requests
 // are routed securely through the egress gateway and that the TLS origination happens at the gateway.
 func TestEgressGatewayTls(t *testing.T) {
+	// https://issues.redhat.com/browse/OSSM-755
+	t.Skip("https://github.com/istio/istio/issues/0")
 	framework.NewTest(t).
 		Features("security.egress.tls.filebased").
 		Run(func(ctx framework.TestContext) {

--- a/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/sds_tls_origination/egress_gateway_origination_test.go
@@ -35,6 +35,8 @@ import (
 // TestSimpleTlsOrigination test SIMPLE TLS mode with TLS origination happening at Gateway proxy
 // It uses CredentialName set in DestinationRule API to fetch secrets from k8s API server
 func TestSimpleTlsOrigination(t *testing.T) {
+	// https://issues.redhat.com/browse/OSSM-755
+	t.Skip("https://github.com/istio/istio/issues/0")
 	framework.NewTest(t).
 		Features("security.egress.tls.sds").
 		Run(func(ctx framework.TestContext) {
@@ -137,6 +139,8 @@ func TestSimpleTlsOrigination(t *testing.T) {
 // TestMutualTlsOrigination test MUTUAL TLS mode with TLS origination happening at Gateway proxy
 // It uses CredentialName set in DestinationRule API to fetch secrets from k8s API server
 func TestMutualTlsOrigination(t *testing.T) {
+	// https://issues.redhat.com/browse/OSSM-755
+	t.Skip("https://github.com/istio/istio/issues/0")
 	framework.NewTest(t).
 		Features("security.egress.mtls.sds").
 		Run(func(ctx framework.TestContext) {


### PR DESCRIPTION
This is a stop-gap measure until OSSM-755 is fixed.