### PR TITLE
[cni] MAISTRA-2291 Support deployment of multiple plugin versions in Istio CNI

### DIFF
--- a/cni/pkg/cmd/root.go
+++ b/cni/pkg/cmd/root.go
@@ -145,6 +145,7 @@ func init() {
 	registerBooleanParameter(constants.UpdateCNIBinaries, true, "Whether to refresh existing binaries when installing CNI")
 	registerStringArrayParameter(constants.SkipCNIBinaries, []string{},
 		"Binaries that should not be installed. Currently Istio only installs one binary `istio-cni`")
+	registerStringParameter(constants.CNIBinariesPrefix, "", "The filename prefix to add to each binary when copying")
 	registerIntegerParameter(constants.MonitoringPort, 15014, "HTTP port to serve prometheus metrics")
 	registerStringParameter(constants.LogUDSAddress, "/var/run/istio-cni/log.sock", "The UDS server address which CNI plugin will copy log ouptut to")
 
@@ -232,6 +233,7 @@ func constructConfig() (*config.Config, error) {
 
 		CNIBinSourceDir:   constants.CNIBinDir,
 		CNIBinTargetDirs:  []string{constants.HostCNIBinDir, constants.SecondaryBinDir},
+		CNIBinariesPrefix: viper.GetString(constants.CNIBinariesPrefix),
 		UpdateCNIBinaries: viper.GetBool(constants.UpdateCNIBinaries),
 		SkipCNIBinaries:   viper.GetStringSlice(constants.SkipCNIBinaries),
 		MonitoringPort:    viper.GetInt(constants.MonitoringPort),

--- a/cni/pkg/config/config.go
+++ b/cni/pkg/config/config.go
@@ -68,6 +68,8 @@ type InstallConfig struct {
 	CNIBinSourceDir string
 	// Directories into which to copy the CNI binaries
 	CNIBinTargetDirs []string
+	// The prefix to add to the name of each CNI binary
+	CNIBinariesPrefix string
 	// Whether to override existing CNI binaries
 	UpdateCNIBinaries bool
 

--- a/cni/pkg/constants/constants.go
+++ b/cni/pkg/constants/constants.go
@@ -32,6 +32,7 @@ const (
 	SkipTLSVerify        = "skip-tls-verify"
 	SkipCNIBinaries      = "skip-cni-binaries"
 	UpdateCNIBinaries    = "update-cni-binaries"
+	CNIBinariesPrefix    = "cni-binaries-prefix"
 	MonitoringPort       = "monitoring-port"
 	LogUDSAddress        = "log-uds-address"
 

--- a/cni/pkg/install/binaries.go
+++ b/cni/pkg/install/binaries.go
@@ -21,7 +21,7 @@ import (
 	"istio.io/istio/pkg/file"
 )
 
-func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipBinaries []string) error {
+func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipBinaries []string, binariesPrefix string) error {
 	skipBinariesSet := arrToSet(skipBinaries)
 
 	for _, targetDir := range targetDirs {
@@ -42,18 +42,19 @@ func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipB
 				continue
 			}
 
-			targetFilepath := filepath.Join(targetDir, filename)
+			targetFilename := binariesPrefix + filename
+			targetFilepath := filepath.Join(targetDir, targetFilename)
 			if _, err := os.Stat(targetFilepath); err == nil && !updateBinaries {
 				installLog.Infof("%s is already here and UPDATE_CNI_BINARIES isn't true, skipping", targetFilepath)
 				continue
 			}
 
 			srcFilepath := filepath.Join(srcDir, filename)
-			err := file.AtomicCopy(srcFilepath, targetDir, filename)
+			err := file.AtomicCopy(srcFilepath, targetDir, targetFilename)
 			if err != nil {
 				return err
 			}
-			installLog.Infof("Copied %s to %s.", filename, targetDir)
+			installLog.Infof("Copied %s to %s.", filename, targetFilepath)
 		}
 	}
 

--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -15,7 +15,6 @@
 package install
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,17 +63,9 @@ func TestCopyBinaries(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
+	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			srcDir, err := os.MkdirTemp("", fmt.Sprintf("test-case-%d-src-", i))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				if err := os.RemoveAll(srcDir); err != nil {
-					t.Fatal(err)
-				}
-			}()
+			srcDir := t.TempDir()
 			for filename, contents := range c.srcFiles {
 				err := os.WriteFile(filepath.Join(srcDir, filename), []byte(contents), os.ModePerm)
 				if err != nil {
@@ -82,15 +73,7 @@ func TestCopyBinaries(t *testing.T) {
 				}
 			}
 
-			targetDir, err := os.MkdirTemp("", fmt.Sprintf("test-case-%d-target-", i))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				if err := os.RemoveAll(targetDir); err != nil {
-					t.Fatal(err)
-				}
-			}()
+			targetDir := t.TempDir()
 			for filename, contents := range c.existingFiles {
 				err := os.WriteFile(filepath.Join(targetDir, filename), []byte(contents), os.ModePerm)
 				if err != nil {
@@ -98,7 +81,7 @@ func TestCopyBinaries(t *testing.T) {
 				}
 			}
 
-			err = copyBinaries(srcDir, []string{targetDir}, c.updateBinaries, c.skipBinaries, c.prefix)
+			err := copyBinaries(srcDir, []string{targetDir}, c.updateBinaries, c.skipBinaries, c.prefix)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -16,7 +16,6 @@ package install
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,7 +66,7 @@ func TestCopyBinaries(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			srcDir, err := ioutil.TempDir("", fmt.Sprintf("test-case-%d-src-", i))
+			srcDir, err := os.MkdirTemp("", fmt.Sprintf("test-case-%d-src-", i))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -77,13 +76,13 @@ func TestCopyBinaries(t *testing.T) {
 				}
 			}()
 			for filename, contents := range c.srcFiles {
-				err := ioutil.WriteFile(filepath.Join(srcDir, filename), []byte(contents), os.ModePerm)
+				err := os.WriteFile(filepath.Join(srcDir, filename), []byte(contents), os.ModePerm)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			targetDir, err := ioutil.TempDir("", fmt.Sprintf("test-case-%d-target-", i))
+			targetDir, err := os.MkdirTemp("", fmt.Sprintf("test-case-%d-target-", i))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -93,7 +92,7 @@ func TestCopyBinaries(t *testing.T) {
 				}
 			}()
 			for filename, contents := range c.existingFiles {
-				err := ioutil.WriteFile(filepath.Join(targetDir, filename), []byte(contents), os.ModePerm)
+				err := os.WriteFile(filepath.Join(targetDir, filename), []byte(contents), os.ModePerm)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -105,7 +104,7 @@ func TestCopyBinaries(t *testing.T) {
 			}
 
 			for filename, expectedContents := range c.expectedFiles {
-				contents, err := ioutil.ReadFile(filepath.Join(targetDir, filename))
+				contents, err := os.ReadFile(filepath.Join(targetDir, filename))
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install/cniconfig.go
@@ -180,7 +180,7 @@ func getCNIConfigFilepath(ctx context.Context, cfg pluginConfig) (string, error)
 		return filepath.Join(cfg.mountedCNINetDir, filename), nil
 	}
 
-	watcher, fileModified, errChan, err := util.CreateFileWatcher(cfg.mountedCNINetDir)
+	watcher, fileModified, errChan, err := util.CreateFileWatcher("", []string{cfg.mountedCNINetDir})
 	if err != nil {
 		return "", err
 	}

--- a/cni/pkg/install/install_test.go
+++ b/cni/pkg/install/install_test.go
@@ -37,6 +37,7 @@ func TestCheckInstall(t *testing.T) {
 		chainedCNIPlugin  bool
 		skipInstall       bool
 		existingConfFiles map[string]string // {srcFilename: targetFilename, ...}
+		cniBinariesPrefix string
 	}{
 		{
 			name:              "preempted config",
@@ -95,6 +96,12 @@ func TestCheckInstall(t *testing.T) {
 			cniConfigFilename: "istio-cni.conf",
 			existingConfFiles: map[string]string{"istio-cni.conf": "istio-cni.conf"},
 		},
+		{
+			name:              "custom binaries prefix",
+			cniConfigFilename: "istio-cni.conf",
+			cniBinariesPrefix: "prefix-",
+			existingConfFiles: map[string]string{"istio-cni-prefixed.conf": "istio-cni.conf"},
+		},
 	}
 
 	for _, c := range cases {
@@ -110,10 +117,11 @@ func TestCheckInstall(t *testing.T) {
 			}
 
 			cfg := &config.InstallConfig{
-				MountedCNINetDir: tempDir,
-				CNIConfName:      c.cniConfName,
-				ChainedCNIPlugin: c.chainedCNIPlugin,
-				CNIEnableInstall: !c.skipInstall,
+				MountedCNINetDir:  tempDir,
+				CNIConfName:       c.cniConfName,
+				ChainedCNIPlugin:  c.chainedCNIPlugin,
+				CNIEnableInstall:  !c.skipInstall,
+				CNIBinariesPrefix: c.cniBinariesPrefix,
 			}
 			err := checkInstall(cfg, filepath.Join(tempDir, c.cniConfigFilename))
 			if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {
@@ -299,6 +307,7 @@ func TestCleanup(t *testing.T) {
 		configFilename         string
 		existingConfigFilename string
 		expectedConfigFilename string
+		cniBinariesPrefix      string
 	}{
 		{
 			name:                   "chained CNI plugin",
@@ -311,6 +320,13 @@ func TestCleanup(t *testing.T) {
 			name:                   "standalone CNI plugin",
 			configFilename:         "istio-cni.conf",
 			existingConfigFilename: "istio-cni.conf",
+		},
+		{
+			name:                   "prefix",
+			cniBinariesPrefix:      "prefix-",
+			configFilename:         "list-cni-prefixed.conf",
+			existingConfigFilename: "list-with-istio.conflist",
+			expectedConfigFilename: "list-no-istio.conflist",
 		},
 	}
 
@@ -327,7 +343,8 @@ func TestCleanup(t *testing.T) {
 			}
 
 			// Create existing binary files
-			if err := os.WriteFile(filepath.Join(cniBinDir, "istio-cni"), []byte{1, 2, 3}, 0o755); err != nil {
+			filename := c.cniBinariesPrefix + "istio-cni"
+			if err := os.WriteFile(filepath.Join(cniBinDir, filename), []byte{1, 2, 3}, 0o755); err != nil {
 				t.Fatal(err)
 			}
 
@@ -338,9 +355,10 @@ func TestCleanup(t *testing.T) {
 			}
 
 			cfg := &config.InstallConfig{
-				MountedCNINetDir: cniNetDir,
-				ChainedCNIPlugin: c.chainedCNIPlugin,
-				CNIBinTargetDirs: []string{cniBinDir},
+				MountedCNINetDir:  cniNetDir,
+				ChainedCNIPlugin:  c.chainedCNIPlugin,
+				CNIBinariesPrefix: c.cniBinariesPrefix,
+				CNIBinTargetDirs:  []string{cniBinDir},
 			}
 
 			isReady := &atomic.Value{}

--- a/cni/pkg/install/kubeconfig.go
+++ b/cni/pkg/install/kubeconfig.go
@@ -120,6 +120,11 @@ func createKubeconfigFile(cfg *config.InstallConfig, saToken string) (kubeconfig
 		return "", err
 	}
 
+	// When using Multus, the net.d dir might not exist yet, so we must create it
+	if err := os.MkdirAll(cfg.MountedCNINetDir, os.FileMode(0o755)); err != nil {
+		return "", err
+	}
+
 	kubeconfigFilepath = filepath.Join(cfg.MountedCNINetDir, cfg.KubeconfigFilename)
 	installLog.Infof("write kubeconfig file %s with: \n%+v", kubeconfigFilepath, kcbbToPrint.String())
 	if err = file.AtomicWrite(kubeconfigFilepath, kcbb.Bytes(), os.FileMode(cfg.KubeconfigMode)); err != nil {

--- a/cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install/kubeconfig_test.go
@@ -45,6 +45,7 @@ func TestCreateKubeconfigFile(t *testing.T) {
 		saToken            string
 		kubeCAFilepath     string
 		skipTLSVerify      bool
+		cniNetDir          string
 	}{
 		{
 			name:            "k8s service host not set",
@@ -73,12 +74,25 @@ func TestCreateKubeconfigFile(t *testing.T) {
 			saToken:            saToken,
 			kubeCAFilepath:     kubeCAFilepath,
 		},
+		{
+			name:               "nonexistent net.d dir",
+			kubeconfigFilename: "istio-cni-kubeconfig",
+			kubeconfigMode:     constants.DefaultKubeconfigMode,
+			k8sServiceHost:     k8sServiceHost,
+			k8sServicePort:     k8sServicePort,
+			saToken:            saToken,
+			skipTLSVerify:      true,
+			cniNetDir:          filepath.Join(t.TempDir(), "nonexistent-dir"),
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			// Create temp directory for files
-			tempDir := t.TempDir()
+			tempDir := c.cniNetDir
+			// Create temp directory for files if not provided in test case
+			if tempDir == "" {
+				tempDir = t.TempDir()
+			}
 
 			cfg := &config.InstallConfig{
 				MountedCNINetDir:   tempDir,

--- a/cni/pkg/plugin/iptables_linux.go
+++ b/cni/pkg/plugin/iptables_linux.go
@@ -38,6 +38,7 @@ func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.NetworkNamespace, netns)
 	viper.Set(constants.EnvoyPort, rdrct.targetPort)
 	viper.Set(constants.ProxyUID, rdrct.noRedirectUID)
+	viper.Set(constants.ProxyGID, rdrct.noRedirectGID)
 	viper.Set(constants.InboundInterceptionMode, rdrct.redirectMode)
 	viper.Set(constants.ServiceCidr, rdrct.includeIPCidrs)
 	viper.Set(constants.LocalExcludePorts, rdrct.excludeInboundPorts)

--- a/cni/pkg/plugin/kubernetes.go
+++ b/cni/pkg/plugin/kubernetes.go
@@ -42,6 +42,8 @@ type PodInfo struct {
 	Annotations       map[string]string
 	ProxyEnvironments map[string]string
 	ProxyConfig       *meshconfig.ProxyConfig
+	ProxyUID          *int64
+	ProxyGID          *int64
 }
 
 // newK8sClient returns a Kubernetes client
@@ -99,6 +101,10 @@ func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (
 					}
 					break
 				}
+			}
+			if container.SecurityContext != nil {
+				pi.ProxyUID = container.SecurityContext.RunAsUser
+				pi.ProxyGID = container.SecurityContext.RunAsGroup
 			}
 			continue
 		}

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -33,6 +33,7 @@ const (
 	defaultProxyStatusPort       = "15020"
 	defaultRedirectToPort        = "15001"
 	defaultNoRedirectUID         = "1337"
+	defaultNoRedirectGID         = "1337"
 	defaultRedirectMode          = redirectModeREDIRECT
 	defaultRedirectIPCidr        = "*"
 	defaultRedirectExcludeIPCidr = ""
@@ -75,6 +76,7 @@ type Redirect struct {
 	targetPort           string
 	redirectMode         string
 	noRedirectUID        string
+	noRedirectGID        string
 	includeIPCidrs       string
 	excludeIPCidrs       string
 	excludeInboundPorts  string
@@ -214,6 +216,13 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
 			"redirectMode", isFound, valErr)
 	}
 	redir.noRedirectUID = defaultNoRedirectUID
+	if pi.ProxyUID != nil {
+		redir.noRedirectUID = fmt.Sprintf("%d", *pi.ProxyUID)
+	}
+	redir.noRedirectGID = defaultNoRedirectGID
+	if pi.ProxyGID != nil {
+		redir.noRedirectGID = fmt.Sprintf("%d", *pi.ProxyGID)
+	}
 	isFound, redir.includeIPCidrs, valErr = getAnnotationOrDefault("includeIPCidrs", pi.Annotations)
 	if valErr != nil {
 		return nil, fmt.Errorf("annotation value error for value %s; annotationFound = %t: %v",


### PR DESCRIPTION
Includes:

  * MAISTRA-2135 Add unit tests for our CNI binary-prefix work (#325)

  * MAISTRA-2137 Make network namespace setup executable name configurable (#273)

    To support the deployment of multiple CNI plugin versions, the name of the
    executable that is invoked to set up the network namespace must be configurable.

  * OSSM-1430: CNI: Watch for modified files with a prefix (#510)

    Because our CNI pod contains more than one container, and they write to
    the same directory, and they watch for changes on those directories,
    changes made by one container trigger the watch on the other, which will
    responde by copying the files to the directory, which will in turn
    trigger the watcher of the other container in an endless loop.

    This leads to high CPU usage on the node.

    This PR changes the logic to only monitor for files that have the
    desired prefix. Thus, for example, the 2.2 container will only react to
    changes to files whose names  start with "v2-2". This avoid this race
    condition and achieve the same end result.**Please provide a description of this PR:**
 
 * MAISTRA-2051 use correct UID/GID in istio-iptables
 * OSSM-2082 CNI installer now creates the net.d directory if necessary #638



