### PR TITLE
Add delete configmap privilege to fix distribution report cleanup

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1505,6 +1505,11 @@ rules:
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 
+# For status controller, so it can delete the distribution report configmap
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["delete"]
+
 # For MeshFederation support
 - apiGroups: ["federation.maistra.io"]
   resources: ["servicemeshpeers", "servicemeshpeers/status", "exportedservicesets", "exportedservicesets/status", "importedservicesets", "importedservicesets/status"]

--- a/manifests/charts/istio-control/istio-discovery/templates/role.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/role.yaml
@@ -19,6 +19,11 @@ rules:
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 
+# For status controller, so it can delete the distribution report configmap
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["delete"]
+
 # For MeshFederation support
 - apiGroups: ["federation.maistra.io"]
   resources: ["servicemeshpeers", "servicemeshpeers/status", "exportedservicesets", "exportedservicesets/status", "importedservicesets", "importedservicesets/status"]

--- a/manifests/charts/istiod-remote/templates/role.yaml
+++ b/manifests/charts/istiod-remote/templates/role.yaml
@@ -20,6 +20,11 @@ rules:
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 
+# For status controller, so it can delete the distribution report configmap
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["delete"]
+
 # For MeshFederation support
 - apiGroups: ["federation.maistra.io"]
   resources: ["servicemeshpeers", "servicemeshpeers/status", "exportedservicesets", "exportedservicesets/status", "importedservicesets", "importedservicesets/status"]


### PR DESCRIPTION
This fixes the following error during istiod shutdown when PILOT_ENABLE_STATUS=true:

error   status  failed to properly clean up distribution report: configmaps "istiod-649887579d-rck66-distribution" is forbidden: User "system:serviceaccount:istio-system:istiod" cannot delete resource "configmaps" in API group "" in the namespace "istio-system"