### PR TITLE
fix(discovery): invalidates discovery for servicemesh tests

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -230,6 +230,9 @@ type CLIClient interface {
 
 	// SetPortManager overrides the default port manager to provision local ports
 	SetPortManager(PortManager)
+
+	// InvalidateDiscovery invalidates the discovery client
+	InvalidateDiscovery()
 }
 
 type PortManager func() (uint16, error)
@@ -1173,11 +1176,15 @@ func (c *client) applyYAMLFile(namespace string, dryRun bool, file string) error
 			log.Warnf("Failed to read %s: %v", file, err)
 		}
 		if len(yml.SplitYamlByKind(string(f))[gvk.CustomResourceDefinition.Kind]) > 0 {
-			c.discoveryClient.Invalidate()
-			c.mapper.Reset()
+			c.InvalidateDiscovery()
 		}
 	}
 	return nil
+}
+
+func (c *client) InvalidateDiscovery() {
+	c.discoveryClient.Invalidate()
+	c.mapper.Reset()
 }
 
 func (c *client) DeleteYAMLFiles(namespace string, yamlFiles ...string) (err error) {

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -235,6 +235,10 @@ func (c MockClient) ApplyYAMLFilesDryRun(string, ...string) error {
 	panic("not implemented by mock")
 }
 
+func (c MockClient) InvalidateDiscovery() {
+	panic("not implemented by mock")
+}
+
 // CreatePerRPCCredentials -- when implemented -- mocks per-RPC credentials (bearer token)
 func (c MockClient) CreatePerRPCCredentials(ctx context.Context, tokenNamespace, tokenServiceAccount string, audiences []string,
 	expirationSeconds int64,

--- a/tests/integration/servicemesh/main_test.go
+++ b/tests/integration/servicemesh/main_test.go
@@ -25,16 +25,13 @@ import (
 	"istio.io/istio/tests/integration/servicemesh/maistra"
 )
 
-var i istio.Instance
-
 func TestMain(m *testing.M) {
 	// do not change order of setup functions
 	// nolint: staticcheck
 	framework.
 		NewSuite(m).
-		RequireMaxClusters(1).
 		Setup(maistra.ApplyServiceMeshCRDs).
-		Setup(istio.Setup(&i, nil)).
+		Setup(istio.Setup(nil, nil)).
 		Setup(maistra.Install).
 		Run()
 }

--- a/tests/integration/servicemesh/maistra/maistra.go
+++ b/tests/integration/servicemesh/maistra/maistra.go
@@ -47,6 +47,7 @@ func ApplyServiceMeshCRDs(ctx resource.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("cannot read maistra CRD YAMLs: %s", err)
 	}
+
 	for _, c := range ctx.Clusters().Kube().Primaries() {
 		for _, crd := range crds {
 			// we need to manually Create() the CRD because Apply() wants to write its content into an annotation which fails because of size limitations
@@ -65,6 +66,8 @@ func ApplyServiceMeshCRDs(ctx resource.Context) (err error) {
 				}
 			}
 		}
+
+		c.InvalidateDiscovery()
 	}
 	return err
 }


### PR DESCRIPTION
Based on the discussion with @jwendell we concluded to ship this as a separate PR so that we can easily rebase it later when [upstream change](https://github.com/istio/istio/pull/42006) will be incorporated.