### PR TITLE
OSSM-2179: changes the restriction about the number of layers in a WASM plugin.

### DIFF
--- a/pkg/wasm/imagefetcher.go
+++ b/pkg/wasm/imagefetcher.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -169,12 +170,12 @@ func extractDockerImage(img v1.Image) ([]byte, error) {
 		return nil, fmt.Errorf("could not fetch layers: %v", err)
 	}
 
-	// The image must be single-layered.
-	if len(layers) != 1 {
-		return nil, fmt.Errorf("number of layers must be 1 but got %d", len(layers))
+	// The image must have at least one layer.
+	if len(layers) == 0 {
+		return nil, errors.New("number of layers must be greater than zero")
 	}
 
-	layer := layers[0]
+	layer := layers[len(layers)-1]
 	mt, err := layer.MediaType()
 	if err != nil {
 		return nil, fmt.Errorf("could not get media type: %v", err)
@@ -207,12 +208,12 @@ func extractOCIStandardImage(img v1.Image) ([]byte, error) {
 		return nil, fmt.Errorf("could not fetch layers: %v", err)
 	}
 
-	// The image must be single-layered.
-	if len(layers) != 1 {
-		return nil, fmt.Errorf("number of layers must be 1 but got %d", len(layers))
+	// The image must have at least one layer.
+	if len(layers) == 0 {
+		return nil, fmt.Errorf("number of layers must be greater than zero")
 	}
 
-	layer := layers[0]
+	layer := layers[len(layers)-1]
 	mt, err := layer.MediaType()
 	if err != nil {
 		return nil, fmt.Errorf("could not get media type: %v", err)

--- a/pkg/wasm/imagefetcher_test.go
+++ b/pkg/wasm/imagefetcher_test.go
@@ -268,43 +268,55 @@ func TestImageFetcher_Fetch(t *testing.T) {
 }
 
 func TestExtractDockerImage(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
+	t.Run("no layers", func(t *testing.T) {
+		_, err := extractDockerImage(empty.Image)
+		if err == nil || err.Error() != "number of layers must be greater than zero" {
+			t.Fatal("extractDockerImage should fail due to empty image")
+		}
+	})
+
+	t.Run("valid layers", func(t *testing.T) {
+		previousLayer, err := newMockLayer(types.DockerLayer, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		exp := "this is wasm binary"
-		l, err := newMockLayer(types.DockerLayer, map[string][]byte{
+		lastLayer, err := newMockLayer(types.DockerLayer, map[string][]byte{
 			"plugin.wasm": []byte(exp),
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		img, err := mutate.Append(empty.Image, mutate.Addendum{Layer: l})
-		if err != nil {
-			t.Fatal(err)
-		}
-		actual, err := extractDockerImage(img)
-		if err != nil {
-			t.Fatalf("extractDockerImage failed: %v", err)
+
+		tCases := map[string]int{
+			"one layer":           0,
+			"more than one layer": 1,
 		}
 
-		if string(actual) != exp {
-			t.Fatalf("got %s, but want %s", string(actual), exp)
-		}
-	})
+		for name, numberOfPreviousLayers := range tCases {
+			t.Run(name, func(t *testing.T) {
+				img := empty.Image
+				for i := 0; i < numberOfPreviousLayers; i++ {
+					img, err = mutate.Append(img, mutate.Addendum{Layer: previousLayer})
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
 
-	t.Run("multiple layers", func(t *testing.T) {
-		l, err := newMockLayer(types.DockerLayer, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		img := empty.Image
-		for i := 0; i < 2; i++ {
-			img, err = mutate.Append(img, mutate.Addendum{Layer: l})
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		_, err = extractDockerImage(img)
-		if err == nil || !strings.Contains(err.Error(), "number of layers must be") {
-			t.Fatal("extractDockerImage should fail due to invalid number of layers")
+				img, err = mutate.Append(img, mutate.Addendum{Layer: lastLayer})
+				if err != nil {
+					t.Fatal(err)
+				}
+				actual, err := extractDockerImage(img)
+				if err != nil {
+					t.Fatalf("extractDockerImage failed: %v", err)
+				}
+
+				if string(actual) != exp {
+					t.Fatalf("got %s, but want %s", string(actual), exp)
+				}
+			})
 		}
 	})
 
@@ -325,43 +337,55 @@ func TestExtractDockerImage(t *testing.T) {
 }
 
 func TestExtractOCIStandardImage(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
+	t.Run("no layers", func(t *testing.T) {
+		_, err := extractOCIStandardImage(empty.Image)
+		if err == nil || err.Error() != "number of layers must be greater than zero" {
+			t.Fatal("extractDockerImage should fail due to empty image")
+		}
+	})
+
+	t.Run("valid layers", func(t *testing.T) {
+		previousLayer, err := newMockLayer(types.DockerLayer, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		exp := "this is wasm binary"
-		l, err := newMockLayer(types.OCILayer, map[string][]byte{
+		lastLayer, err := newMockLayer(types.OCILayer, map[string][]byte{
 			"plugin.wasm": []byte(exp),
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		img, err := mutate.Append(empty.Image, mutate.Addendum{Layer: l})
-		if err != nil {
-			t.Fatal(err)
-		}
-		actual, err := extractOCIStandardImage(img)
-		if err != nil {
-			t.Fatalf("extractOCIStandardImage failed: %v", err)
+
+		tCases := map[string]int{
+			"one layer":           0,
+			"more than one layer": 1,
 		}
 
-		if string(actual) != exp {
-			t.Fatalf("got %s, but want %s", string(actual), exp)
-		}
-	})
+		for name, numberOfPreviousLayers := range tCases {
+			t.Run(name, func(t *testing.T) {
+				img := empty.Image
+				for i := 0; i < numberOfPreviousLayers; i++ {
+					img, err = mutate.Append(img, mutate.Addendum{Layer: previousLayer})
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
 
-	t.Run("multiple layers", func(t *testing.T) {
-		l, err := newMockLayer(types.OCILayer, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		img := empty.Image
-		for i := 0; i < 2; i++ {
-			img, err = mutate.Append(img, mutate.Addendum{Layer: l})
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		_, err = extractOCIStandardImage(img)
-		if err == nil || !strings.Contains(err.Error(), "number of layers must be") {
-			t.Fatal("extractOCIStandardImage should fail due to invalid number of layers")
+				img, err = mutate.Append(img, mutate.Addendum{Layer: lastLayer})
+				if err != nil {
+					t.Fatal(err)
+				}
+				actual, err := extractOCIStandardImage(img)
+				if err != nil {
+					t.Fatalf("extractOCIStandardImage failed: %v", err)
+				}
+
+				if string(actual) != exp {
+					t.Fatalf("got %s, but want %s", string(actual), exp)
+				}
+			})
 		}
 	})
 

--- a/releasenotes/notes/wasm-multilayer.yaml
+++ b/releasenotes/notes/wasm-multilayer.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: extensibility
+issue: []
+releaseNotes:
+  - |
+    **Improved** WasmPlugin images (docker and OCI standard image) to support more than one layer as per spec changes.
+    See https://github.com/solo-io/wasm/pull/293


### PR DESCRIPTION
Manual cherry-pick of upstream commit 9a2359d8f08be06ee5f854b30e44da3523992e41

The attempt to backport it to upstream 1.14 branch was not successful: https://github.com/istio/istio/pull/41550