### PR TITLE
[cni] MAISTRA-2132 Support deployment of multiple plugin versions in Istio CNI (#271)

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -140,6 +140,7 @@ func init() {
 	registerBooleanParameter(constants.UpdateCNIBinaries, true, "Whether to refresh existing binaries when installing CNI")
 	registerStringArrayParameter(constants.SkipCNIBinaries, []string{},
 		"Binaries that should not be installed. Currently Istio only installs one binary `istio-cni`")
+	registerStringParameter(constants.CNIBinariesPrefix, "", "The filename prefix to add to each binary when copying")
 	registerIntegerParameter(constants.MonitoringPort, 15014, "HTTP port to serve prometheus metrics")
 	registerStringParameter(constants.LogUDSAddress, "/var/run/istio-cni/log.sock", "The UDS server address which CNI plugin will copy log ouptut to")
 
@@ -235,6 +236,7 @@ func constructConfig() (*config.Config, error) {
 
 		CNIBinSourceDir:   constants.CNIBinDir,
 		CNIBinTargetDirs:  []string{constants.HostCNIBinDir, constants.SecondaryBinDir},
+		CNIBinariesPrefix: viper.GetString(constants.CNIBinariesPrefix),
 		UpdateCNIBinaries: viper.GetBool(constants.UpdateCNIBinaries),
 		SkipCNIBinaries:   viper.GetStringSlice(constants.SkipCNIBinaries),
 		MonitoringPort:    viper.GetInt(constants.MonitoringPort),

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -68,6 +68,8 @@ type InstallConfig struct {
 	CNIBinSourceDir string
 	// Directories into which to copy the CNI binaries
 	CNIBinTargetDirs []string
+	// The prefix to add to the name of each CNI binary
+	CNIBinariesPrefix string
 	// Whether to override existing CNI binaries
 	UpdateCNIBinaries bool
 

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -32,6 +32,7 @@ const (
 	SkipTLSVerify        = "skip-tls-verify"
 	SkipCNIBinaries      = "skip-cni-binaries"
 	UpdateCNIBinaries    = "update-cni-binaries"
+	CNIBinariesPrefix    = "cni-binaries-prefix"
 	MonitoringPort       = "monitoring-port"
 	LogUDSAddress        = "log-uds-address"
 

--- a/cni/pkg/install/binaries.go
+++ b/cni/pkg/install/binaries.go
@@ -21,7 +21,7 @@ import (
 	"istio.io/istio/pkg/file"
 )
 
-func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipBinaries []string) error {
+func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipBinaries []string, binariesPrefix string) error {
 	skipBinariesSet := arrToSet(skipBinaries)
 
 	for _, targetDir := range targetDirs {
@@ -42,18 +42,19 @@ func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipB
 				continue
 			}
 
-			targetFilepath := filepath.Join(targetDir, filename)
+			targetFilename := binariesPrefix + filename
+			targetFilepath := filepath.Join(targetDir, targetFilename)
 			if _, err := os.Stat(targetFilepath); err == nil && !updateBinaries {
 				installLog.Infof("%s is already here and UPDATE_CNI_BINARIES isn't true, skipping", targetFilepath)
 				continue
 			}
 
 			srcFilepath := filepath.Join(srcDir, filename)
-			err := file.AtomicCopy(srcFilepath, targetDir, filename)
+			err := file.AtomicCopy(srcFilepath, targetDir, targetFilename)
 			if err != nil {
 				return err
 			}
-			installLog.Infof("Copied %s to %s.", filename, targetDir)
+			installLog.Infof("Copied %s to %s.", filename, targetFilepath)
 		}
 	}
 

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -180,7 +180,7 @@ func getCNIConfigFilepath(ctx context.Context, cfg pluginConfig) (string, error)
 		return filepath.Join(cfg.mountedCNINetDir, filename), nil
 	}
 
-	watcher, fileModified, errChan, err := util.CreateFileWatcher(cfg.mountedCNINetDir)
+	watcher, fileModified, errChan, err := util.CreateFileWatcher("", []string{cfg.mountedCNINetDir})
 	if err != nil {
 		return "", err
 	}

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -184,7 +184,7 @@ func readServiceAccountToken() (string, error) {
 func sleepCheckInstall(ctx context.Context, cfg *config.InstallConfig, cniConfigFilepath string, isReady *atomic.Value) error {
 	// Create file watcher before checking for installation
 	// so that no file modifications are missed while and after checking
-	watcher, fileModified, errChan, err := util.CreateFileWatcher(append(cfg.CNIBinTargetDirs, cfg.MountedCNINetDir)...)
+	watcher, fileModified, errChan, err := util.CreateFileWatcher(cfg.CNIBinariesPrefix, append(cfg.CNIBinTargetDirs, cfg.MountedCNINetDir))
 	if err != nil {
 		return err
 	}

--- a/cni/pkg/install/install.go
+++ b/cni/pkg/install/install.go
@@ -49,7 +49,7 @@ func NewInstaller(cfg *config.InstallConfig, isReady *atomic.Value) *Installer {
 func (in *Installer) install(ctx context.Context) (err error) {
 	if err = copyBinaries(
 		in.cfg.CNIBinSourceDir, in.cfg.CNIBinTargetDirs,
-		in.cfg.UpdateCNIBinaries, in.cfg.SkipCNIBinaries); err != nil {
+		in.cfg.UpdateCNIBinaries, in.cfg.SkipCNIBinaries, in.cfg.CNIBinariesPrefix); err != nil {
 		cniInstalls.With(resultLabel.Value(resultCopyBinariesFailure)).Increment()
 		return
 	}
@@ -103,6 +103,8 @@ func (in *Installer) Run(ctx context.Context) (err error) {
 
 // Cleanup remove Istio CNI's config, kubeconfig file, and binaries.
 func (in *Installer) Cleanup() error {
+	istioCniExecutableName := in.cfg.CNIBinariesPrefix + "istio-cni"
+
 	installLog.Info("Cleaning up.")
 	if len(in.cniConfigFilepath) > 0 && file.Exists(in.cniConfigFilepath) {
 		if in.cfg.ChainedCNIPlugin {
@@ -123,7 +125,7 @@ func (in *Installer) Cleanup() error {
 				if err != nil {
 					return fmt.Errorf("%s: %w", in.cniConfigFilepath, err)
 				}
-				if plugin["type"] == "istio-cni" {
+				if plugin["type"] == istioCniExecutableName {
 					cniConfigMap["plugins"] = append(plugins[:i], plugins[i+1:]...)
 					break
 				}
@@ -152,7 +154,7 @@ func (in *Installer) Cleanup() error {
 	}
 
 	for _, targetDir := range in.cfg.CNIBinTargetDirs {
-		if istioCNIBin := filepath.Join(targetDir, "istio-cni"); file.Exists(istioCNIBin) {
+		if istioCNIBin := filepath.Join(targetDir, istioCniExecutableName); file.Exists(istioCNIBin) {
 			installLog.Infof("Removing binary: %s", istioCNIBin)
 			if err := os.Remove(istioCNIBin); err != nil {
 				return err
@@ -221,6 +223,7 @@ func checkInstall(cfg *config.InstallConfig, cniConfigFilepath string) error {
 	if !cfg.CNIEnableInstall {
 		return nil
 	}
+	istioCniExecutableName := cfg.CNIBinariesPrefix + "istio-cni"
 	defaultCNIConfigFilename, err := getDefaultCNINetwork(cfg.MountedCNINetDir)
 	if err != nil {
 		return err
@@ -255,7 +258,7 @@ func checkInstall(cfg *config.InstallConfig, cniConfigFilepath string) error {
 			if err != nil {
 				return fmt.Errorf("%s: %w", cniConfigFilepath, err)
 			}
-			if plugin["type"] == "istio-cni" {
+			if plugin["type"] == istioCniExecutableName {
 				return nil
 			}
 		}
@@ -268,7 +271,7 @@ func checkInstall(cfg *config.InstallConfig, cniConfigFilepath string) error {
 		return err
 	}
 
-	if cniConfigMap["type"] != "istio-cni" {
+	if cniConfigMap["type"] != istioCniExecutableName {
 		return fmt.Errorf("istio-cni CNI config file modified: %s", cniConfigFilepath)
 	}
 	return nil

--- a/cni/pkg/plugin/iptables_linux.go
+++ b/cni/pkg/plugin/iptables_linux.go
@@ -37,6 +37,7 @@ func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.NetworkNamespace, netns)
 	viper.Set(constants.EnvoyPort, rdrct.targetPort)
 	viper.Set(constants.ProxyUID, rdrct.noRedirectUID)
+	viper.Set(constants.ProxyGID, rdrct.noRedirectGID)
 	viper.Set(constants.InboundInterceptionMode, rdrct.redirectMode)
 	viper.Set(constants.ServiceCidr, rdrct.includeIPCidrs)
 	viper.Set(constants.LocalExcludePorts, rdrct.excludeInboundPorts)

--- a/cni/pkg/plugin/kubernetes.go
+++ b/cni/pkg/plugin/kubernetes.go
@@ -42,6 +42,8 @@ type PodInfo struct {
 	Annotations       map[string]string
 	ProxyEnvironments map[string]string
 	ProxyConfig       *meshconfig.ProxyConfig
+	ProxyUID          *int64
+	ProxyGID          *int64
 }
 
 // newK8sClient returns a Kubernetes client
@@ -99,6 +101,10 @@ func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (
 					}
 					break
 				}
+			}
+			if container.SecurityContext != nil {
+				pi.ProxyUID = container.SecurityContext.RunAsUser
+				pi.ProxyGID = container.SecurityContext.RunAsGroup
 			}
 			continue
 		}

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -33,6 +33,7 @@ const (
 	defaultProxyStatusPort       = "15020"
 	defaultRedirectToPort        = "15001"
 	defaultNoRedirectUID         = "1337"
+	defaultNoRedirectGID         = "1337"
 	defaultRedirectMode          = redirectModeREDIRECT
 	defaultRedirectIPCidr        = "*"
 	defaultRedirectExcludeIPCidr = ""
@@ -75,6 +76,7 @@ type Redirect struct {
 	targetPort           string
 	redirectMode         string
 	noRedirectUID        string
+	noRedirectGID        string
 	includeIPCidrs       string
 	excludeIPCidrs       string
 	excludeInboundPorts  string
@@ -213,6 +215,13 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
 			"redirectMode", isFound, valErr)
 	}
 	redir.noRedirectUID = defaultNoRedirectUID
+	if pi.ProxyUID != nil {
+		redir.noRedirectUID = fmt.Sprintf("%d", *pi.ProxyUID)
+	}
+	redir.noRedirectGID = defaultNoRedirectGID
+	if pi.ProxyGID != nil {
+		redir.noRedirectGID = fmt.Sprintf("%d", *pi.ProxyGID)
+	}
 	isFound, redir.includeIPCidrs, valErr = getAnnotationOrDefault("includeIPCidrs", pi.Annotations)
 	if valErr != nil {
 		return nil, fmt.Errorf("annotation value error for value %s; annotationFound = %t: %v",


### PR DESCRIPTION
Includes:

  * MAISTRA-2135 Add unit tests for our CNI binary-prefix work (#325)

  * MAISTRA-2137 Make network namespace setup executable name configurable (#273)

    To support the deployment of multiple CNI plugin versions, the name of the
    executable that is invoked to set up the network namespace must be configurable.