### PR TITLE
OSSM-1211 Fix federation locality failover issues

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -159,8 +159,8 @@ func (c *Controller) Services() ([]*model.Service, error) {
 			errs = multierror.Append(errs, err)
 			continue
 		}
-
-		if r.Provider() != provider.Kubernetes {
+		// The second condition is required for merging Services and Service Accounts from federation controllers
+		if r.Provider() != provider.Kubernetes && r.Provider() != provider.Federation {
 			services = append(services, svcs...)
 		} else {
 			for _, s := range svcs {
@@ -191,7 +191,7 @@ func (c *Controller) GetService(hostname host.Name) *model.Service {
 		if service == nil {
 			continue
 		}
-		if r.Provider() != provider.Kubernetes {
+		if r.Provider() != provider.Kubernetes && r.Provider() != provider.Federation {
 			return service
 		}
 		if out == nil {
@@ -207,7 +207,7 @@ func (c *Controller) GetService(hostname host.Name) *model.Service {
 func mergeService(dst, src *model.Service, srcRegistry serviceregistry.Instance) {
 	// Prefer the k8s HostVIPs where possible
 	clusterID := srcRegistry.Cluster()
-	if srcRegistry.Provider() == provider.Kubernetes || len(dst.ClusterVIPs.GetAddressesFor(clusterID)) == 0 {
+	if srcRegistry.Provider() == provider.Kubernetes || srcRegistry.Provider() == provider.Federation || len(dst.ClusterVIPs.GetAddressesFor(clusterID)) == 0 {
 		newAddresses := src.ClusterVIPs.GetAddressesFor(clusterID)
 		dst.ClusterVIPs.SetAddressesFor(clusterID, newAddresses)
 	}

--- a/pilot/pkg/serviceregistry/federation/controller_test.go
+++ b/pilot/pkg/serviceregistry/federation/controller_test.go
@@ -1,0 +1,62 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package federation
+
+import (
+	"testing"
+
+	v1 "maistra.io/api/federation/v1"
+)
+
+// TestMergeLocality tests the federation mergeLocality function
+func TestMergeLocality(t *testing.T) {
+	remoteLocality := v1.ImportedServiceLocality{
+		Region:  "region1",
+		Zone:    "zone1",
+		Subzone: "subzone1",
+	}
+	merged := mergeLocality(&remoteLocality, nil)
+	if merged.Region != "region1" {
+		t.Fatalf("Federation controller should initialize importConfig locality region. Actual %v, expected %v",
+			merged.Region, "region1")
+	}
+	if merged.Zone != "zone1" {
+		t.Fatalf("Federation controller should initialize importConfig locality zone. Actual %v, expected %v",
+			merged.Zone, "zone1")
+	}
+	if merged.Subzone != "subzone1" {
+		t.Fatalf("Federation controller should initialize importConfig locality subzone Actual %v, expected %v",
+			merged.Subzone, "subzone1")
+	}
+
+	updatedLocality := v1.ImportedServiceLocality{
+		Region:  "region2",
+		Zone:    "zone2",
+		Subzone: "subzone2",
+	}
+	merged = mergeLocality(&updatedLocality, &remoteLocality)
+	if merged.Region != "region2" {
+		t.Fatalf("Federation controller should update importConfig locality region. Actual %v, expected %v",
+			merged.Region, "region2")
+	}
+	if merged.Zone != "zone2" {
+		t.Fatalf("Federation controller should update importConfig locality zone. Actual %v, expected %v",
+			merged.Zone, "zone2")
+	}
+	if merged.Subzone != "subzone2" {
+		t.Fatalf("Federation controller should update importConfig locality subzone Actual %v, expected %v",
+			merged.Subzone, "subzone2")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yuanlin <yuanlin.xu@redhat.com>

OSSM-1211 Fix federation locality failover issues
This PR resolves two federation issues when importing a service as a local service.

    Updated Federation Controller mergeLocality logic and added a unit test.
    Fix an issue: Missing locality setting.

    Updated pilot aggregate controller Services method and updated unit tests.
    Fix an issue: Overwrite ServiceAccounts instead of merging them when aggregating services

    Integration test have been added in maistra-test-tool:

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
