### PR TITLE
OSSM-1949: Workaround xns-informers bad behavior

### DIFF
--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -149,9 +149,13 @@ func (r *route) initialSync(initialNamespaces []string) error {
 	// List the gateways and put them into the gatewaysMap
 	// The store must be synced otherwise we might get an empty list
 	// We enforce this before calling this function in UpdateNamespaces()
-	configs, err := r.store.List(collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(), model.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("could not get list of Gateways: %s", err)
+	var configs []config.Config
+	for _, ns := range initialNamespaces {
+		config, err := r.store.List(collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(), ns)
+		if err != nil {
+			return fmt.Errorf("could not get list of Gateways: %s", err)
+		}
+		configs = append(configs, config...)
 	}
 	IORLog.Debugf("initialSync() - Got %d Gateway(s)", len(configs))
 


### PR DESCRIPTION
In some cases, it is possible that xns-informer reports `true` in its `HasSynced()` method when in fact it isn't. This might happen when a new namespace is added after it was initially sync. It now depends on the new informer to be synced so it can properly respond to queries like `List()`. When `List()` is invoked, because the new informer isn't ready yet, the xns-informer returns an empty list.

We workaround this by querying inidividual namespaces instead of querying All ("") namespaces. This bypass the xsn-informer and queries directly the namespace informer.
