### PR TITLE
[no-cluster-rbac] MAISTRA-2051: Allow istiod to run without Node access (#255)

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -158,6 +158,8 @@ func addFlags(c *cobra.Command) {
 		"The name of the MemberRoll resource")
 	c.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableCRDScan, "enableCRDScan", true,
 		"Whether to scan CRDs at startup")
+	c.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.DisableNodeAccess, "disableNodeAccess", false,
+		"Whether to prevent istiod watching Node objects")
 
 	// using address, so it can be configured as localhost:.. (possibly UDS in future)
 	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.HTTPAddr, "httpAddr", ":8080",

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -102,7 +102,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, args.Revision, s.kubeClient).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					if ingressV1 {
-						ingressSyncer := ingressv1.NewStatusSyncer(s.environment.Watcher, s.kubeClient)
+						ingressSyncer := ingressv1.NewStatusSyncer(s.environment.Watcher, s.kubeClient, args.RegistryOptions.KubeOptions.DisableNodeAccess)
 						// Start informers again. This fixes the case where informers for namespace do not start,
 						// as we create them only after acquiring the leader lock
 						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
@@ -112,7 +112,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 						log.Infof("Starting ingress controller")
 						ingressSyncer.Run(leaderStop)
 					} else {
-						ingressSyncer := ingress.NewStatusSyncer(s.environment.Watcher, s.kubeClient)
+						ingressSyncer := ingress.NewStatusSyncer(s.environment.Watcher, s.kubeClient, args.RegistryOptions.KubeOptions.DisableNodeAccess)
 						// Start informers again. This fixes the case where informers for namespace do not start,
 						// as we create them only after acquiring the leader lock
 						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -61,7 +61,7 @@ func (s *StatusSyncer) Run(stopCh <-chan struct{}) {
 }
 
 // NewStatusSyncer creates a new instance
-func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client) *StatusSyncer {
+func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client, noNodeAccess bool) *StatusSyncer {
 	// as in controller, ingressClassListener can be nil since not supported in k8s version <1.18
 	var ingressClassLister listerv1beta1.IngressClassLister
 	if NetworkingIngressAvailable(client) {
@@ -71,16 +71,20 @@ func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client) *StatusSynce
 	// queue requires a time duration for a retry delay after a handler error
 	q := queue.NewQueue(5 * time.Second)
 
-	return &StatusSyncer{
+	s := &StatusSyncer{
 		meshHolder:         meshHolder,
 		client:             client.Kube(),
 		ingressLister:      client.KubeInformer().Networking().V1beta1().Ingresses().Lister(),
 		podLister:          client.KubeInformer().Core().V1().Pods().Lister(),
 		serviceLister:      client.KubeInformer().Core().V1().Services().Lister(),
-		nodeLister:         client.KubeInformer().Core().V1().Nodes().Lister(),
 		ingressClassLister: ingressClassLister,
 		queue:              q,
 	}
+
+	if !noNodeAccess {
+		s.nodeLister = client.KubeInformer().Core().V1().Nodes().Lister()
+	}
+	return s
 }
 
 func (s *StatusSyncer) onEvent() error {
@@ -199,7 +203,7 @@ func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 
 	for _, pod := range igPods {
 		// only Running pods are valid
-		if pod.Status.Phase != coreV1.PodRunning {
+		if pod.Status.Phase != coreV1.PodRunning || s.nodeLister == nil {
 			continue
 		}
 

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -116,7 +116,7 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
-	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client)
+	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client, false)
 	stop := test.NewStop(t)
 	client.RunAndWait(stop)
 	return sync

--- a/pilot/pkg/config/kube/ingressv1/status_test.go
+++ b/pilot/pkg/config/kube/ingressv1/status_test.go
@@ -116,8 +116,9 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
-	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client)
-	client.RunAndWait(test.NewStop(t))
+	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client, false)
+	stop := test.NewStop(t)
+	client.RunAndWait(stop)
 	return sync
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -153,6 +153,12 @@ type Options struct {
 	// that are. If this is set to false, all CRDs defined in the schema must be
 	// present for istiod to function.
 	EnableCRDScan bool
+
+	// DisableNodeAccess determines whether the controller should attempt to
+	// watch and/or list Node objects.  If this is true, some features will not
+	// be available, e.g. NodePort gateways and determining locality information
+	// based on Nodes.
+	DisableNodeAccess bool
 }
 
 // DetectEndpointMode determines whether to use Endpoints or EndpointSlice based on the
@@ -371,10 +377,12 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		c.endpoints = newEndpointSliceController(c)
 	}
 
-	// This is for getting the node IPs of a selected set of nodes
-	c.nodeInformer = kubeClient.KubeInformer().Core().V1().Nodes().Informer()
-	c.nodeLister = kubeClient.KubeInformer().Core().V1().Nodes().Lister()
-	c.registerHandlers(c.nodeInformer, "Nodes", c.onNodeEvent, nil)
+	if !options.DisableNodeAccess {
+		// This is for getting the node IPs of a selected set of nodes
+		c.nodeInformer = kubeClient.KubeInformer().Core().V1().Nodes().Informer()
+		c.nodeLister = kubeClient.KubeInformer().Core().V1().Nodes().Lister()
+		c.registerHandlers(c.nodeInformer, "Nodes", c.onNodeEvent, nil)
+	}
 
 	podInformer := filter.NewFilteredSharedIndexInformer(c.opts.DiscoveryNamespacesFilter.Filter, kubeClient.KubeInformer().Core().V1().Pods().Informer())
 	c.pods = newPodCache(c, podInformer, func(key string) {
@@ -743,7 +751,7 @@ func (c *Controller) informersSynced() bool {
 		!c.serviceInformer.HasSynced() ||
 		!c.endpoints.HasSynced() ||
 		!c.pods.informer.HasSynced() ||
-		!c.nodeInformer.HasSynced() ||
+		(c.nodeInformer != nil && !c.nodeInformer.HasSynced()) ||
 		!c.exports.HasSynced() ||
 		!c.imports.HasSynced() {
 		return false
@@ -789,6 +797,9 @@ func (c *Controller) syncDiscoveryNamespaces() error {
 }
 
 func (c *Controller) syncNodes() error {
+	if c.nodeInformer == nil {
+		return nil
+	}
 	var err *multierror.Error
 	nodes := c.nodeInformer.GetIndexer().List()
 	log.Debugf("initializing %d nodes", len(nodes))
@@ -890,6 +901,19 @@ func (c *Controller) getPodLocality(pod *v1.Pod) string {
 	// if pod has `istio-locality` label, skip below ops
 	if len(pod.Labels[model.LocalityLabel]) > 0 {
 		return model.GetLocalityLabelOrDefault(pod.Labels[model.LocalityLabel], "")
+	}
+
+	if c.nodeLister == nil {
+		// Maistra compatibility. Try Node labels copied to Pod.
+		region := getLabelValue(pod, NodeRegionLabel, NodeRegionLabelGA)
+		zone := getLabelValue(pod, NodeZoneLabel, NodeZoneLabelGA)
+		subzone := getLabelValue(pod, label.TopologySubzone.Name, "")
+
+		if region == "" && zone == "" && subzone == "" {
+			return ""
+		}
+
+		return region + "/" + zone + "/" + subzone // Format: "%s/%s/%s"
 	}
 
 	// NodeName is set by the scheduler after the pod is created


### PR DESCRIPTION
This is a reimplementation of the following for the Maistra 2.1 /
Istio 1.8 rebase:

 - MAISTRA-1723: Allow disabling NodePort gateway support (#180)
 - Ensure Pilot can run without privileges for reading nodes (#125)

A new istiod flag is added, `disableNodeAccess`, that will disable any
feature relying on access to Node objects.