### PR TITLE
OSSM-1442: IOR: Ignore UPDATE events if resourceVersions are the same

### DIFF
--- a/pilot/pkg/config/kube/ior/client.go
+++ b/pilot/pkg/config/kube/ior/client.go
@@ -18,22 +18,22 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
+	"istio.io/istio/pkg/kube"
 )
 
-// KubeClient is an extension of `kubernetes.Interface` with auxiliary functions for IOR
+// KubeClient is an extension of `kube.Client` with auxiliary functions for IOR
 type KubeClient interface {
 	IsRouteSupported() bool
-	GetActualClient() kubernetes.Interface
+	GetActualClient() kube.Client
 	GetHandleEventTimeout() time.Duration
 }
 
 type kubeClient struct {
-	client kubernetes.Interface
+	client kube.Client
 }
 
 // NewKubeClient creates the IOR version of KubeClient
-func NewKubeClient(client kubernetes.Interface) KubeClient {
+func NewKubeClient(client kube.Client) KubeClient {
 	return &kubeClient{client: client}
 }
 
@@ -50,7 +50,7 @@ func (c *kubeClient) IsRouteSupported() bool {
 	return false
 }
 
-func (c *kubeClient) GetActualClient() kubernetes.Interface {
+func (c *kubeClient) GetActualClient() kube.Client {
 	return c.client
 }
 

--- a/pilot/pkg/config/kube/ior/fake.go
+++ b/pilot/pkg/config/kube/ior/fake.go
@@ -25,9 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/servicemesh/controller"
 )
 
@@ -44,11 +44,11 @@ type FakeRouterClient struct {
 }
 
 type fakeKubeClient struct {
-	client kubernetes.Interface
+	client kube.Client
 }
 
 // NewFakeKubeClient creates a new FakeKubeClient
-func NewFakeKubeClient(client kubernetes.Interface) KubeClient {
+func NewFakeKubeClient(client kube.Client) KubeClient {
 	return &fakeKubeClient{client: client}
 }
 
@@ -56,7 +56,7 @@ func (c *fakeKubeClient) IsRouteSupported() bool {
 	return true
 }
 
-func (c *fakeKubeClient) GetActualClient() kubernetes.Interface {
+func (c *fakeKubeClient) GetActualClient() kube.Client {
 	return c.client
 }
 

--- a/pilot/pkg/config/kube/ior/ior.go
+++ b/pilot/pkg/config/kube/ior/ior.go
@@ -62,7 +62,7 @@ func Register(
 
 	IORLog.Debugf("Registering IOR into Istio's Gateway broadcast")
 	kind := collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
-	store.RegisterEventHandler(kind, func(_, curr config.Config, event model.Event) {
+	store.RegisterEventHandler(kind, func(old, curr config.Config, event model.Event) {
 		aliveLock.Lock()
 		defer aliveLock.Unlock()
 		if !alive {
@@ -77,7 +77,9 @@ func Register(
 				return
 			}
 
-			IORLog.Debugf("Event %v arrived. Object: %v", event, curr)
+			IORLog.Debugf("Event %v arrived.", event)
+			IORLog.Debugf("Old object: %v", event, old)
+			IORLog.Debugf("New object: %v", event, curr)
 			if err := r.handleEvent(event, curr); err != nil {
 				IORLog.Errora(err)
 				if errorChannel != nil {

--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -363,6 +363,11 @@ func TestEdit(t *testing.T) {
 			validateRoutes(t, c.hosts, list, "gw", c.tls)
 		})
 	}
+
+	// Try to edit a gateway with the same resourceVersion
+	// No effect. UPDATE Event is not generated. I'll remove it.
+	IORLog.SetOutputLevel(log.DebugLevel)
+	editGateway(t, store, "istio-system", "gw", []string{"one.org.br"}, map[string]string{"istio": "ingressgateway"}, true, "6")
 }
 
 // TestPerf makes sure we are not doing more API calls than necessary

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -50,6 +50,8 @@ const (
 	gatewayNamespaceLabel       = maistraPrefix + "gateway-namespace"
 	gatewayResourceVersionLabel = maistraPrefix + "gateway-resourceVersion"
 	ShouldManageRouteAnnotation = maistraPrefix + "manageRoute"
+
+	eventDuplicatedMessage = "event UPDATE arrived but resourceVersions are the same - ignoring"
 )
 
 type syncRoutes struct {
@@ -354,7 +356,7 @@ func (r *route) verifyResourceVersions(cfg config.Config) error {
 		}
 	}
 
-	return fmt.Errorf("event UPDATE arrived but resourceVersions are the same - ignoring")
+	return fmt.Errorf(eventDuplicatedMessage)
 }
 
 func (r *route) handleEvent(event model.Event, cfg config.Config) error {

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -338,6 +338,25 @@ func (r *route) handleDel(cfg config.Config) error {
 	return result.ErrorOrNil()
 }
 
+func (r *route) verifyResourceVersions(cfg config.Config) error {
+	r.gatewaysLock.Lock()
+	defer r.gatewaysLock.Unlock()
+
+	key := gatewaysMapKey(cfg.Namespace, cfg.Name)
+	syncRoute, ok := r.gatewaysMap[key]
+	if !ok {
+		return fmt.Errorf("could not find an internal reference to gateway %s/%s", cfg.Namespace, cfg.Name)
+	}
+
+	for _, route := range syncRoute.routes {
+		if route.Labels[gatewayResourceVersionLabel] != cfg.ResourceVersion {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("event UPDATE arrived but resourceVersions are the same - ignoring")
+}
+
 func (r *route) handleEvent(event model.Event, cfg config.Config) error {
 	// Block until initial sync has finished
 	<-r.initialSyncRun
@@ -356,6 +375,10 @@ func (r *route) handleEvent(event model.Event, cfg config.Config) error {
 		return r.handleAdd(cfg)
 
 	case model.EventUpdate:
+		if err = r.verifyResourceVersions(cfg); err != nil {
+			return err
+		}
+
 		var result *multierror.Error
 		result = multierror.Append(result, r.handleDel(cfg))
 		result = multierror.Append(result, r.handleAdd(cfg))


### PR DESCRIPTION
For some obscure reason, it looks like we may receive UPDATE events with
the new object being equal to the old one. As IOR always delete and
recreate routes when receiving an UPDATE event, this might lead to some
service downtime, given for a few moments the route will not exist.

We guard against this behavior by comparing the `resourceVersion` field
of the new object and the one stored in the Route object.