### PR TITLE
OSSM-1962: Use EndpointSlices instead of Endpoints in federation controller

### DIFF
--- a/tests/integration/servicemesh/federation/federation.go
+++ b/tests/integration/servicemesh/federation/federation.go
@@ -138,10 +138,6 @@ components:
         # required for handing discovery requests from mesh2
         - port: 8188
           name: https-discovery
-values:
-  pilot:
-    env:
-      PILOT_USE_ENDPOINT_SLICE: "false"
 `
 }
 


### PR DESCRIPTION
OSSM 2.3 will be supported on OpenShift 4.8 and higher, which is compatible with Kubernetes 1.21, so we don't have to worry about whether to use Endpoints or EndpointSlices. 

Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>