### PR TITLE
OSSM-2109 Fix flaky IOR unit test

### DIFF
--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -277,7 +277,7 @@ func (r *route) ensureNamespaceExists(cfg config.Config) error {
 		default:
 			IORLog.Debugf("Namespace %s not found in SMMR, trying again", cfg.Namespace)
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(r.handleEventTimeout / 100)
 	}
 }
 


### PR DESCRIPTION
The sleep in ensureNamespaceExists was hardcoded to 100ms, regardless of r.handleEventTimeout. This timeout during unit tests is only 1ms, so the 100ms sleep caused the for loop to only run once.

Here we change the duration of the sleep to be 1/100 of r.handleEventTimeout. This change preserves the production sleep time of 100ms, but reduces the sleep time in unit tests to 10μs. This makes ensureNamespaceExists() run the for loop multiple times before giving up, fixing the test's flakiness.