### PR TITLE
OSSM-2123 gw-api deploymentcontroller should not set securityContext

### DIFF
--- a/pilot/pkg/config/kube/gateway/templates/deployment.yaml
+++ b/pilot/pkg/config/kube/gateway/templates/deployment.yaml
@@ -42,30 +42,6 @@ spec:
       containers:
       - image: auto
         name: istio-proxy
-        securityContext:
-        {{- if .KubeVersion122 }}
-          # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
-          capabilities:
-            drop:
-            - ALL
-          allowPrivilegeEscalation: false
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsUser: 1337
-          runAsGroup: 1337
-          runAsNonRoot: true
-        {{- else }}
-          capabilities:
-            drop:
-            - ALL
-            add:
-            - NET_BIND_SERVICE
-          runAsUser: 0
-          runAsGroup: 1337
-          runAsNonRoot: false
-          allowPrivilegeEscalation: true
-          readOnlyRootFilesystem: true
-        {{- end }}
         ports:
         - containerPort: 15021
           name: status-port

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -67,16 +67,6 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -62,16 +62,6 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -70,16 +70,6 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -61,16 +61,6 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 2
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start


### PR DESCRIPTION
I'm just removing the whole `securityContext` block here because I think adding that is the job of gateway injection. I tested this on OCP 4.8 (k8s 1.21) and was able to create a Gateway resource with a listener on port 80- it's correctly created and running without privileges in the `restricted` SCC.

I believe ideally this would work similarly to the injectors, by using a ConfigMap that stores the template, instead of keeping it compiled into the binary. Might submit a PR upstream