### PR TITLE
[maistra-2.2] OSSM-1206: Make ServiceEntries with duplicated host names reachable

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -48,6 +48,11 @@ type instancesKey struct {
 	namespace string
 }
 
+type octetPair struct {
+	thirdOctet  int
+	fourthOctet int
+}
+
 func makeInstanceKey(i *model.ServiceInstance) instancesKey {
 	return instancesKey{i.Service.Hostname, i.Service.Attributes.Namespace}
 }
@@ -919,28 +924,44 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 	// So we bump X to 511, so that the resulting IP is 240.240.2.1
 	maxIPs := 255 * 255 // are we going to exceed this limit by processing 64K services?
 	x := 0
+	hostnameAllocatedOctets := make(map[string]octetPair)
+
 	for _, svc := range services {
 		// we can allocate IPs only if
 		// 1. the service has resolution set to static/dns. We cannot allocate
 		//   for NONE because we will not know the original DST IP that the application requested.
 		// 2. the address is not set (0.0.0.0)
 		// 3. the hostname is not a wildcard
-		if svc.DefaultAddress == constants.UnspecifiedIP && !svc.Hostname.IsWildCarded() &&
-			svc.Resolution != model.Passthrough {
-			x++
-			if x%255 == 0 {
+		if svc.DefaultAddress == constants.UnspecifiedIP && !svc.Hostname.IsWildCarded() && svc.Resolution != model.Passthrough {
+			hostname := svc.Hostname.String()
+			if allocatedOctets, ok := hostnameAllocatedOctets[hostname]; ok {
+				log.Debugf("Reuse IP for domain %s", hostname)
+				setAutoAllocatedIPs(svc, allocatedOctets)
+			} else {
 				x++
+				if x%255 == 0 {
+					x++
+				}
+				if x >= maxIPs {
+					log.Errorf("out of IPs to allocate for service entries")
+					return services
+				}
+				pair := octetPair{
+					thirdOctet:  x / 255,
+					fourthOctet: x % 255,
+				}
+				hostnameAllocatedOctets[hostname] = pair
+				setAutoAllocatedIPs(svc, pair)
 			}
-			if x >= maxIPs {
-				log.Errorf("out of IPs to allocate for service entries")
-				return services
-			}
-			thirdOctet := x / 255
-			fourthOctet := x % 255
-			svc.AutoAllocatedAddress = fmt.Sprintf("240.240.%d.%d", thirdOctet, fourthOctet)
 		}
 	}
 	return services
+}
+
+func setAutoAllocatedIPs(svc *model.Service, octets octetPair) {
+	a := octets.thirdOctet
+	b := octets.fourthOctet
+	svc.AutoAllocatedAddress = fmt.Sprintf("240.240.%d.%d", a, b)
 }
 
 func makeConfigKey(svc *model.Service) model.ConfigKey {

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -1400,7 +1400,7 @@ func Test_autoAllocateIP_values(t *testing.T) {
 	inServices := make([]*model.Service, 512)
 	for i := 0; i < 512; i++ {
 		temp := model.Service{
-			Hostname:       "foo.com",
+			Hostname:       host.Name(fmt.Sprintf("foo%d.com", i)),
 			Resolution:     model.ClientSideLB,
 			DefaultAddress: constants.UnspecifiedIP,
 		}
@@ -1429,15 +1429,15 @@ func Test_autoAllocateIP_values(t *testing.T) {
 		t.Errorf("expected last IP address to be %s, got %s", expectedLastIP, gotServices[len(gotServices)-1].AutoAllocatedAddress)
 	}
 
-	gotIPMap := make(map[string]bool)
+	gotIPMap := make(map[string]string)
 	for _, svc := range gotServices {
 		if svc.AutoAllocatedAddress == "" || doNotWant[svc.AutoAllocatedAddress] {
 			t.Errorf("unexpected value for auto allocated IP address %s", svc.AutoAllocatedAddress)
 		}
-		if gotIPMap[svc.AutoAllocatedAddress] {
-			t.Errorf("multiple allocations of same IP address to different services: %s", svc.AutoAllocatedAddress)
+		if v, ok := gotIPMap[svc.AutoAllocatedAddress]; ok && v != svc.Hostname.String() {
+			t.Errorf("multiple allocations of same IP address to different services with different hostname: %s", svc.AutoAllocatedAddress)
 		}
-		gotIPMap[svc.AutoAllocatedAddress] = true
+		gotIPMap[svc.AutoAllocatedAddress] = svc.Hostname.String()
 	}
 }
 

--- a/releasenotes/notes/serviceentry-ip-auto-allocation.yaml
+++ b/releasenotes/notes/serviceentry-ip-auto-allocation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 40166
+releaseNotes:
+- |
+  **Fixed** an issue where adding a `ServiceEntry` could affect an existing `ServiceEntry` with the same hostname.


### PR DESCRIPTION
This is a backport of @yannuil's commit from upstream.
I had to slightly refactor this implementation, because service entries in Istio 1.12.z have only IPv4 address.