### PR TITLE
OSSM-774 Fix flaky TestStatusManager

### DIFF
--- a/pkg/servicemesh/federation/status/manager_test.go
+++ b/pkg/servicemesh/federation/status/manager_test.go
@@ -811,6 +811,8 @@ func TestStatusManager(t *testing.T) {
 			for index, f := range tc.events {
 				t.Logf("processing event %d", index)
 				f(handler)
+				// give it a little time for the status update to propagate
+				time.Sleep(25 * time.Millisecond)
 				verifyPeerStatus(t, cs, tc.mesh, &tc.status[index].peer, tc.assertions[index])
 				verifyExportStatus(t, cs, tc.mesh, &tc.status[index].exports)
 				verifyImportStatus(t, cs, tc.mesh, &tc.status[index].imports)


### PR DESCRIPTION
This adds a little sleep to our unit tests for the StatusManager, because without it, we're running into the issue that we're updating a ServiceMeshPeer's status very quickly, and in some cases it might be that the last change has not been propagated when we're generating the patch for the next status change, which can lead to failures (because the patch that is based on outdated information does not e.g. remove a field that should be removed).

This can happen in the real world, but you would need to change a ServiceMeshPeer's status within a few milliseconds, I doubt that it affects users. It would also be fixed with the next status update. For those reasons, I'm only fixing it in the test, with a Sleep() call.