### PR TITLE
OSSM-1689 Simplify IOR

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -151,8 +151,6 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 	// Create the config store.
 	s.environment.IstioConfigStore = model.MakeIstioStore(s.configController)
 
-	s.startIOR(args)
-
 	// Defer starting the controller until after the service is created.
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go s.configController.Run(stop)
@@ -160,32 +158,6 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 	})
 
 	return nil
-}
-
-// startIOR tries to start IOR, if it's enabled. If it encounters any failure, it logs an error and continue
-func (s *Server) startIOR(args *PilotArgs) {
-	if !features.EnableIOR {
-		return
-	}
-
-	routerClient, err := ior.NewRouterClient()
-	if err != nil {
-		ior.IORLog.Errorf("error creating an openshift router client: %v", err)
-		return
-	}
-
-	iorKubeClient := ior.NewKubeClient(s.kubeClient)
-
-	s.addStartFunc(func(stop <-chan struct{}) error {
-		go leaderelection.
-			NewLeaderElection(args.Namespace, args.PodName, leaderelection.IORController, args.Revision, s.kubeClient).
-			AddRunFunction(func(stop <-chan struct{}) {
-				if err := ior.Register(iorKubeClient, routerClient, s.configController, args.Namespace, s.kubeClient.GetMemberRoll(), stop, nil); err != nil {
-					ior.IORLog.Error(err)
-				}
-			}).Run(stop)
-		return nil
-	})
 }
 
 func (s *Server) initK8SConfigStore(args *PilotArgs) error {
@@ -246,6 +218,16 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 		if err := s.initInprocessAnalysisController(args); err != nil {
 			return err
 		}
+	}
+	if features.EnableIOR {
+		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
+			leaderelection.
+				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IORController, args.Revision, s.kubeClient).
+				AddRunFunction(func(leaderStop <-chan struct{}) {
+					ior.Run(s.kubeClient, configController, args.Namespace, leaderStop, nil)
+				}).Run(stop)
+			return nil
+		})
 	}
 	s.RWConfigStore, err = configaggregate.MakeWriteableCache(s.ConfigStores, configController)
 	if err != nil {

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -224,7 +224,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 			leaderelection.
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IORController, args.Revision, s.kubeClient).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
-					ior.Run(s.kubeClient, configController, args.Namespace, leaderStop, nil)
+					ior.Run(s.kubeClient, configController, args.Namespace, leaderStop)
 				}).Run(stop)
 			return nil
 		})

--- a/pilot/pkg/config/kube/ior/fake.go
+++ b/pilot/pkg/config/kube/ior/fake.go
@@ -121,7 +121,26 @@ func (fk *FakeRouter) Create(ctx context.Context, route *v1.Route, opts metav1.C
 
 // Update implements routev1.RouteInterface
 func (fk *FakeRouter) Update(ctx context.Context, route *v1.Route, opts metav1.UpdateOptions) (*v1.Route, error) {
-	panic("not implemented")
+	fk.routesLock.Lock()
+	defer fk.routesLock.Unlock()
+
+	if _, ok := fk.routes[route.Name]; !ok {
+		return nil, fmt.Errorf("exisiting not found")
+	}
+
+	if strings.Contains(route.Spec.Host, "/") {
+		return nil, fmt.Errorf("invalid hostname")
+	}
+
+	if route.Spec.Host == "" {
+		generatedHostNumber++
+		route.Spec.Host = fmt.Sprintf("generated-host%d.com", generatedHostNumber)
+	}
+
+	fk.routes[route.Name] = route
+
+	countCallsIncrement("update")
+	return route, nil
 }
 
 // UpdateStatus implements routev1.RouteInterface
@@ -176,7 +195,8 @@ func (fk *FakeRouter) Watch(ctx context.Context, opts metav1.ListOptions) (watch
 
 // Patch implements routev1.RouteInterface
 func (fk *FakeRouter) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions,
-	subresources ...string) (result *v1.Route, err error) {
+	subresources ...string,
+) (result *v1.Route, err error) {
 	panic("not implemented")
 }
 

--- a/pilot/pkg/config/kube/ior/ior.go
+++ b/pilot/pkg/config/kube/ior/ior.go
@@ -15,85 +15,35 @@
 package ior
 
 import (
-	"fmt"
-	"sync"
-
-	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
-
-	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/servicemesh/controller"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
 // IORLog is IOR-scoped log
 var IORLog = log.RegisterScope("ior", "IOR logging", 0)
 
-// Register configures IOR component to respond to Gateway creations and removals
-func Register(
-	k8sClient KubeClient,
-	routerClient routev1.RouteV1Interface,
+type IOR struct {
+	route
+}
+
+func Run(
+	kubeClient kube.Client,
 	store model.ConfigStoreCache,
 	pilotNamespace string,
-	mrc controller.MemberRollController,
 	stop <-chan struct{},
-	errorChannel chan error) error {
-	IORLog.Info("Registering IOR component")
-
-	r, err := newRoute(k8sClient, routerClient, store, pilotNamespace, mrc, stop)
+	errorChannel chan error,
+) {
+	IORLog.Info("setting up IOR")
+	rc, err := NewRouterClient()
 	if err != nil {
-		return err
+		return
 	}
-	r.errorChannel = errorChannel
 
-	alive := true
-	var aliveLock sync.Mutex
-	go func(stop <-chan struct{}) {
-		// Stop responding to events when we are no longer a leader.
-		// Two notes here:
-		// (1) There's no such method "UnregisterEventHandler()"
-		// (2) It might take a few seconds to this channel to be closed. So, both pods might be leader for a few seconds.
-		<-stop
-		IORLog.Info("This pod is no longer a leader. IOR stopped responding")
-		aliveLock.Lock()
-		alive = false
-		aliveLock.Unlock()
-	}(stop)
+	r, err := newRoute(NewKubeClient(kubeClient), rc, store, pilotNamespace, kubeClient.GetMemberRoll(), stop, errorChannel)
+	if err != nil {
+		return
+	}
 
-	IORLog.Debugf("Registering IOR into Istio's Gateway broadcast")
-	kind := collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
-	store.RegisterEventHandler(kind, func(old, curr config.Config, event model.Event) {
-		aliveLock.Lock()
-		defer aliveLock.Unlock()
-		if !alive {
-			return
-		}
-
-		// encapsulate in goroutine to not slow down processing because of waiting for mutex
-		go func() {
-			_, ok := curr.Spec.(*networking.Gateway)
-			if !ok {
-				IORLog.Errorf("could not decode object as Gateway. Object = %v", curr)
-				return
-			}
-
-			debugMessage := fmt.Sprintf("Event %v arrived:", event)
-			if event == model.EventUpdate {
-				debugMessage += fmt.Sprintf("\tOld object: %v", old)
-			}
-			debugMessage += fmt.Sprintf("\tNew object: %v", curr)
-			IORLog.Debug(debugMessage)
-
-			if err := r.handleEvent(event, curr); err != nil {
-				IORLog.Errora(err)
-				if r.errorChannel != nil {
-					r.errorChannel <- err
-				}
-			}
-		}()
-	})
-
-	return nil
+	r.Run(stop)
 }

--- a/pilot/pkg/config/kube/ior/ior.go
+++ b/pilot/pkg/config/kube/ior/ior.go
@@ -35,7 +35,7 @@ func Run(
 	errorChannel chan error,
 ) {
 	IORLog.Info("setting up IOR")
-	rc, err := NewRouterClient()
+	rc, err := newRouterClient()
 	if err != nil {
 		return
 	}

--- a/pilot/pkg/config/kube/ior/ior.go
+++ b/pilot/pkg/config/kube/ior/ior.go
@@ -32,7 +32,6 @@ func Run(
 	store model.ConfigStoreCache,
 	pilotNamespace string,
 	stop <-chan struct{},
-	errorChannel chan error,
 ) {
 	IORLog.Info("setting up IOR")
 	rc, err := newRouterClient()
@@ -40,7 +39,7 @@ func Run(
 		return
 	}
 
-	r, err := newRoute(NewKubeClient(kubeClient), rc, store, pilotNamespace, kubeClient.GetMemberRoll(), stop, errorChannel)
+	r, err := newRoute(NewKubeClient(kubeClient), rc, store, pilotNamespace, kubeClient.GetMemberRoll(), stop)
 	if err != nil {
 		return
 	}

--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -444,6 +444,7 @@ func TestEdit(t *testing.T) {
 
 // TestPerf makes sure we are not doing more API calls than necessary
 func TestPerf(t *testing.T) {
+	t.SkipNow()
 	IORLog.SetOutputLevel(log.DebugLevel)
 	countCallsReset()
 

--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -580,7 +580,7 @@ func TestDuplicateUpdateEvents(t *testing.T) {
 	func() {
 		r.gatewaysLock.Lock()
 		defer r.gatewaysLock.Unlock()
-		if len(r.gatewaysMap) != 1 {
+		if len(r.gatewayMap) != 1 {
 			t.Fatal("error creating the first route")
 		}
 	}()

--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -540,6 +540,7 @@ func TestConcurrency(t *testing.T) {
 }
 
 func TestDuplicateUpdateEvents(t *testing.T) {
+	t.SkipNow()
 	IORLog.SetOutputLevel(log.DebugLevel)
 	stop := make(chan struct{})
 	defer func() { close(stop) }()

--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -23,7 +23,6 @@ import (
 
 	routeapiv1 "github.com/openshift/api/route/v1"
 	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
-	"github.com/stretchr/testify/assert"
 	k8sioapicorev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -44,7 +43,6 @@ const prefixedLabel = maistraPrefix + "fake"
 func initClients(
 	t *testing.T,
 	stop <-chan struct{},
-	errorChannel chan error,
 	mrc memberroll.MemberRollController,
 ) (model.ConfigStoreCache, KubeClient, routev1.RouteV1Interface, *route) {
 	t.Helper()
@@ -67,7 +65,7 @@ func initClients(
 		return nil
 	}, retry.Timeout(time.Second))
 
-	r, err := newRoute(iorKubeClient, routerClient, store, "istio-system", mrc, stop, errorChannel)
+	r, err := newRoute(iorKubeClient, routerClient, store, "istio-system", mrc, stop)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,16 +142,6 @@ func TestCreate(t *testing.T) {
 			1,
 			"",
 			true,
-			nil,
-		},
-		{
-			"Non-existing namespace",
-			"non-existing",
-			[]string{"fail.com"},
-			map[string]string{"istio": "ingressgateway"},
-			0,
-			"could not handle the ADD event for non-existing",
-			false,
 			nil,
 		},
 		{
@@ -241,7 +229,6 @@ func TestCreate(t *testing.T) {
 	IORLog.SetOutputLevel(log.DebugLevel)
 
 	var stop chan struct{}
-	var errorChannel chan error
 	var store model.ConfigStoreCache
 	var k8sClient KubeClient
 	var routerClient routev1.RouteV1Interface
@@ -249,65 +236,31 @@ func TestCreate(t *testing.T) {
 	var r *route
 	controlPlaneNs := "istio-system"
 
-	for _, testType := range []string{"initialSync", "events"} {
-		if testType == "events" {
-			stop = make(chan struct{})
-			defer func() { close(stop) }()
-			errorChannel = make(chan error)
-			mrc = newFakeMemberRollController()
-			store, k8sClient, routerClient, r = initClients(t, stop, errorChannel, mrc)
-			r.Run(stop)
-			mrc.setNamespaces(controlPlaneNs)
+	stop = make(chan struct{})
+	defer func() { close(stop) }()
+	mrc = newFakeMemberRollController()
+	store, k8sClient, routerClient, r = initClients(t, stop, mrc)
+	r.Run(stop)
+	mrc.setNamespaces(controlPlaneNs)
 
-			createIngressGateway(t, k8sClient.GetActualClient(), controlPlaneNs, map[string]string{"istio": "ingressgateway"})
-		}
+	createIngressGateway(t, k8sClient.GetActualClient(), controlPlaneNs, map[string]string{"istio": "ingressgateway"})
 
-		for i, c := range cases {
-			t.Run(testType+"-"+c.testName, func(t *testing.T) {
-				if testType == "initialSync" {
-					stop = make(chan struct{})
-					defer func() { close(stop) }()
-					errorChannel = make(chan error)
-					mrc = newFakeMemberRollController()
-					store, k8sClient, routerClient, r = initClients(t, stop, errorChannel, mrc)
-					createIngressGateway(t, k8sClient.GetActualClient(), controlPlaneNs, map[string]string{"istio": "ingressgateway"})
-					r.Run(stop)
-				}
-				gatewayName := fmt.Sprintf("gw%d", i)
-				createGateway(t, store, c.ns, gatewayName, c.hosts, c.gwSelector, c.tls, c.annotations)
-				if testType == "initialSync" {
-					mrc.setNamespaces(controlPlaneNs)
-				}
-				list, _ := getRoutes(t, routerClient, controlPlaneNs, c.expectedRoutes, time.Second)
-				if err := getError(errorChannel); err != nil {
-					if c.expectedError == "" {
-						t.Fatal(err)
-					}
+	for i, c := range cases {
+		t.Run(c.testName, func(t *testing.T) {
+			gatewayName := fmt.Sprintf("gw%d", i)
+			createGateway(t, store, c.ns, gatewayName, c.hosts, c.gwSelector, c.tls, c.annotations)
 
-					if !strings.Contains(err.Error(), c.expectedError) {
-						t.Fatalf("expected error message containing `%s', got: %s", c.expectedError, err.Error())
-					}
+			list, _ := getRoutes(t, routerClient, controlPlaneNs, c.expectedRoutes, time.Second)
 
-					// Error is expected and matches the golden string, nothing to do
-				} else {
-					if c.expectedError != "" {
-						t.Fatalf("expected error message containing `%s', got success", c.expectedError)
-					}
+			// Only continue the validation if any route is expected to be created
+			if c.expectedRoutes > 0 {
+				validateRoutes(t, c.hosts, list, gatewayName, c.tls)
 
-					// Only continue the validation if any route is expected to be created
-					if c.expectedRoutes > 0 {
-						validateRoutes(t, c.hosts, list, gatewayName, c.tls)
-
-						// Remove the gateway and expect all routes get removed
-						deleteGateway(t, store, c.ns, gatewayName)
-						_, _ = getRoutes(t, routerClient, c.ns, 0, time.Second)
-						if err := getError(errorChannel); err != nil {
-							t.Fatal(err)
-						}
-					}
-				}
-			})
-		}
+				// Remove the gateway and expect all routes get removed
+				deleteGateway(t, store, c.ns, gatewayName)
+				_, _ = getRoutes(t, routerClient, c.ns, 0, time.Second)
+			}
+		})
 	}
 }
 
@@ -412,11 +365,12 @@ func TestEdit(t *testing.T) {
 		},
 	}
 
+	IORLog.SetOutputLevel(log.DebugLevel)
+
 	stop := make(chan struct{})
 	defer func() { close(stop) }()
-	errorChannel := make(chan error)
 	mrc := newFakeMemberRollController()
-	store, k8sClient, routerClient, r := initClients(t, stop, errorChannel, mrc)
+	store, k8sClient, routerClient, r := initClients(t, stop, mrc)
 	r.Run(stop)
 
 	controlPlane := "istio-system"
@@ -425,89 +379,15 @@ func TestEdit(t *testing.T) {
 	mrc.setNamespaces("istio-system")
 
 	list, _ := getRoutes(t, routerClient, controlPlane, 1, time.Second)
-	if err := getError(errorChannel); err != nil {
-		t.Fatal(err)
-	}
 
 	for i, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
 			editGateway(t, store, c.ns, "gw", c.hosts, c.gwSelector, c.tls, fmt.Sprintf("%d", i+2))
 			list, _ = getRoutes(t, routerClient, controlPlane, c.expectedRoutes, time.Second)
-			if err := getError(errorChannel); err != nil {
-				t.Fatal(err)
-			}
 
 			validateRoutes(t, c.hosts, list, "gw", c.tls)
 		})
 	}
-}
-
-// TestPerf makes sure we are not doing more API calls than necessary
-func TestPerf(t *testing.T) {
-	t.SkipNow()
-	IORLog.SetOutputLevel(log.DebugLevel)
-	countCallsReset()
-
-	stop := make(chan struct{})
-	defer func() { close(stop) }()
-	errorChannel := make(chan error)
-	mrc := newFakeMemberRollController()
-	store, k8sClient, routerClient, r := initClients(t, stop, errorChannel, mrc)
-	r.Run(stop)
-
-	// Create a bunch of namespaces and gateways, and make sure they don't take too long to be created
-	createIngressGateway(t, k8sClient.GetActualClient(), "istio-system", map[string]string{"istio": "ingressgateway"})
-	qty := 100
-	qtyNamespaces := qty + 1
-	createGateways(t, store, 1, qty)
-	mrc.setNamespaces(generateNamespaces(qty)...)
-
-	// It takes ~ 2s on my laptop, it's slower on prow
-	_, ignore := getRoutes(t, routerClient, "istio-system", qty, time.Minute)
-	if err := getError(errorChannel); err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, qty, countCallsGet("create"), "wrong number of calls to client.Routes().Create()")
-	assert.Equal(t, 0, countCallsGet("delete"), "wrong number of calls to client.Routes().Delete()")
-	assert.Equal(t, qtyNamespaces, countCallsGet("list")-ignore, "wrong number of calls to client.Routes().List()")
-	// qty=number of Create() calls; qtyNamespaces=number of List() calls
-	assert.Equal(t, qty+qtyNamespaces, countCallsGet("routes")-ignore, "wrong number of calls to client.Routes()")
-
-	// Now we have a lot of routes created, let's create one more gateway. We don't expect a lot of new API calls
-	countCallsReset()
-	createGateway(t, store, "ns1", "gw-ns1-1", []string{"instant.com"}, map[string]string{"istio": "ingressgateway"}, false, nil)
-	_, ignore = getRoutes(t, routerClient, "istio-system", qty+1, time.Second)
-	if err := getError(errorChannel); err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, 1, countCallsGet("create"), "wrong number of calls to client.Routes().Create()")
-	assert.Equal(t, 0, countCallsGet("delete"), "wrong number of calls to client.Routes().Delete()")
-	assert.Equal(t, 0, countCallsGet("list")-ignore, "wrong number of calls to client.Routes().List()")
-	assert.Equal(t, 1, countCallsGet("routes")-ignore, "wrong number of calls to client.Routes()")
-
-	// Editing. We don't expect a lot of new API calls
-	countCallsReset()
-	editGateway(t, store, "ns1", "gw-ns1-1", []string{"edited.com", "edited-other.com"}, map[string]string{"istio": "ingressgateway"}, false, "2")
-	_, ignore = getRoutes(t, routerClient, "istio-system", qty+2, time.Second)
-	if err := getError(errorChannel); err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, 2, countCallsGet("create"), "wrong number of calls to client.Routes().Create()")
-	assert.Equal(t, 1, countCallsGet("delete"), "wrong number of calls to client.Routes().Delete()")
-	assert.Equal(t, 0, countCallsGet("list")-ignore, "wrong number of calls to client.Routes().List()")
-	assert.Equal(t, 3, countCallsGet("routes")-ignore, "wrong number of calls to client.Routes()")
-
-	// Same for deletion. We don't expect a lot of new API calls
-	countCallsReset()
-	deleteGateway(t, store, "ns1", "gw-ns1-1")
-	_, ignore = getRoutes(t, routerClient, "istio-system", qty, time.Second)
-	if err := getError(errorChannel); err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, 0, countCallsGet("create"), "wrong number of calls to client.Routes().Create()")
-	assert.Equal(t, 2, countCallsGet("delete"), "wrong number of calls to client.Routes().Delete()")
-	assert.Equal(t, 0, countCallsGet("list")-ignore, "wrong number of calls to client.Routes().List()")
-	assert.Equal(t, 2, countCallsGet("routes")-ignore, "wrong number of calls to client.Routes()")
 }
 
 // TestConcurrency makes sure IOR can respond to events even when doing its initial sync
@@ -515,9 +395,8 @@ func TestConcurrency(t *testing.T) {
 	IORLog.SetOutputLevel(log.DebugLevel)
 	stop := make(chan struct{})
 	defer func() { close(stop) }()
-	errorChannel := make(chan error)
 	mrc := newFakeMemberRollController()
-	store, k8sClient, routerClient, r := initClients(t, stop, errorChannel, mrc)
+	store, k8sClient, routerClient, r := initClients(t, stop, mrc)
 	r.Run(stop)
 
 	qty := 10
@@ -537,66 +416,6 @@ func TestConcurrency(t *testing.T) {
 
 	// And expect all `qty * 2` gateways to be created
 	_, _ = getRoutes(t, routerClient, "istio-system", (qty * runs), time.Minute)
-	if err := getError(errorChannel); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestDuplicateUpdateEvents(t *testing.T) {
-	t.SkipNow()
-	IORLog.SetOutputLevel(log.DebugLevel)
-	stop := make(chan struct{})
-	defer func() { close(stop) }()
-	errorChannel := make(chan error)
-	mrc := newFakeMemberRollController()
-	store, k8sClient, routerClient, route := initClients(t, stop, errorChannel, mrc)
-	route.Run(stop)
-
-	r, err := newRoute(k8sClient, routerClient, store, "istio-system", mrc, stop, errorChannel)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mrc.setNamespaces("istio-system")
-	createIngressGateway(t, k8sClient.GetActualClient(), "istio-system", map[string]string{"istio": "ingressgateway"})
-
-	cfg := config.Config{
-		Meta: config.Meta{
-			GroupVersionKind: collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
-			Namespace:        "istio-system",
-			Name:             "a",
-			ResourceVersion:  "1",
-		},
-		Spec: &networking.Gateway{
-			Servers: []*networking.Server{
-				{
-					Hosts: []string{"a.com"},
-				},
-			},
-		},
-	}
-
-	// Create the first router, should work just fine
-	err = r.handleEvent(model.EventAdd, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	func() {
-		r.gatewaysLock.Lock()
-		defer r.gatewaysLock.Unlock()
-		if len(r.gatewayMap) != 1 {
-			t.Fatal("error creating the first route")
-		}
-	}()
-
-	// Simulate an UPDATE event with the same data, should be ignored
-	err = r.handleEvent(model.EventUpdate, cfg)
-	if err == nil {
-		t.Fatalf("expecting the error: %q, but got nothing", eventDuplicatedMessage)
-	}
-	if msg := err.Error(); msg != eventDuplicatedMessage {
-		t.Fatalf("expecting the error: %q, but got %q", eventDuplicatedMessage, msg)
-	}
 }
 
 func generateNamespaces(qty int) []string {
@@ -620,21 +439,6 @@ func createGateways(t *testing.T, store model.ConfigStoreCache, begin, end int) 
 			false,
 			nil)
 	}
-}
-
-// getError tries to read an error from the error channel.
-// It tries 3 times beforing returning nil, in case of there's no error in the channel,
-// this is to give some time to async functions to run and fill the channel properly
-func getError(errorChannel chan error) error {
-	for i := 1; i < 3; i++ {
-		select {
-		case err := <-errorChannel:
-			return err
-		default:
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return nil
 }
 
 // getRoutes is a helper function that keeps trying getting a list of routes until it gets `size` items.

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -366,7 +366,7 @@ func (r *route) createRoute(metadata config.Meta, originalHost string, tls *netw
 
 	nr, err := r.routerClient.Routes(serviceNamespace).Create(context.TODO(), &v1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        getRouteName(metadata.Namespace, metadata.Name, actualHost),
+			Name:        getRouteName(metadata.Namespace, metadata.Name, originalHost),
 			Namespace:   serviceNamespace,
 			Labels:      labels,
 			Annotations: annotations,
@@ -437,8 +437,8 @@ func (r *route) findService(gateway *networking.Gateway) (string, string, error)
 		gwSelector.String(), namespaces)
 }
 
-func getRouteName(namespace, name, actualHost string) string {
-	return fmt.Sprintf("%s-%s-%s", namespace, name, hostHash(actualHost))
+func getRouteName(namespace, name, host string) string {
+	return fmt.Sprintf("%s-%s-%s", namespace, name, hostHash(host))
 }
 
 // getActualHost returns the actual hostname to be used in the route

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/servicemesh/controller"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -562,12 +563,14 @@ func (r *route) processEvent(old, curr config.Config, event model.Event) {
 		return
 	}
 
-	debugMessage := fmt.Sprintf("Event %v arrived:", event)
-	if event == model.EventUpdate {
-		debugMessage += fmt.Sprintf("\tOld object: %v", old)
+	if IORLog.GetOutputLevel() >= log.DebugLevel {
+		debugMessage := fmt.Sprintf("Event %v arrived:", event)
+		if event == model.EventUpdate {
+			debugMessage += fmt.Sprintf("\tOld object: %v", old)
+		}
+		debugMessage += fmt.Sprintf("\tNew object: %v", curr)
+		IORLog.Debug(debugMessage)
 	}
-	debugMessage += fmt.Sprintf("\tNew object: %v", curr)
-	IORLog.Debug(debugMessage)
 
 	if err := r.handleEvent(event, curr); err != nil {
 		IORLog.Errora(err)

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -103,7 +103,9 @@ func newRoute(
 	store model.ConfigStoreCache,
 	pilotNamespace string,
 	mrc controller.MemberRollController,
-	stop <-chan struct{}) (*route, error) {
+	stop <-chan struct{},
+	errorChannel chan error,
+) (*route, error) {
 	if !kubeClient.IsRouteSupported() {
 		return nil, fmt.Errorf("routes are not supported in this cluster")
 	}
@@ -119,6 +121,7 @@ func newRoute(
 	r.stop = stop
 	r.initialSyncRun = make(chan struct{})
 	r.handleEventTimeout = kubeClient.GetHandleEventTimeout()
+	r.errorChannel = errorChannel
 
 	if r.mrc != nil {
 		IORLog.Debugf("Registering IOR into SMMR broadcast")
@@ -624,4 +627,46 @@ func hostHash(name string) string {
 
 	hash := sha256.Sum256([]byte(name))
 	return hex.EncodeToString(hash[:8])
+}
+
+func (r *route) processEvent(old, curr config.Config, event model.Event) {
+	_, ok := curr.Spec.(*networking.Gateway)
+
+	if !ok {
+		IORLog.Errorf("could not decode object as Gateway. Object = %v", curr)
+		return
+	}
+
+	debugMessage := fmt.Sprintf("Event %v arrived:", event)
+	if event == model.EventUpdate {
+		debugMessage += fmt.Sprintf("\tOld object: %v", old)
+	}
+	debugMessage += fmt.Sprintf("\tNew object: %v", curr)
+	IORLog.Debug(debugMessage)
+
+	if err := r.handleEvent(event, curr); err != nil {
+		IORLog.Errora(err)
+		if r.errorChannel != nil {
+			r.errorChannel <- err
+		}
+	}
+}
+
+func (r *route) Run(stop <-chan struct{}) {
+	alive := true
+	go func(s <-chan struct{}) {
+		// Stop responding to events when we are no longer a leader.
+		// The worker may be in the middle of handling an event. It will finish what it is doing then stop.
+		<-s
+		IORLog.Info("This pod is no longer a leader. IOR stopped responding")
+		alive = false
+	}(stop)
+
+	kind := collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
+
+	r.store.RegisterEventHandler(kind, func(old, curr config.Config, evt model.Event) {
+		if alive {
+			r.processEvent(old, curr, evt)
+		}
+	})
 }

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -66,19 +65,16 @@ type route struct {
 	routerClient       routev1.RouteV1Interface
 	kubeClient         kubernetes.Interface
 	store              model.ConfigStoreCache
-	gatewaysMap        map[string]*syncRoutes
+	gatewayMap         map[string]*syncRoutes
 	gatewaysLock       sync.Mutex
-	initialSyncRun     chan struct{}
-	alive              bool
 	stop               <-chan struct{}
 	handleEventTimeout time.Duration
 	errorChannel       chan error
 
 	// memberroll functionality
-	mrc              controller.MemberRollController
-	namespaceLock    sync.Mutex
-	namespaces       []string
-	gotInitialUpdate bool
+	mrc           controller.MemberRollController
+	namespaces    []string
+	namespaceLock sync.Mutex
 }
 
 // NewRouterClient returns an OpenShift client for Routers
@@ -119,121 +115,14 @@ func newRoute(
 	r.mrc = mrc
 	r.namespaces = []string{pilotNamespace}
 	r.stop = stop
-	r.initialSyncRun = make(chan struct{})
 	r.handleEventTimeout = kubeClient.GetHandleEventTimeout()
 	r.errorChannel = errorChannel
 
-	if r.mrc != nil {
-		IORLog.Debugf("Registering IOR into SMMR broadcast")
-		r.alive = true
-		r.mrc.Register(r, "ior")
-
-		go func(stop <-chan struct{}) {
-			<-stop
-			r.alive = false
-			IORLog.Debugf("Unregistering IOR from SMMR broadcast")
-		}(stop)
-	}
+	r.gatewaysLock.Lock()
+	r.gatewayMap = make(map[string]*syncRoutes)
+	r.gatewaysLock.Unlock()
 
 	return r, nil
-}
-
-// initialSync runs on initialization only.
-//
-// It lists all Istio Gateways (source of truth) and OpenShift Routes, compares them and makes the necessary adjustments
-// (creation and/or removal of routes) so that gateways and routes be in sync.
-func (r *route) initialSync(initialNamespaces []string) error {
-	var result *multierror.Error
-	r.gatewaysMap = make(map[string]*syncRoutes)
-
-	r.gatewaysLock.Lock()
-	defer r.gatewaysLock.Unlock()
-
-	// List the gateways and put them into the gatewaysMap
-	// The store must be synced otherwise we might get an empty list
-	// We enforce this before calling this function in UpdateNamespaces()
-	configs, err := r.store.List(collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(), model.NamespaceAll)
-	if err != nil {
-		return fmt.Errorf("could not get list of Gateways: %s", err)
-	}
-	IORLog.Debugf("initialSync() - Got %d Gateway(s)", len(configs))
-
-	for i, cfg := range configs {
-		if err := r.ensureNamespaceExists(cfg); err != nil {
-			result = multierror.Append(result, err)
-			continue
-		}
-		manageRoute, err := isManagedByIOR(cfg)
-		if err != nil {
-			result = multierror.Append(result, err)
-			continue
-		}
-		if !manageRoute {
-			IORLog.Debugf("initialSync() - Ignoring Gateway %s/%s as it is not managed by Istiod", cfg.Namespace, cfg.Name)
-			continue
-		}
-
-		IORLog.Debugf("initialSync() - Parsing Gateway [%d] %s/%s", i+1, cfg.Namespace, cfg.Name)
-		r.addNewSyncRoute(cfg)
-	}
-
-	// List the routes and put them into a map. Map key is the route object name
-	routes := map[string]v1.Route{}
-	for _, ns := range initialNamespaces {
-		IORLog.Debugf("initialSync() - Listing routes in ns %s", ns)
-		routeList, err := r.routerClient.Routes(ns).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", generatedByLabel, generatedByValue),
-		})
-		if err != nil {
-			return fmt.Errorf("could not get list of Routes in namespace %s: %s", ns, err)
-		}
-		for _, route := range routeList.Items {
-			routes[route.Name] = route
-		}
-	}
-	IORLog.Debugf("initialSync() - Got %d route(s) across all %d namespace(s)", len(routes), len(initialNamespaces))
-
-	// Now that we have maps and routes mapped we can compare them (Gateways are the source of truth)
-	for _, syncRoute := range r.gatewaysMap {
-		for _, server := range syncRoute.gateway.Servers {
-			for _, host := range server.Hosts {
-				actualHost, _ := getActualHost(host, false)
-				routeName := getRouteName(syncRoute.metadata.Namespace, syncRoute.metadata.Name, actualHost)
-				route, ok := routes[routeName]
-				if ok {
-					// A route for this host was found, remove its entry in this map so that in the end only orphan routes are left
-					delete(routes, routeName)
-
-					// Route matches, no need to create one. Put it in the gatewaysMap and move to the next one
-					if syncRoute.metadata.ResourceVersion == route.Labels[gatewayResourceVersionLabel] {
-						syncRoute.routes = append(syncRoute.routes, &route)
-						continue
-					}
-
-					// Route does not match, remove it.
-					result = multierror.Append(result, r.deleteRoute(&route))
-				}
-
-				// Route is not found or was removed above because it didn't match. We need to create one now.
-				route2, err := r.createRoute(syncRoute.metadata, syncRoute.gateway, host, server.Tls)
-				if err != nil {
-					result = multierror.Append(result, err)
-				} else {
-					// Put it in the gatewaysMap and move to the next one
-					syncRoute.routes = append(syncRoute.routes, route2)
-				}
-			}
-		}
-	}
-
-	// At this point there are routes for every hostname in every Gateway.
-	// The `routes` map should only contain "orphan" routes, i.e., routes that do not belong to any Gateway
-	//
-	for _, route := range routes {
-		result = multierror.Append(result, r.deleteRoute(&route))
-	}
-
-	return result.ErrorOrNil()
 }
 
 func gatewaysMapKey(namespace, name string) string {
@@ -249,7 +138,7 @@ func (r *route) addNewSyncRoute(cfg config.Config) *syncRoutes {
 		gateway:  gw,
 	}
 
-	r.gatewaysMap[gatewaysMapKey(cfg.Namespace, cfg.Name)] = syncRoute
+	r.gatewayMap[gatewaysMapKey(cfg.Namespace, cfg.Name)] = syncRoute
 	return syncRoute
 }
 
@@ -293,7 +182,7 @@ func (r *route) handleAdd(cfg config.Config) error {
 	r.gatewaysLock.Lock()
 	defer r.gatewaysLock.Unlock()
 
-	if _, ok := r.gatewaysMap[gatewaysMapKey(cfg.Namespace, cfg.Name)]; ok {
+	if _, ok := r.gatewayMap[gatewaysMapKey(cfg.Namespace, cfg.Name)]; ok {
 		IORLog.Infof("gateway %s/%s already exists, not creating route(s) for it", cfg.Namespace, cfg.Name)
 		return nil
 	}
@@ -343,7 +232,7 @@ func (r *route) handleDel(cfg config.Config) error {
 	defer r.gatewaysLock.Unlock()
 
 	key := gatewaysMapKey(cfg.Namespace, cfg.Name)
-	syncRoute, ok := r.gatewaysMap[key]
+	syncRoute, ok := r.gatewayMap[key]
 	if !ok {
 		return fmt.Errorf("could not find an internal reference to gateway %s/%s", cfg.Namespace, cfg.Name)
 	}
@@ -353,7 +242,7 @@ func (r *route) handleDel(cfg config.Config) error {
 		result = multierror.Append(result, r.deleteRoute(route))
 	}
 
-	delete(r.gatewaysMap, key)
+	delete(r.gatewayMap, key)
 
 	return result.ErrorOrNil()
 }
@@ -363,7 +252,7 @@ func (r *route) verifyResourceVersions(cfg config.Config) error {
 	defer r.gatewaysLock.Unlock()
 
 	key := gatewaysMapKey(cfg.Namespace, cfg.Name)
-	syncRoute, ok := r.gatewaysMap[key]
+	syncRoute, ok := r.gatewayMap[key]
 	if !ok {
 		return fmt.Errorf("could not find an internal reference to gateway %s/%s", cfg.Namespace, cfg.Name)
 	}
@@ -376,9 +265,6 @@ func (r *route) verifyResourceVersions(cfg config.Config) error {
 }
 
 func (r *route) handleEvent(event model.Event, cfg config.Config) error {
-	// Block until initial sync has finished
-	<-r.initialSyncRun
-
 	manageRoute, err := isManagedByIOR(cfg)
 	if err != nil {
 		return err
@@ -411,43 +297,10 @@ func (r *route) handleEvent(event model.Event, cfg config.Config) error {
 
 // Trigerred by SMMR controller when SMMR changes
 func (r *route) SetNamespaces(namespaces []string) {
-	if !r.alive {
-		return
-	}
-
-	if namespaces == nil {
-		return
-	}
-
 	IORLog.Debugf("UpdateNamespaces(%v)", namespaces)
 	r.namespaceLock.Lock()
 	r.namespaces = namespaces
 	r.namespaceLock.Unlock()
-
-	if r.gotInitialUpdate {
-		return
-	}
-	r.gotInitialUpdate = true
-
-	// In the first update we perform an initial sync
-	go func() {
-		// But only after gateway store cache is synced
-		IORLog.Debug("Waiting for the Gateway store cache to sync before performing our initial sync")
-		if !cache.WaitForNamedCacheSync("Gateways", r.stop, r.store.HasSynced) {
-			IORLog.Infof("Failed to sync Gateway store cache. Not performing initial sync.")
-			return
-		}
-		IORLog.Debug("Gateway store cache synced. Performing our initial sync now")
-
-		if err := r.initialSync(namespaces); err != nil {
-			IORLog.Errora(err)
-			if r.errorChannel != nil {
-				r.errorChannel <- err
-			}
-		}
-		IORLog.Debug("Initial sync finished")
-		close(r.initialSyncRun)
-	}()
 }
 
 func getHost(route v1.Route) string {
@@ -654,16 +507,18 @@ func (r *route) processEvent(old, curr config.Config, event model.Event) {
 
 func (r *route) Run(stop <-chan struct{}) {
 	alive := true
-	go func(s <-chan struct{}) {
-		// Stop responding to events when we are no longer a leader.
-		// The worker may be in the middle of handling an event. It will finish what it is doing then stop.
-		<-s
-		IORLog.Info("This pod is no longer a leader. IOR stopped responding")
+
+	go func(stop <-chan struct{}) {
+		<-stop
 		alive = false
+		IORLog.Info("This pod is no longer a leader. IOR stopped responding")
 	}(stop)
 
-	kind := collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
+	IORLog.Debugf("Registering IOR into SMMR broadcast")
+	r.mrc.Register(r, "ior")
 
+	IORLog.Debugf("Registering IOR into Gateway broadcast")
+	kind := collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
 	r.store.RegisterEventHandler(kind, func(old, curr config.Config, evt model.Event) {
 		if alive {
 			r.processEvent(old, curr, evt)

--- a/pilot/pkg/config/kube/ior/route.go
+++ b/pilot/pkg/config/kube/ior/route.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	v1 "github.com/openshift/api/route/v1"
@@ -51,32 +50,20 @@ const (
 	gatewayNamespaceLabel       = maistraPrefix + "gateway-namespace"
 	gatewayResourceVersionLabel = maistraPrefix + "gateway-resourceVersion"
 	ShouldManageRouteAnnotation = maistraPrefix + "manageRoute"
-
-	eventDuplicatedMessage = "event UPDATE arrived but resourceVersions are the same - ignoring"
 )
-
-type syncRoutes struct {
-	metadata config.Meta
-	gateway  *networking.Gateway
-	routes   map[string]*v1.Route
-}
 
 // route manages the integration between Istio Gateways and OpenShift Routes
 type route struct {
-	pilotNamespace     string
-	routerClient       routev1.RouteV1Interface
-	kubeClient         kubernetes.Interface
-	store              model.ConfigStoreCache
-	gatewayMap         map[string]*syncRoutes
-	gatewaysLock       sync.Mutex
-	stop               <-chan struct{}
-	handleEventTimeout time.Duration
-	errorChannel       chan error
+	pilotNamespace string
+	routerClient   routev1.RouteV1Interface
+	kubeClient     kubernetes.Interface
+	store          model.ConfigStoreCache
+	stop           <-chan struct{}
 
 	// memberroll functionality
 	mrc           controller.MemberRollController
-	namespaces    []string
 	namespaceLock sync.Mutex
+	namespaces    []string
 }
 
 // newRouterClient returns an OpenShift client for Routers
@@ -102,7 +89,6 @@ func newRoute(
 	pilotNamespace string,
 	mrc controller.MemberRollController,
 	stop <-chan struct{},
-	errorChannel chan error,
 ) (*route, error) {
 	if !kubeClient.IsRouteSupported() {
 		return nil, fmt.Errorf("routes are not supported in this cluster")
@@ -117,155 +103,8 @@ func newRoute(
 	r.mrc = mrc
 	r.namespaces = []string{pilotNamespace}
 	r.stop = stop
-	r.handleEventTimeout = kubeClient.GetHandleEventTimeout()
-	r.errorChannel = errorChannel
-
-	r.gatewayMap = make(map[string]*syncRoutes)
 
 	return r, nil
-}
-
-func gatewayMapKey(namespace, name string) string {
-	return namespace + "/" + name
-}
-
-// addNewSyncRoute creates a new syncRoutes and adds it to the gatewaysMap
-// Must be called with gatewaysLock locked
-func (r *route) addNewSyncRoute(cfg config.Config) *syncRoutes {
-	gw := cfg.Spec.(*networking.Gateway)
-	syncRoute := &syncRoutes{
-		metadata: cfg.Meta,
-		gateway:  gw,
-		routes:   make(map[string]*v1.Route),
-	}
-
-	r.gatewayMap[gatewayMapKey(cfg.Namespace, cfg.Name)] = syncRoute
-	return syncRoute
-}
-
-// ensureNamespaceExists makes sure the gateway namespace is present in r.namespaces
-// r.namespaces is updated by the SMMR controller, in SetNamespaces()
-// This handles the case where an ADD event comes before SetNamespaces() is called and
-// the unlikely case an ADD event arrives for a gateway whose namespace does not belong to the SMMR at all
-func (r *route) ensureNamespaceExists(cfg config.Config) error {
-	timeout := time.After(r.handleEventTimeout) // production default is 10s, but test default is only 1ms
-
-	for {
-		r.namespaceLock.Lock()
-		namespaces := r.namespaces
-		r.namespaceLock.Unlock()
-
-		for _, ns := range namespaces {
-			if ns == cfg.Namespace {
-				IORLog.Debugf("Namespace %s found in SMMR", cfg.Namespace)
-				return nil
-			}
-		}
-
-		select {
-		case <-timeout:
-			IORLog.Debugf("Namespace %s not found in SMMR. Aborting.", cfg.Namespace)
-			return fmt.Errorf("could not handle the ADD event for %s/%s: SMMR does not recognize this namespace", cfg.Namespace, cfg.Name)
-		default:
-			IORLog.Debugf("Namespace %s not found in SMMR, trying again", cfg.Namespace)
-		}
-		time.Sleep(r.handleEventTimeout / 100)
-	}
-}
-
-func (r *route) onGatewayAdded(cfg config.Config) error {
-	var result *multierror.Error
-
-	if err := r.ensureNamespaceExists(cfg); err != nil {
-		return err
-	}
-
-	r.gatewaysLock.Lock()
-	defer r.gatewaysLock.Unlock()
-
-	if _, ok := r.gatewayMap[gatewayMapKey(cfg.Namespace, cfg.Name)]; ok {
-		IORLog.Infof("gateway %s/%s already exists, not creating route(s) for it", cfg.Namespace, cfg.Name)
-		return nil
-	}
-
-	syncRoute := r.addNewSyncRoute(cfg)
-
-	serviceNamespace, serviceName, err := r.findService(syncRoute.gateway)
-	if err != nil {
-		return err
-	}
-
-	for _, server := range syncRoute.gateway.Servers {
-		for _, host := range server.Hosts {
-			route, err := r.createRoute(cfg.Meta, host, server.Tls, serviceNamespace, serviceName)
-			if err != nil {
-				result = multierror.Append(result, err)
-			} else {
-				syncRoute.routes[getRouteName(cfg.Meta.Namespace, cfg.Meta.Name, host)] = route
-			}
-		}
-	}
-
-	return result.ErrorOrNil()
-}
-
-func (r *route) onGatewayUpdated(cfg config.Config) error {
-	var result *multierror.Error
-
-	if err := r.ensureNamespaceExists(cfg); err != nil {
-		return err
-	}
-
-	r.gatewaysLock.Lock()
-	defer r.gatewaysLock.Unlock()
-
-	curr, gotGateway := r.gatewayMap[gatewayMapKey(cfg.Namespace, cfg.Name)]
-
-	if !gotGateway {
-		return fmt.Errorf("gateway %s/%s does not exists, IOR failed to update", cfg.Namespace, cfg.Name)
-	}
-
-	sr := r.addNewSyncRoute(cfg)
-
-	serviceNamespace, serviceName, err := r.findService(sr.gateway)
-	if err != nil {
-		return errors.Wrapf(err, "gateway %s/%s does not specify a valid service target.", cfg.Namespace, cfg.Name)
-	}
-
-	cr := curr.routes
-
-	for _, server := range sr.gateway.Servers {
-		for _, host := range server.Hosts {
-			var route *v1.Route
-			var gotRoute bool
-			var err error
-
-			name := getRouteName(cfg.Meta.Namespace, cfg.Meta.Name, host)
-
-			_, gotRoute = cr[name]
-
-			if gotRoute {
-				route, err = r.updateRoute(cfg.Meta, host, server.Tls, serviceNamespace, serviceName)
-			} else {
-				route, err = r.createRoute(cfg.Meta, host, server.Tls, serviceNamespace, serviceName)
-			}
-
-			if err != nil {
-				result = multierror.Append(result, err)
-			} else {
-				sr.routes[name] = route
-				delete(cr, name)
-			}
-		}
-	}
-
-	for _, route := range cr {
-		if err := r.deleteRoute(route); err != nil {
-			result = multierror.Append(result, err)
-		}
-	}
-
-	return result.ErrorOrNil()
 }
 
 func isManagedByIOR(cfg config.Config) (bool, error) {
@@ -290,55 +129,10 @@ func isManagedByIOR(cfg config.Config) (bool, error) {
 	return manageRoute, nil
 }
 
-func (r *route) onGatewayRemoved(cfg config.Config) error {
-	var result *multierror.Error
-
-	r.gatewaysLock.Lock()
-	defer r.gatewaysLock.Unlock()
-
-	key := gatewayMapKey(cfg.Namespace, cfg.Name)
-	syncRoute, ok := r.gatewayMap[key]
-	if !ok {
-		return fmt.Errorf("could not find an internal reference to gateway %s/%s", cfg.Namespace, cfg.Name)
-	}
-
-	IORLog.Debugf("The gateway %s/%s has %d route(s) associated with it. Removing them now.", cfg.Namespace, cfg.Name, len(syncRoute.routes))
-	for _, route := range syncRoute.routes {
-		result = multierror.Append(result, r.deleteRoute(route))
-	}
-
-	delete(r.gatewayMap, key)
-
-	return result.ErrorOrNil()
-}
-
-func (r *route) handleEvent(event model.Event, cfg config.Config) error {
-	manageRoute, err := isManagedByIOR(cfg)
-	if err != nil {
-		return err
-	}
-	if !manageRoute {
-		IORLog.Infof("Ignoring Gateway %s/%s as it is not managed by Istiod", cfg.Namespace, cfg.Name)
-		return nil
-	}
-
-	switch event {
-	case model.EventAdd:
-		return r.onGatewayAdded(cfg)
-
-	case model.EventUpdate:
-		return r.onGatewayUpdated(cfg)
-
-	case model.EventDelete:
-		return r.onGatewayRemoved(cfg)
-	}
-
-	return fmt.Errorf("unknown event type %s", event)
-}
-
 // Trigerred by SMMR controller when SMMR changes
 func (r *route) SetNamespaces(namespaces []string) {
-	IORLog.Debugf("UpdateNamespaces(%v)", namespaces)
+	IORLog.Debugf("update namespaces to %v", namespaces)
+
 	r.namespaceLock.Lock()
 	r.namespaces = namespaces
 	r.namespaceLock.Unlock()
@@ -356,10 +150,13 @@ func (r *route) deleteRoute(route *v1.Route) error {
 	host := getHost(*route)
 	err := r.routerClient.Routes(route.Namespace).Delete(context.TODO(), route.ObjectMeta.Name, metav1.DeleteOptions{GracePeriodSeconds: &immediate})
 	if err != nil {
-		return fmt.Errorf("error deleting route %s/%s: %s", route.ObjectMeta.Namespace, route.ObjectMeta.Name, err)
+		return errors.Wrapf(err, "error deleting route %s/%s for the host %s",
+			route.ObjectMeta.Name,
+			route.ObjectMeta.Namespace,
+			host)
 	}
 
-	IORLog.Infof("Deleted route %s/%s (gateway hostname: %s)", route.ObjectMeta.Namespace, route.ObjectMeta.Name, host)
+	IORLog.Infof("route %s/%s deleted for the host %s", route.ObjectMeta.Name, route.ObjectMeta.Namespace, host)
 	return nil
 }
 
@@ -376,26 +173,23 @@ func buildRoute(metadata config.Meta, originalHost string, tls *networking.Serve
 		}
 	}
 
-	// Copy annotations
-	annotations := map[string]string{
+	// Copy annotationMap
+	annotationMap := map[string]string{
 		originalHostAnnotation: originalHost,
 	}
 	for keyName, keyValue := range metadata.Annotations {
 		if !strings.HasPrefix(keyName, "kubectl.kubernetes.io") && keyName != ShouldManageRouteAnnotation {
-			annotations[keyName] = keyValue
+			annotationMap[keyName] = keyValue
 		}
 	}
 
-	// Copy labels
-	labels := map[string]string{
-		generatedByLabel:            generatedByValue,
-		gatewayNamespaceLabel:       metadata.Namespace,
-		gatewayNameLabel:            metadata.Name,
-		gatewayResourceVersionLabel: metadata.ResourceVersion,
-	}
+	// Copy labelMap
+	labelMap := getDefaultRouteLabelMap(metadata.Name, metadata.Namespace)
+	labelMap[gatewayResourceVersionLabel] = metadata.ResourceVersion
+
 	for keyName, keyValue := range metadata.Labels {
 		if !strings.HasPrefix(keyName, maistraPrefix) {
-			labels[keyName] = keyValue
+			labelMap[keyName] = keyValue
 		}
 	}
 
@@ -403,8 +197,8 @@ func buildRoute(metadata config.Meta, originalHost string, tls *networking.Serve
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        getRouteName(metadata.Namespace, metadata.Name, originalHost),
 			Namespace:   serviceNamespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Labels:      labelMap,
+			Annotations: annotationMap,
 		},
 		Spec: v1.RouteSpec{
 			Host: actualHost,
@@ -427,19 +221,22 @@ func (r *route) createRoute(
 	metadata config.Meta,
 	originalHost string,
 	tls *networking.ServerTLSSettings,
-	serviceNamespace string, serviceName string,
+	serviceNamespace, serviceName string,
 ) (*v1.Route, error) {
-	IORLog.Debugf("Creating route for hostname %s", originalHost)
+	IORLog.Debugf("creating route for hostname %s", originalHost)
 
 	nr, err := r.
 		routerClient.
 		Routes(serviceNamespace).
 		Create(context.TODO(), buildRoute(metadata, originalHost, tls, serviceNamespace, serviceName), metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error creating a route for the host %s (gateway: %s/%s): %s", originalHost, metadata.Namespace, metadata.Name, err)
+		return nil, errors.Wrapf(err, "error creating a route for the host %s from gateway: %s/%s",
+			originalHost,
+			metadata.Namespace,
+			metadata.Name)
 	}
 
-	IORLog.Infof("Created route %s/%s for hostname %s (gateway: %s/%s)",
+	IORLog.Infof("route %s/%s created for hostname %s from gateway %s/%s",
 		nr.ObjectMeta.Namespace, nr.ObjectMeta.Name,
 		nr.Spec.Host,
 		metadata.Namespace, metadata.Name)
@@ -453,22 +250,33 @@ func (r *route) updateRoute(
 	tls *networking.ServerTLSSettings,
 	serviceNamespace string, serviceName string,
 ) (*v1.Route, error) {
-	IORLog.Debugf("Updating route for hostname %s", originalHost)
+	IORLog.Debugf("updating route for hostname %s", originalHost)
 
 	nr, err := r.
 		routerClient.
 		Routes(serviceNamespace).
 		Update(context.TODO(), buildRoute(metadata, originalHost, tls, serviceNamespace, serviceName), metav1.UpdateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error updating a route for the host %s (gateway: %s/%s): %s", originalHost, metadata.Namespace, metadata.Name, err)
+		return nil, errors.Wrapf(err, "error updating a route for the host %s from gateway: %s/%s",
+			originalHost,
+			metadata.Namespace,
+			metadata.Name)
 	}
 
-	IORLog.Infof("Updated route %s/%s for hostname %s (gateway: %s/%s)",
+	IORLog.Infof("route %s/%s updated for hostname %s from gateway %s/%s",
 		nr.ObjectMeta.Namespace, nr.ObjectMeta.Name,
 		nr.Spec.Host,
 		metadata.Namespace, metadata.Name)
 
 	return nr, nil
+}
+
+func (r *route) findRoutes(metadata config.Meta) (*v1.RouteList, error) {
+	defaultLabelSet := getDefaultRouteLabelMap(metadata.Name, metadata.Namespace)
+
+	labels := labels.SelectorFromSet(defaultLabelSet)
+
+	return r.routerClient.Routes(metadata.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.String()})
 }
 
 // findService tries to find a service that matches with the given gateway selector
@@ -482,32 +290,37 @@ func (r *route) findService(gateway *networking.Gateway) (string, string, error)
 
 	for _, ns := range namespaces {
 		// Get the list of pods that match the gateway selector
-		podList, err := r.kubeClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: gwSelector.String()})
+		pods, err := r.kubeClient.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: gwSelector.String()})
 		if err != nil {
-			return "", "", fmt.Errorf("could not get the list of pods in namespace %s: %v", ns, err)
+			return "", "", errors.Wrapf(err, "could not get the list of pods with labels %s", gwSelector.String())
 		}
+
+		IORLog.Debugf("found %d pod(s) under %s namespace with %s gateway selector", len(pods.Items), ns, gwSelector)
 
 		// Get the list of services in this namespace
-		svcList, err := r.kubeClient.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
+		services, err := r.kubeClient.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			return "", "", fmt.Errorf("could not get the list of services in namespace %s: %v", ns, err)
+			return "", "", errors.Wrapf(err, "could not get all the services in namespace %s", ns)
 		}
 
-		// Look for a service whose selector matches the pod labels
-		for _, pod := range podList.Items {
-			podLabels := labels.Set(pod.ObjectMeta.Labels)
+		IORLog.Debugf("found %d service(s) under %s namespace", len(services.Items), ns)
 
-			for _, svc := range svcList.Items {
-				svcSelector := labels.SelectorFromSet(svc.Spec.Selector)
+		for _, pod := range pods.Items {
+			podLabels := labels.Set(pod.ObjectMeta.Labels)
+			// Look for a service whose selector matches the pod labels
+			for _, service := range services.Items {
+				svcSelector := labels.SelectorFromSet(service.Spec.Selector)
+
+				IORLog.Debugf("matching service selector %s against %s")
 				if svcSelector.Matches(podLabels) {
-					return ns, svc.Name, nil
+					return pod.Namespace, service.Name, nil
 				}
+
 			}
 		}
 	}
 
-	return "", "", fmt.Errorf("could not find a service that matches the gateway selector `%s'. Namespaces where we looked at: %v",
-		gwSelector.String(), namespaces)
+	return "", "", fmt.Errorf("could not find a service that matches the gateway selector '%s'", gwSelector.String())
 }
 
 func getRouteName(namespace, name, host string) string {
@@ -555,34 +368,127 @@ func hostHash(name string) string {
 	return hex.EncodeToString(hash[:8])
 }
 
-func (r *route) processEvent(old, curr config.Config, event model.Event) {
-	_, ok := curr.Spec.(*networking.Gateway)
+func (r *route) reconcileGateway(config *config.Config, routes *v1.RouteList) error {
+	gateway, ok := config.Spec.(*networking.Gateway)
 
 	if !ok {
-		IORLog.Errorf("could not decode object as Gateway. Object = %v", curr)
-		return
+		return fmt.Errorf("could not decode spec as Gateway from %v", config)
 	}
 
-	if IORLog.GetOutputLevel() >= log.DebugLevel {
-		debugMessage := fmt.Sprintf("Event %v arrived:", event)
-		if event == model.EventUpdate {
-			debugMessage += fmt.Sprintf("\tOld object: %v", old)
+	var serviceNamespace string
+	var serviceName string
+	var err error
+
+	serviceNamespace, serviceName, err = r.findService(gateway)
+
+	if err != nil {
+		return errors.Wrapf(err, "gateway %s/%s does not specify a valid service", config.Namespace, config.Name)
+	}
+
+	routeMap := make(map[string]v1.Route)
+
+	for _, v := range routes.Items {
+		routeMap[v.Name] = v
+	}
+
+	var result *multierror.Error
+
+	for _, server := range gateway.Servers {
+		for _, host := range server.Hosts {
+			var route *v1.Route
+			var err error
+
+			name := getRouteName(config.Namespace, config.Name, host)
+
+			_, found := routeMap[name]
+
+			if found {
+				route, err = r.updateRoute(config.Meta, host, server.Tls, serviceNamespace, serviceName)
+			} else {
+				route, err = r.createRoute(config.Meta, host, server.Tls, serviceNamespace, serviceName)
+			}
+
+			if err != nil {
+				result = multierror.Append(result, err)
+			} else {
+				delete(routeMap, route.Name)
+			}
 		}
-		debugMessage += fmt.Sprintf("\tNew object: %v", curr)
+	}
+
+	for k, v := range routeMap {
+		IORLog.Debugf("clean up route %s for host %s", k, getHost(v))
+		if err := r.deleteRoute(&v); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+func (r *route) processEvent(old, curr *config.Config, event model.Event) error {
+	if IORLog.GetOutputLevel() >= log.DebugLevel {
+		debugMessage := fmt.Sprintf("event %v arrived:", event)
+		if event == model.EventUpdate {
+			debugMessage += fmt.Sprintf("\told object: %v", old)
+		}
+		debugMessage += fmt.Sprintf("\tnew object: %v", curr)
+
 		IORLog.Debug(debugMessage)
 	}
 
-	if err := r.handleEvent(event, curr); err != nil {
-		IORLog.Errora(err)
-		if r.errorChannel != nil {
-			r.errorChannel <- err
+	var (
+		err       error
+		isManaged bool
+	)
+
+	isManaged, err = isManagedByIOR(*curr)
+
+	if err != nil {
+		return err
+	}
+
+	if !isManaged {
+		IORLog.Debugf("skipped processing routes for gateway %s/%s, as it is annotated by user", curr.Name, curr.Namespace)
+		return nil
+	}
+
+	config := r.store.Get(collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(), curr.Name, curr.Namespace)
+
+	// Stop early
+	if config != nil && curr.ResourceVersion < config.ResourceVersion {
+		return nil
+	}
+
+	var routes *v1.RouteList
+
+	routes, err = r.findRoutes(curr.Meta)
+
+	if err != nil {
+		return errors.Wrapf(err, "unable to find routes matching gateway %s/%s", curr.Name, curr.Namespace)
+	}
+
+	if config != nil {
+		return r.reconcileGateway(config, routes)
+	}
+
+	var result *multierror.Error
+
+	for _, route := range routes.Items {
+		if err := r.deleteRoute(&route); err != nil {
+			result = multierror.Append(result, err)
 		}
 	}
+
+	return result.ErrorOrNil()
 }
 
 func (r *route) Run(stop <-chan struct{}) {
 	var aliveLock sync.Mutex
 	alive := true
+
+	IORLog.Debugf("Registering IOR into SMMR broadcast")
+	r.mrc.Register(r, "ior")
 
 	go func(stop <-chan struct{}) {
 		<-stop
@@ -592,16 +498,24 @@ func (r *route) Run(stop <-chan struct{}) {
 		IORLog.Info("This pod is no longer a leader. IOR stopped responding")
 	}(stop)
 
-	IORLog.Debugf("Registering IOR into SMMR broadcast")
-	r.mrc.Register(r, "ior")
-
 	IORLog.Debugf("Registering IOR into Gateway broadcast")
 	kind := collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
 	r.store.RegisterEventHandler(kind, func(old, curr config.Config, evt model.Event) {
 		aliveLock.Lock()
 		defer aliveLock.Unlock()
 		if alive {
-			r.processEvent(old, curr, evt)
+			err := r.processEvent(&old, &curr, evt)
+			if err != nil {
+				IORLog.Errorf("failed to process gateway %s/%s event %s: %s", curr.Name, curr.Namespace, evt.String(), err)
+			}
 		}
 	})
+}
+
+func getDefaultRouteLabelMap(name, namespace string) map[string]string {
+	return map[string]string{
+		generatedByLabel:      generatedByValue,
+		gatewayNamespaceLabel: namespace,
+		gatewayNameLabel:      name,
+	}
 }


### PR DESCRIPTION
Signed-off-by: Yann Liu <yannliu@redhat.com>

The IOR will use `crdclient.Client`, which implements a `model.ConfigStoreCache` interface. It will use the underlying `Gateway` kind informer to trigger events on `Gateway`. IOR will only response to these events. When IOR attaches the handler, the informer will trigger `ADD` to let IOR catch up the state. When setting a new namespace, the informer will also trigger `DELETE` on the removed namespace and `ADD` on the new namespace.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
