### PR TITLE
[no-cluster-rbac] MAISTRA-1897: Allow disabling IngressClass support (#263)

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -160,6 +160,8 @@ func addFlags(c *cobra.Command) {
 		"Whether to scan CRDs at startup")
 	c.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.DisableNodeAccess, "disableNodeAccess", false,
 		"Whether to prevent istiod watching Node objects")
+	c.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.EnableIngressClassName, "enableIngressClassName",
+		true, "Whether support processing Ingress resources that use the new ingressClassName field in their spec")
 
 	// using address, so it can be configured as localhost:.. (possibly UDS in future)
 	c.PersistentFlags().StringVar(&serverArgs.ServerOptions.HTTPAddr, "httpAddr", ":8080",

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -102,7 +102,8 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, args.Revision, s.kubeClient).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					if ingressV1 {
-						ingressSyncer := ingressv1.NewStatusSyncer(s.environment.Watcher, s.kubeClient, args.RegistryOptions.KubeOptions.DisableNodeAccess)
+						ingressSyncer := ingressv1.NewStatusSyncer(s.environment.Watcher, s.kubeClient,
+							args.RegistryOptions.KubeOptions.DisableNodeAccess, args.RegistryOptions.KubeOptions.EnableIngressClassName)
 						// Start informers again. This fixes the case where informers for namespace do not start,
 						// as we create them only after acquiring the leader lock
 						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
@@ -112,7 +113,8 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 						log.Infof("Starting ingress controller")
 						ingressSyncer.Run(leaderStop)
 					} else {
-						ingressSyncer := ingress.NewStatusSyncer(s.environment.Watcher, s.kubeClient, args.RegistryOptions.KubeOptions.DisableNodeAccess)
+						ingressSyncer := ingress.NewStatusSyncer(s.environment.Watcher, s.kubeClient,
+							args.RegistryOptions.KubeOptions.DisableNodeAccess, args.RegistryOptions.KubeOptions.EnableIngressClassName)
 						// Start informers again. This fixes the case where informers for namespace do not start,
 						// as we create them only after acquiring the leader lock
 						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -152,7 +152,7 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 	serviceInformer := client.KubeInformer().Core().V1().Services()
 
 	var classes v1beta1.IngressClassInformer
-	if NetworkingIngressAvailable(client) {
+	if options.EnableIngressClassName && NetworkingIngressAvailable(client) {
 		classes = client.KubeInformer().Networking().V1beta1().IngressClasses()
 		// Register the informer now, so it will be properly started
 		_ = classes.Informer()

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -61,10 +61,10 @@ func (s *StatusSyncer) Run(stopCh <-chan struct{}) {
 }
 
 // NewStatusSyncer creates a new instance
-func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client, noNodeAccess bool) *StatusSyncer {
+func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client, noNodeAccess, enableIngressClassName bool) *StatusSyncer {
 	// as in controller, ingressClassListener can be nil since not supported in k8s version <1.18
 	var ingressClassLister listerv1beta1.IngressClassLister
-	if NetworkingIngressAvailable(client) {
+	if enableIngressClassName && NetworkingIngressAvailable(client) {
 		ingressClassLister = client.KubeInformer().Networking().V1beta1().IngressClasses().Lister()
 	}
 

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -116,7 +116,7 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
-	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client, false)
+	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client, false, true)
 	stop := test.NewStop(t)
 	client.RunAndWait(stop)
 	return sync

--- a/pilot/pkg/config/kube/ingressv1/status.go
+++ b/pilot/pkg/config/kube/ingressv1/status.go
@@ -61,9 +61,14 @@ func (s *StatusSyncer) Run(stopCh <-chan struct{}) {
 }
 
 // NewStatusSyncer creates a new instance
-func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client, noNodeAccess bool) *StatusSyncer {
+func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client, noNodeAccess, enableIngressClassName bool) *StatusSyncer {
 	// queue requires a time duration for a retry delay after a handler error
 	q := queue.NewQueue(5 * time.Second)
+
+	var ingressClassLister ingresslister.IngressClassLister
+	if enableIngressClassName {
+		ingressClassLister = client.KubeInformer().Networking().V1().IngressClasses().Lister()
+	}
 
 	s := &StatusSyncer{
 		meshHolder:         meshHolder,
@@ -71,7 +76,7 @@ func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client, noNodeAccess
 		ingressLister:      client.KubeInformer().Networking().V1().Ingresses().Lister(),
 		podLister:          client.KubeInformer().Core().V1().Pods().Lister(),
 		serviceLister:      client.KubeInformer().Core().V1().Services().Lister(),
-		ingressClassLister: client.KubeInformer().Networking().V1().IngressClasses().Lister(),
+		ingressClassLister: ingressClassLister,
 		queue:              q,
 	}
 

--- a/pilot/pkg/config/kube/ingressv1/status_test.go
+++ b/pilot/pkg/config/kube/ingressv1/status_test.go
@@ -116,7 +116,7 @@ func makeStatusSyncer(t *testing.T) *StatusSyncer {
 
 	client := kubelib.NewFakeClient()
 	setupFake(t, client)
-	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client, false)
+	sync := NewStatusSyncer(fakeMeshHolder("istio-ingress"), client, false, true)
 	stop := test.NewStop(t)
 	client.RunAndWait(stop)
 	return sync

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -159,6 +159,12 @@ type Options struct {
 	// be available, e.g. NodePort gateways and determining locality information
 	// based on Nodes.
 	DisableNodeAccess bool
+
+	// EnableIngressClassName determines whether the controller will support
+	// processing Kubernetes Ingress resources that use the new (as of 1.18)
+	// `ingressClassName` in their spec, or if it will only check the deprecated
+	// `kubernetes.io/ingress.class` annotation.
+	EnableIngressClassName bool
 }
 
 // DetectEndpointMode determines whether to use Endpoints or EndpointSlice based on the


### PR DESCRIPTION
This adds an option to istiod that allows disabling reading
IngressClass resources, which are cluster-scoped.

When this is disabled, processing of Ingress resources that use the new (as of
Kubernetes v1.18) `ingressClassName` field in their spec is not supported.

Only resources that use the deprecated annotation will be processed.