### PR TITLE
OSSM-2107 Update bookinfo images for 2.3

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -41,13 +41,15 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: mongodb
         version: v1
     spec:
       containers:
       - name: mongodb 
-        image: docker.io/istio/examples-bookinfo-mongodb:1.16.4
+        image: quay.io/maistra/examples-bookinfo-mongodb:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -30,19 +30,19 @@ spec:
       version: v2
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: details
         version: v2
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v2:1.16.4
+        image: quay.io/maistra/examples-bookinfo-details-v2:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
         env:
         - name: DO_NOT_ENCRYPT
           value: "true"
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -44,16 +44,16 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: details
         version: v1
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.16.4
+        image: quay.io/maistra/examples-bookinfo-details-v1:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -53,13 +53,15 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: mysqldb
         version: v1
     spec:
       containers:
       - name: mysqldb
-        image: docker.io/istio/examples-bookinfo-mysqldb:1.16.4
+        image: quay.io/maistra/examples-bookinfo-mysqldb:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -27,13 +27,15 @@ spec:
       version: v2-mysql-vm
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: ratings
         version: v2-mysql-vm
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.4
+        image: quay.io/maistra/examples-bookinfo-ratings-v2:2.3.0
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as
@@ -50,6 +52,4 @@ spec:
             value: password
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -27,13 +27,15 @@ spec:
       version: v2-mysql
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: ratings
         version: v2-mysql
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.4
+        image: quay.io/maistra/examples-bookinfo-ratings-v2:2.3.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -32,6 +32,8 @@ spec:
       version: v2
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: ratings
         version: v2
@@ -39,7 +41,7 @@ spec:
       serviceAccountName: bookinfo-ratings-v2
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.4
+        image: quay.io/maistra/examples-bookinfo-ratings-v2:2.3.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.
@@ -60,6 +62,4 @@ spec:
             value: mongodb://mongodb:27017/test
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -44,16 +44,16 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: ratings
         version: v1
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.4
+        image: quay.io/maistra/examples-bookinfo-ratings-v1:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -30,13 +30,15 @@ spec:
       version: v2
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: reviews
         version: v2
     spec:
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.4
+        image: quay.io/maistra/examples-bookinfo-reviews-v2:2.3.0
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -48,8 +50,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -65,6 +65,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: details
         version: v1
@@ -72,12 +74,10 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.16.4
+        image: quay.io/maistra/examples-bookinfo-details-v1:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---
 ##################################################################################################
 # Ratings service
@@ -118,6 +118,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: ratings
         version: v1
@@ -125,12 +127,10 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.4
+        image: quay.io/maistra/examples-bookinfo-ratings-v1:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        securityContext:
-          runAsUser: 1000
 ---
 ##################################################################################################
 # Reviews service
@@ -171,6 +171,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: reviews
         version: v1
@@ -178,7 +180,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.4
+        image: quay.io/maistra/examples-bookinfo-reviews-v1:2.3.0
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -190,8 +192,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -213,6 +213,8 @@ spec:
       version: v2
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: reviews
         version: v2
@@ -220,7 +222,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.4
+        image: quay.io/maistra/examples-bookinfo-reviews-v2:2.3.0
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -232,8 +234,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -255,6 +255,8 @@ spec:
       version: v3
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: reviews
         version: v3
@@ -262,7 +264,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.16.4
+        image: quay.io/maistra/examples-bookinfo-reviews-v3:2.3.0
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -274,8 +276,6 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -321,6 +321,8 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: productpage
         version: v1
@@ -328,15 +330,13 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.4
+        image: quay.io/maistra/examples-bookinfo-productpage-v1:2.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
         volumeMounts:
         - name: tmp
           mountPath: /tmp
-        securityContext:
-          runAsUser: 1000
       volumes:
       - name: tmp
         emptyDir: {}


### PR DESCRIPTION
Rebuilt bookinfo images for 2.3, removed runAsUser from deployment and added sidecar injection. Tested with SMCP 2.2, 2.3, operator 2.3. 

Reference PRs for history + for future reference:
#402 #396 #505 
