### PR TITLE
Remove arm64 from charts for gateways

### DIFF
--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -163,7 +163,7 @@ global:
   # To output all istio components logs in json format by adding --log_as_json argument to each container argument
   logAsJson: false
 
-  # Specify pod scheduling arch(amd64, ppc64le, s390x, arm64) and weight as follows:
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
   #   0 - Never scheduled
   #   1 - Least preferred
   #   2 - No preference
@@ -172,7 +172,6 @@ global:
     amd64: 2
     s390x: 2
     ppc64le: 2
-    arm64: 2
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -180,7 +180,7 @@ global:
   # To output all istio components logs in json format by adding --log_as_json argument to each container argument
   logAsJson: false
 
-  # Specify pod scheduling arch(amd64, ppc64le, s390x, arm64) and weight as follows:
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
   #   0 - Never scheduled
   #   1 - Least preferred
   #   2 - No preference
@@ -189,7 +189,6 @@ global:
     amd64: 2
     s390x: 2
     ppc64le: 2
-    arm64: 2
 
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components


### PR DESCRIPTION
We do not support arm64 architecture, so it shouldn't be included in
global.arch list that is used to generate node affinity conditions.

Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>