### PR TITLE
OSSM-1185 Make sure to generate valid ImageStreamImport names

### DIFF
--- a/mec/pkg/pullstrategy/ossm/strategy.go
+++ b/mec/pkg/pullstrategy/ossm/strategy.go
@@ -239,7 +239,7 @@ func (p *ossmPullStrategy) Login(registryURL, token string) (output string, err 
 }
 
 func getImageStreamName(image *model.ImageRef) string {
-	reponame := image.Repository
+	reponame := strings.Replace(image.Repository, "-", "", -1)
 	if len(reponame) > 8 {
 		reponame = reponame[:8]
 	}

--- a/mec/pkg/pullstrategy/ossm/strategy_test.go
+++ b/mec/pkg/pullstrategy/ossm/strategy_test.go
@@ -294,6 +294,44 @@ func TestPullImage(t *testing.T) {
 			imageRef:      model.StringToImageRef("docker.io/test/test:latest"),
 			expectedError: true,
 		},
+		{
+			name: "pass_imageStreamPresent",
+			imageStream: &imagev1.ImageStream{
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{
+							From: &v1.ObjectReference{
+								Name: "docker.io/test/service-mesh-wasm-go:latest",
+							},
+						},
+					},
+				},
+				Status: imagev1.ImageStreamStatus{
+					DockerImageRepository: "docker.io/test/service-mesh-wasm-go",
+					Tags: []imagev1.NamedTagEventList{
+						{
+							Conditions: []imagev1.TagEventCondition{
+								{
+									Status: v1.ConditionTrue,
+								},
+							},
+							Items: []imagev1.TagEvent{
+								{
+									Image: "sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3",
+								},
+							},
+						},
+					},
+				},
+			},
+			imageRef:      model.StringToImageRef("docker.io/test/service-mesh-wasm-go:latest"),
+			expectedError: false,
+			expectedImage: &ossmImage{
+				imageID:  "41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3",
+				sha256:   "sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3",
+				manifest: &fakestrategy.FakeManifest,
+			},
+		},
 	}
 	fakePodman := &fakePodman{}
 	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Please provide a description of this PR:**
https://issues.redhat.com/browse/MAISTRA-2747
Exactly, if the image name of the user wasm contains a '-' in 8 position, the name will have a '-' and the separator is a '-' so the ImageStreamImport will have a double '--' and the name doesn't comply a ImageStreamImport regex expression: "[a-z0-9](?:[._-][a-z0-9])*" 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [X] User Experience
- [X] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
