### PR TITLE
OSSM-2000 Re-enable Wasm tests

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/wasm/stats_wasm_filter_test.go
@@ -39,8 +39,6 @@ func TestWasmStatsFilter(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).
-		// FIXME: https://issues.redhat.com/browse/OSSM-2000
-		Skip("https://github.com/istio/istio/issues/0").
 		Label(label.CustomSetup).
 		Label(label.IPv4). // https://github.com/istio/istio/issues/35915
 		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).


### PR DESCRIPTION
I fixed this by uploading the upstream builds of the Wasm filters to our bucket. That means we're not testing our own builds, but at least we're testing our proxy-wasm implementation with a large Wasm filter.