### PR TITLE
OSSM-1430: CNI: Watch for modified files with a prefix

### DIFF
--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -178,7 +178,7 @@ func getCNIConfigFilepath(ctx context.Context, cfg pluginConfig) (string, error)
 		return filepath.Join(cfg.mountedCNINetDir, filename), nil
 	}
 
-	watcher, fileModified, errChan, err := util.CreateFileWatcher(cfg.mountedCNINetDir)
+	watcher, fileModified, errChan, err := util.CreateFileWatcher("", []string{cfg.mountedCNINetDir})
 	if err != nil {
 		return "", err
 	}

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -180,7 +180,7 @@ func readServiceAccountToken() (string, error) {
 func sleepCheckInstall(ctx context.Context, cfg *config.InstallConfig, cniConfigFilepath string, isReady *atomic.Value) error {
 	// Create file watcher before checking for installation
 	// so that no file modifications are missed while and after checking
-	watcher, fileModified, errChan, err := util.CreateFileWatcher(append(cfg.CNIBinTargetDirs, cfg.MountedCNINetDir)...)
+	watcher, fileModified, errChan, err := util.CreateFileWatcher(cfg.CNIBinariesPrefix, append(cfg.CNIBinTargetDirs, cfg.MountedCNINetDir))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Because our CNI pod contains more than one container, and they write to
the same directory, and they watch for changes on those directories,
changes made by one container trigger the watch on the other, which will
responde by copying the files to the directory, which will in turn
trigger the watcher of the other container in an endless loop.

This leads to high CPU usage on the node.

This PR changes the logic to only monitor for files that have the
desired prefix. Thus, for example, the 2.2 container will only react to
changes to files whose names  start with "v2-2". This avoid this race
condition and achieve the same end result.
