### PR TITLE
Remove redundant function ApplyServiceMeshCRDs

### DIFF
--- a/tests/integration/servicemesh/federation/federation_test.go
+++ b/tests/integration/servicemesh/federation/federation_test.go
@@ -1,4 +1,6 @@
+//go:build integ
 // +build integ
+
 // Copyright Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +39,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireMinClusters(2).
-		Setup(servicemesh.ApplyServiceMeshCRDs).
 		Setup(istio.Setup(GetIstioInstance(), setupConfig)).
 		Run()
 }

--- a/tests/integration/servicemesh/util.go
+++ b/tests/integration/servicemesh/util.go
@@ -1,4 +1,6 @@
+//go:build integ
 // +build integ
+
 // Copyright Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,9 +20,7 @@ package servicemesh
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
-	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -32,13 +32,11 @@ import (
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/cluster"
-	"istio.io/istio/pkg/test/framework/resource"
 	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
 var (
-	manifestsDir      = env.IstioSrc + "/vendor/maistra.io/api/manifests"
 	bookinfoManifests = []string{
 		env.IstioSrc + "/samples/bookinfo/platform/kube/bookinfo.yaml",
 		env.IstioSrc + "/samples/bookinfo/networking/bookinfo-gateway.yaml",
@@ -46,33 +44,6 @@ var (
 	sleepManifest = env.IstioSrc + "/samples/sleep/sleep.yaml"
 	rnd           = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
-
-func ApplyServiceMeshCRDs(ctx resource.Context) (err error) {
-	crds, err := findCRDs()
-	if err != nil {
-		return fmt.Errorf("cannot read maistra CRD YAMLs: %s", err)
-	}
-	for _, cluster := range ctx.Clusters().Kube().Primaries() {
-		if err = cluster.ApplyYAMLFiles("", crds...); err != nil {
-			return err
-		}
-	}
-	return err
-}
-
-func findCRDs() (list []string, err error) {
-	list = []string{}
-	files, err := ioutil.ReadDir(manifestsDir)
-	if err != nil {
-		return
-	}
-	for _, file := range files {
-		if !file.IsDir() && strings.HasSuffix(file.Name(), ".yaml") {
-			list = append(list, file.Name())
-		}
-	}
-	return
-}
 
 func InstallBookinfo(ctx framework.TestContext, c cluster.Cluster, namespace string) {
 	if err := c.ApplyYAMLFiles(namespace, bookinfoManifests...); err != nil {


### PR DESCRIPTION
Function `ApplyServiceMeshCRDs` was added in #447, but it's redundant, because Maistra CRDs already exist in [manifests directory](https://github.com/maistra/istio/tree/maistra-2.1/manifests/charts/base/crds).

What's more, this function has no effect, because `os.Stat` returns `no such file or directory` for all files in `${IstioSrc}/vendor/maistra.io/api/manifests` and `kubectl apply` skips these files.