### PR TITLE
OSSM-1650 Make sure initialSync and event loop behave the same

### DIFF
--- a/pilot/pkg/config/kube/ior/ior.go
+++ b/pilot/pkg/config/kube/ior/ior.go
@@ -45,6 +45,7 @@ func Register(
 	if err != nil {
 		return err
 	}
+	r.errorChannel = errorChannel
 
 	alive := true
 	var aliveLock sync.Mutex
@@ -82,8 +83,8 @@ func Register(
 			IORLog.Debugf("New object: %v", event, curr)
 			if err := r.handleEvent(event, curr); err != nil {
 				IORLog.Errora(err)
-				if errorChannel != nil {
-					errorChannel <- err
+				if r.errorChannel != nil {
+					r.errorChannel <- err
 				}
 			}
 		}()

--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -197,50 +197,75 @@ func TestCreate(t *testing.T) {
 	}
 
 	IORLog.SetOutputLevel(log.DebugLevel)
-	stop := make(chan struct{})
-	defer func() { close(stop) }()
-	errorChannel := make(chan error)
-	mrc := newFakeMemberRollController()
-	store, k8sClient, routerClient := initClients(t, stop, errorChannel, mrc, true)
-	mrc.setNamespaces("istio-system")
 
-	controlPlane := "istio-system"
-	createIngressGateway(t, k8sClient.GetActualClient(), controlPlane, map[string]string{"istio": "ingressgateway"})
+	var stop chan struct{}
+	var errorChannel chan error
+	var store model.ConfigStoreCache
+	var k8sClient KubeClient
+	var routerClient routev1.RouteV1Interface
+	var mrc *fakeMemberRollController
+	controlPlaneNs := "istio-system"
 
-	for i, c := range cases {
-		t.Run(c.testName, func(t *testing.T) {
-			gatewayName := fmt.Sprintf("gw%d", i)
-			createGateway(t, store, c.ns, gatewayName, c.hosts, c.gwSelector, c.tls, c.annotations)
+	for _, testType := range []string{"initialSync", "events"} {
+		if testType == "events" {
+			stop = make(chan struct{})
+			defer func() { close(stop) }()
+			errorChannel = make(chan error)
+			mrc = newFakeMemberRollController()
+			store, k8sClient, routerClient = initClients(t, stop, errorChannel, mrc, true)
+			mrc.setNamespaces(controlPlaneNs)
 
-			list, _ := getRoutes(t, routerClient, controlPlane, c.expectedRoutes, time.Second)
-			if err := getError(errorChannel); err != nil {
-				if c.expectedError == "" {
-					t.Fatal(err)
-				}
+			createIngressGateway(t, k8sClient.GetActualClient(), controlPlaneNs, map[string]string{"istio": "ingressgateway"})
+		}
 
-				if !strings.Contains(err.Error(), c.expectedError) {
-					t.Fatalf("expected error message containing `%s', got: %s", c.expectedError, err.Error())
-				}
-
-				// Error is expected and matches the golden string, nothing to do
-			} else {
-				if c.expectedError != "" {
-					t.Fatalf("expected error message containing `%s', got success", c.expectedError)
-				}
-
-				// Only continue the validation if any route is expected to be created
-				if c.expectedRoutes > 0 {
-					validateRoutes(t, c.hosts, list, gatewayName, c.tls)
-
-					// Remove the gateway and expect all routes get removed
-					deleteGateway(t, store, c.ns, gatewayName)
-					_, _ = getRoutes(t, routerClient, c.ns, 0, time.Second)
-					if err := getError(errorChannel); err != nil {
+		for i, c := range cases {
+			t.Run(testType+"-"+c.testName, func(t *testing.T) {
+				if testType == "initialSync" {
+					stop = make(chan struct{})
+					defer func() { close(stop) }()
+					errorChannel = make(chan error)
+					mrc = newFakeMemberRollController()
+					store, k8sClient, routerClient = initClients(t, stop, errorChannel, mrc, false)
+					createIngressGateway(t, k8sClient.GetActualClient(), controlPlaneNs, map[string]string{"istio": "ingressgateway"})
+					if err := Register(k8sClient, routerClient, store, controlPlaneNs, mrc, stop, errorChannel); err != nil {
 						t.Fatal(err)
 					}
 				}
-			}
-		})
+				gatewayName := fmt.Sprintf("gw%d", i)
+				createGateway(t, store, c.ns, gatewayName, c.hosts, c.gwSelector, c.tls, c.annotations)
+				if testType == "initialSync" {
+					mrc.setNamespaces(controlPlaneNs)
+				}
+				list, _ := getRoutes(t, routerClient, controlPlaneNs, c.expectedRoutes, time.Second)
+				if err := getError(errorChannel); err != nil {
+					if c.expectedError == "" {
+						t.Fatal(err)
+					}
+
+					if !strings.Contains(err.Error(), c.expectedError) {
+						t.Fatalf("expected error message containing `%s', got: %s", c.expectedError, err.Error())
+					}
+
+					// Error is expected and matches the golden string, nothing to do
+				} else {
+					if c.expectedError != "" {
+						t.Fatalf("expected error message containing `%s', got success", c.expectedError)
+					}
+
+					// Only continue the validation if any route is expected to be created
+					if c.expectedRoutes > 0 {
+						validateRoutes(t, c.hosts, list, gatewayName, c.tls)
+
+						// Remove the gateway and expect all routes get removed
+						deleteGateway(t, store, c.ns, gatewayName)
+						_, _ = getRoutes(t, routerClient, c.ns, 0, time.Second)
+						if err := getError(errorChannel); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -72,6 +72,7 @@ type route struct {
 	alive              bool
 	stop               <-chan struct{}
 	handleEventTimeout time.Duration
+	errorChannel       chan error
 
 	// memberroll functionality
 	mrc              controller.MemberRollController
@@ -155,6 +156,20 @@ func (r *route) initialSync(initialNamespaces []string) error {
 	IORLog.Debugf("initialSync() - Got %d Gateway(s)", len(configs))
 
 	for i, cfg := range configs {
+		if err := r.ensureNamespaceExists(cfg); err != nil {
+			result = multierror.Append(result, err)
+			continue
+		}
+		manageRoute, err := isManagedByIOR(cfg)
+		if err != nil {
+			result = multierror.Append(result, err)
+			continue
+		}
+		if !manageRoute {
+			IORLog.Debugf("initialSync() - Ignoring Gateway %s/%s as it is not managed by Istiod", cfg.Namespace, cfg.Name)
+			continue
+		}
+
 		IORLog.Debugf("initialSync() - Parsing Gateway [%d] %s/%s", i+1, cfg.Namespace, cfg.Name)
 		r.addNewSyncRoute(cfg)
 	}
@@ -421,6 +436,9 @@ func (r *route) SetNamespaces(namespaces ...string) {
 
 		if err := r.initialSync(namespaces); err != nil {
 			IORLog.Errora(err)
+			if r.errorChannel != nil {
+				r.errorChannel <- err
+			}
 		}
 		IORLog.Debug("Initial sync finished")
 		close(r.initialSyncRun)


### PR DESCRIPTION
This PR makes sure that the initial sync behavior and the event-based reconciliation behave the same in IOR. In OSSM-1650, the problem was that the `isManagedByIOR()` func was not called in the initialSync func, so the initialSync would create Routes it shouldn't create (for egress gateways). When I adjusted the tests to test both methods (initialSync and events), I also found another problem - initialSync was not calling `ensureNamespaceExists()` either, so it would create Routes for namespaces that are not managed.

Note that this is merely a bandaid on what I think is a broken implementation - we shouldn't have to maintain two separate code paths for these things. I created [OSSM-1689 - Simplify IOR](https://issues.redhat.com/browse/OSSM-1689) to cover a proper refactoring of the code for 2.3.