### PR TITLE
OSSM-1093 Shorten exported/imported resource name (cherry-pick)

### DIFF
--- a/pilot/pkg/serviceregistry/federation/routing.go
+++ b/pilot/pkg/serviceregistry/federation/routing.go
@@ -31,10 +31,13 @@ import (
 
 // ensure our config gets ignored if the user wants to change routing for
 // exported services
-var armageddonTime = time.Unix(1<<62-1, 0)
+var (
+	armageddonTime     = time.Unix(1<<62-1, 0)
+	prefixResourceName = "fed-imp"
+)
 
 func createResourceName(mesh cluster.ID, source federationmodel.ServiceKey) string {
-	return fmt.Sprintf("federation-imports-%s-%s-%s", mesh, source.Name, source.Namespace)
+	return common.FormatResourceName(prefixResourceName, mesh.String(), source.Namespace, source.Name)
 }
 
 func (c *Controller) deleteRoutingResources(remote federationmodel.ServiceKey) error {

--- a/pkg/servicemesh/federation/common/util.go
+++ b/pkg/servicemesh/federation/common/util.go
@@ -15,6 +15,8 @@
 package common
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/mitchellh/hashstructure/v2"
@@ -22,9 +24,12 @@ import (
 	kubelabels "k8s.io/apimachinery/pkg/labels"
 	v1 "maistra.io/api/federation/v1"
 
+	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
 )
+
+const hashLength = 8
 
 func ContainsPort(ports []corev1.EndpointPort, expectedPort int32) bool {
 	for _, p := range ports {
@@ -88,4 +93,21 @@ func RemoteChecksum(remote v1.ServiceMeshPeerRemote) uint64 {
 		return 0
 	}
 	return checksum
+}
+
+// hashResourceName applies a sha256 on the host and truncates it to the first n char
+func hashResourceName(name string, n int) string {
+	hash := sha256.Sum256([]byte(name))
+	return (hex.EncodeToString(hash[:]))[:n]
+}
+
+// FormatResourceName returns the imported/exported resource name
+// checking if the length of the formatted name < DNS1123LabelMaxLength
+// If not returns the truncated formatted name suffixed by its hash part
+func FormatResourceName(prefix, meshName, namespace, serviceName string) string {
+	resourceName := fmt.Sprintf("%s-%s-%s-%s", prefix, serviceName, namespace, meshName)
+	if len(resourceName) > labels.DNS1123LabelMaxLength {
+		resourceName = resourceName[:labels.DNS1123LabelMaxLength-hashLength] + hashResourceName(resourceName, hashLength)
+	}
+	return resourceName
 }

--- a/pkg/servicemesh/federation/common/util_test.go
+++ b/pkg/servicemesh/federation/common/util_test.go
@@ -1,0 +1,88 @@
+// Copyright Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/config/labels"
+	federationmodel "istio.io/istio/pkg/servicemesh/federation/model"
+)
+
+func TestFormatResourceName(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		prefix               string
+		mesh                 cluster.ID
+		source               federationmodel.ServiceKey
+		expectedResourceName string
+	}{
+		{
+			name:   "standard mesh name + standard namespace + standard service name",
+			prefix: "fed-exp",
+			mesh:   "mesh",
+			source: federationmodel.ServiceKey{
+				Namespace: "bookinfo",
+				Name:      "productpage",
+			},
+			expectedResourceName: "fed-exp-productpage-bookinfo-mesh",
+		},
+		{
+			name:   "long mesh name",
+			prefix: "fed-imp",
+			mesh:   "mesh-production",
+			source: federationmodel.ServiceKey{
+				Namespace: "bookinfo",
+				Name:      "productpage",
+			},
+			expectedResourceName: "fed-imp-productpage-bookinfo-mesh-production",
+		},
+		{
+			name:   "long namespace",
+			prefix: "fed-exp",
+			mesh:   "mesh",
+			source: federationmodel.ServiceKey{
+				Namespace: "bookinfo-production",
+				Name:      "productpage",
+			},
+			expectedResourceName: "fed-exp-productpage-bookinfo-production-mesh",
+		},
+		{
+			name:   "long mesh name + long namespace + long service name",
+			prefix: "fed-imp",
+			mesh:   "test-remote",
+			source: federationmodel.ServiceKey{
+				Namespace: "bookinfo-production",
+				Name:      "productpage-rest-private",
+			},
+			expectedResourceName: "fed-imp-productpage-rest-private-bookinfo-production-te160043b8",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceName := FormatResourceName(tc.prefix, tc.mesh.String(),
+				tc.source.Namespace, tc.source.Name)
+			if !labels.IsDNS1123Label(resourceName) {
+				t.Fatalf("Not a valid RFC 1123 label. Current length of %s: %d (should be <= %d)",
+					resourceName, len(resourceName), labels.DNS1123LabelMaxLength)
+			}
+			if resourceName != tc.expectedResourceName {
+				t.Fatalf("%s not equals to the expected resource name %s",
+					resourceName, tc.expectedResourceName)
+			}
+		})
+	}
+}

--- a/pkg/servicemesh/federation/server/routing.go
+++ b/pkg/servicemesh/federation/server/routing.go
@@ -44,11 +44,12 @@ var (
 	Schemas collection.Schemas
 	// ensure our config gets ignored if the user wants to change routing for
 	// exported services
-	armageddonTime = time.Unix(1<<62-1, 0)
+	armageddonTime     = time.Unix(1<<62-1, 0)
+	prefixResourceName = "fed-exp"
 )
 
 func createResourceName(mesh string, source federationmodel.ServiceKey) string {
-	return fmt.Sprintf("federation-exports-%s-%s-%s", mesh, source.Name, source.Namespace)
+	return common.FormatResourceName(prefixResourceName, mesh, source.Namespace, source.Name)
 }
 
 func (s *meshServer) deleteExportResources(source federationmodel.ServiceKey, target *federationmodel.ServiceMessage) error {


### PR DESCRIPTION
**Please provide a description of this PR:**

This will fix the creation of exported resource with services/namespaces long names

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
