### PR TITLE
OSSM-1698 Restrict istio-cni-node DaemonSet

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
               - key: maistra.io/exclude-cni
                 operator: NotIn
                 values:
-                - true
+                - "true"
       tolerations:
         # Make sure istio-cni-node gets scheduled on all nodes.
         - effect: NoSchedule

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      # Allows for exluding instio-cni from being scheduled on specified nodes
+      # Allows for excluding instio-cni from being scheduled on specified nodes
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+        maistra.io/exclude-cni: "false"
       tolerations:
         # Make sure istio-cni-node gets scheduled on all nodes.
         - effect: NoSchedule

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -38,7 +38,16 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-        maistra.io/exclude-cni: "false"
+      # Allows for exluding instio-cni from being scheduled on specified nodes
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: maistra.io/exclude-cni
+                operator: NotIn
+                values:
+                - true
       tolerations:
         # Make sure istio-cni-node gets scheduled on all nodes.
         - effect: NoSchedule


### PR DESCRIPTION
**Please provide a description of this PR:**

istio-cni by default is installed on all nodes. This PR adds the ability to exclude istio-cni from being installed on specified nodes by adding the `maistra.io/exclude-cni` label to that node and setting it to `true`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
