### PR TITLE
OSSM-1938: Run tests on OCP and Change httpbin port and grpc echo uid

### DIFF
--- a/samples/extauthz/local-ext-authz.yaml
+++ b/samples/extauthz/local-ext-authz.yaml
@@ -69,7 +69,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 80
+        - containerPort: 8001
+        command: ["gunicorn", "-b", "0.0.0.0:8001", "httpbin:app", "-k", "gevent"]
       - image: gcr.io/istio-testing/ext-authz:latest
         imagePullPolicy: IfNotPresent
         name: ext-authz
@@ -88,7 +89,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 80
+    targetPort: 8001
   selector:
     app: httpbin
 ---

--- a/samples/grpc-echo/grpc-echo.yaml
+++ b/samples/grpc-echo/grpc-echo.yaml
@@ -98,8 +98,8 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           securityContext:
-            runAsGroup: 1338
-            runAsUser: 1338
+            runAsGroup: 1000690001
+            runAsUser: 1000690001
           startupProbe:
             failureThreshold: 10
             periodSeconds: 10
@@ -186,8 +186,8 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           securityContext:
-            runAsGroup: 1338
-            runAsUser: 1338
+            runAsGroup: 1000690001
+            runAsUser: 1000690001
           startupProbe:
             failureThreshold: 10
             periodSeconds: 10


### PR DESCRIPTION
Signed-off-by: Yuanlin <yuanlin.xu@redhat.com>

This change is for fixing flaky tests when running on an OCP. 
The local ext auth service is running on port 8000 so the httpbin needs to run on a different port.
The grpc-echo default uid 1338 is forbidden by the default scc.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
