### PR TITLE
OSSM-1206: Make ServiceEntries with duplicated host names reachable

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -55,6 +55,11 @@ type instancesKey struct {
 	namespace string
 }
 
+type octetPair struct {
+	thirdOctet  int
+	fourthOctet int
+}
+
 func makeInstanceKey(i *model.ServiceInstance) instancesKey {
 	return instancesKey{i.Service.Hostname, i.Service.Attributes.Namespace}
 }
@@ -847,6 +852,8 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 	// So we bump X to 511, so that the resulting IP is 240.240.2.1
 	maxIPs := 255 * 255 // are we going to exceed this limit by processing 64K services?
 	x := 0
+	hnMap := make(map[string]octetPair)
+
 	for _, svc := range services {
 		// we can allocate IPs only if
 		// 1. the service has resolution set to static/dns. We cannot allocate
@@ -855,27 +862,43 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 		// 3. the hostname is not a wildcard
 		if svc.DefaultAddress == constants.UnspecifiedIP && !svc.Hostname.IsWildCarded() &&
 			svc.Resolution != model.Passthrough {
-			x++
-			if x%255 == 0 {
-				x++
-			}
-			if x >= maxIPs {
-				log.Errorf("out of IPs to allocate for service entries")
-				return services
-			}
-			thirdOctet := x / 255
-			fourthOctet := x % 255
+			n := svc.Hostname.String()
+			if v, ok := hnMap[n]; ok {
+				log.Debugf("Reuse IP for domain %s", n)
 
-			svc.AutoAllocatedIPv4Address = fmt.Sprintf("240.240.%d.%d", thirdOctet, fourthOctet)
-			// if the service of service entry has IPv6 address, then allocate the IPv4-Mapped IPv6 Address for it
-			if thirdOctet == 0 {
-				svc.AutoAllocatedIPv6Address = fmt.Sprintf("2001:2::f0f0:%x", fourthOctet)
+				setAutoAllocatedIPs(svc, v)
 			} else {
-				svc.AutoAllocatedIPv6Address = fmt.Sprintf("2001:2::f0f0:%x%x", thirdOctet, fourthOctet)
+				x++
+				if x%255 == 0 {
+					x++
+				}
+				if x >= maxIPs {
+					log.Errorf("out of IPs to allocate for service entries")
+					return services
+				}
+
+				pair := octetPair{x / 255, x % 255}
+
+				setAutoAllocatedIPs(svc, pair)
+
+				hnMap[n] = pair
 			}
 		}
 	}
 	return services
+}
+
+func setAutoAllocatedIPs(svc *model.Service, octets octetPair) {
+	a := octets.thirdOctet
+	b := octets.fourthOctet
+
+	svc.AutoAllocatedIPv4Address = fmt.Sprintf("240.240.%d.%d", a, b)
+
+	if a == 0 {
+		svc.AutoAllocatedIPv6Address = fmt.Sprintf("2001:2::f0f0:%x", b)
+	} else {
+		svc.AutoAllocatedIPv6Address = fmt.Sprintf("2001:2::f0f0:%x%x", a, b)
+	}
 }
 
 func makeConfigKey(svc *model.Service) model.ConfigKey {

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -1533,7 +1533,7 @@ func Test_autoAllocateIP_values(t *testing.T) {
 	inServices := make([]*model.Service, 512)
 	for i := 0; i < 512; i++ {
 		temp := model.Service{
-			Hostname:       "foo.com",
+			Hostname:       host.Name(fmt.Sprintf("foo%d.com", i)),
 			Resolution:     model.ClientSideLB,
 			DefaultAddress: constants.UnspecifiedIP,
 		}
@@ -1562,15 +1562,15 @@ func Test_autoAllocateIP_values(t *testing.T) {
 		t.Errorf("expected last IP address to be %s, got %s", expectedLastIP, gotServices[len(gotServices)-1].AutoAllocatedIPv4Address)
 	}
 
-	gotIPMap := make(map[string]bool)
+	gotIPMap := make(map[string]string)
 	for _, svc := range gotServices {
 		if svc.AutoAllocatedIPv4Address == "" || doNotWant[svc.AutoAllocatedIPv4Address] {
 			t.Errorf("unexpected value for auto allocated IP address %s", svc.AutoAllocatedIPv4Address)
 		}
-		if gotIPMap[svc.AutoAllocatedIPv4Address] {
-			t.Errorf("multiple allocations of same IP address to different services: %s", svc.AutoAllocatedIPv4Address)
+		if v, ok := gotIPMap[svc.AutoAllocatedIPv4Address]; ok && v != svc.Hostname.String() {
+			t.Errorf("multiple allocations of same IP address to different services with different hostname: %s", svc.AutoAllocatedIPv4Address)
 		}
-		gotIPMap[svc.AutoAllocatedIPv4Address] = true
+		gotIPMap[svc.AutoAllocatedIPv4Address] = svc.Hostname.String()
 	}
 }
 

--- a/releasenotes/notes/serviceentry-ip-auto-allocation.yaml
+++ b/releasenotes/notes/serviceentry-ip-auto-allocation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 40166
+releaseNotes:
+- |
+  **Fixed** an issue where adding a `ServiceEntry` could affect an existing `ServiceEntry` with the same hostname.


### PR DESCRIPTION
This is a backport of @yannuil's commit from upstream.