### PR TITLE
[proxy-uid] OSSM-2292: Run sidecars with dynamically-determined user IDs

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -275,6 +275,7 @@ refresh-goldens:
 		./pkg/kube/inject/... \
 		./pilot/pkg/security/authz/builder/... \
 		./cni/pkg/plugin/...
+	@REFRESH_GOLDEN=true go test ${GOBUILDFLAGS} ./istioctl/cmd/...
 
 update-golden: refresh-goldens
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -274,8 +274,8 @@ refresh-goldens:
 		./pkg/bootstrap/... \
 		./pkg/kube/inject/... \
 		./pilot/pkg/security/authz/builder/... \
-		./cni/pkg/plugin/...
-	@REFRESH_GOLDEN=true go test ${GOBUILDFLAGS} ./istioctl/cmd/...
+		./cni/pkg/plugin/... \
+		./istioctl/cmd/...
 
 update-golden: refresh-goldens
 

--- a/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
@@ -29,6 +29,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         name: hello
         ports:

--- a/istioctl/cmd/testdata/deployment/hello.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello.yaml.injected
@@ -34,6 +34,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       initContainers:
       - image: docker.io/istio/proxy_init:unittest-test
         name: istio-init

--- a/istioctl/cmd/testdata/deployment/hello.yaml.iop.injected
+++ b/istioctl/cmd/testdata/deployment/hello.yaml.iop.injected
@@ -34,6 +34,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       initContainers:
       - image: docker.io/istio/proxy_init:unittest-testiop
         name: istio-init

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
@@ -52,6 +53,13 @@ import (
 // InjectionPolicy determines the policy for injecting the
 // sidecar proxy into the watched namespace(s).
 type InjectionPolicy string
+
+// Defaults values for injecting istio proxy into kubernetes
+// resources.
+const (
+	DefaultSidecarProxyUID = int64(1337)
+	DefaultSidecarProxyGID = int64(1337)
+)
 
 const (
 	// InjectionPolicyDisabled specifies that the sidecar injector
@@ -106,6 +114,8 @@ type SidecarTemplateData struct {
 	Revision             string
 	EstimatedConcurrency int
 	ProxyImage           string
+	ProxyUID             *int64
+	ProxyGID             *int64
 }
 
 type (
@@ -407,6 +417,8 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		Revision:             params.revision,
 		EstimatedConcurrency: estimateConcurrency(params.proxyConfig, metadata.Annotations, params.valuesConfig.asStruct),
 		ProxyImage:           ProxyImage(params.valuesConfig.asStruct, params.proxyConfig.Image, strippedPod.Annotations),
+		ProxyUID:             params.proxyUID,
+		ProxyGID:             params.proxyGID,
 	}
 
 	mergedPod = params.pod
@@ -775,6 +787,8 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 			revision:            revision,
 			proxyEnvs:           map[string]string{},
 			injectedAnnotations: nil,
+			proxyUID:            pointer.Int64Ptr(DefaultSidecarProxyUID),
+			proxyGID:            pointer.Int64Ptr(DefaultSidecarProxyGID),
 		}
 		patchBytes, err = injectPod(params)
 	}

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -574,6 +574,8 @@ spec:
     - name: hello
       image: fake.docker.io/google-samples/hello-go-gke:1.0
     - name: istio-proxy
+      securityContext:
+        runAsUser: 1337
       image: proxy
 `
 	runWebhook(t, webhook, []byte(input), []byte(fmt.Sprintf(expected, "sidecar,init")), false)

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -135,6 +135,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+        securityContext:
+          runAsUser: 1337
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -127,7 +127,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsNonRoot: false
-          runAsUser: 0
+          runAsUser: 1337
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -38,6 +38,7 @@ import (
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
@@ -52,6 +53,8 @@ import (
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
 )
+
+const ProxyUIDAnnotation = "sidecar.istio.io/proxyUID"
 
 var (
 	runtimeScheme     = runtime.NewScheme()
@@ -301,6 +304,8 @@ type InjectionParameters struct {
 	revision            string
 	proxyEnvs           map[string]string
 	injectedAnnotations map[string]string
+	proxyUID            *int64
+	proxyGID            *int64
 }
 
 func checkPreconditions(params InjectionParameters) {
@@ -551,6 +556,8 @@ func postProcessPod(pod *corev1.Pod, injectedPod corev1.Pod, req InjectionParame
 	if err := reorderPod(pod, req); err != nil {
 		return err
 	}
+
+	replaceProxyRunAsUserID(pod, req.proxyUID)
 
 	return nil
 }
@@ -883,6 +890,42 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 			proxyConfig = generatedProxyConfig
 		}
 	}
+
+	var err error
+	var proxyUID *int64
+	var proxyGID *int64
+	tproxyInterceptionMode := pod.Annotations != nil && pod.Annotations["sidecar.istio.io/interceptionMode"] == string(model.InterceptionTproxy)
+	if !tproxyInterceptionMode && !hasOnlyIstioProxyContainer(pod) {
+		proxyUID, err = getProxyUIDFromAnnotation(pod)
+		if err != nil {
+			log.Infof("Could not get proxyUID from annotation: %v", err)
+		}
+		if proxyUID == nil {
+			if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
+				proxyUID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsUser + 1)
+				// valid GID for fsGroup defaults to first int in UID range in OCP's restricted SCC
+				proxyGID = pod.Spec.SecurityContext.RunAsUser
+			}
+			for _, c := range pod.Spec.Containers {
+				if c.Name != ProxyContainerName && c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
+					uid := *c.SecurityContext.RunAsUser + 1
+					if proxyUID == nil || uid > *proxyUID {
+						proxyUID = &uid
+					}
+					if proxyGID == nil {
+						proxyGID = c.SecurityContext.RunAsUser
+					}
+				}
+			}
+		}
+		if proxyUID == nil {
+			proxyUID = pointer.Int64Ptr(DefaultSidecarProxyUID)
+		}
+		if proxyGID == nil {
+			proxyGID = pointer.Int64Ptr(DefaultSidecarProxyUID)
+		}
+	}
+
 	deploy, typeMeta := kube.GetDeployMetaFromPod(&pod)
 	params := InjectionParameters{
 		pod:                 &pod,
@@ -897,6 +940,8 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 		revision:            wh.revision,
 		injectedAnnotations: wh.Config.InjectedAnnotations,
 		proxyEnvs:           parseInjectEnvs(path),
+		proxyUID:            proxyUID,
+		proxyGID:            proxyGID,
 	}
 	wh.mu.RUnlock()
 
@@ -916,6 +961,10 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	}
 	totalSuccessfulInjections.Increment()
 	return &reviewResponse
+}
+
+func hasOnlyIstioProxyContainer(pod corev1.Pod) bool {
+	return len(pod.Spec.Containers) == 1 && pod.Spec.Containers[0].Name == ProxyContainerName
 }
 
 func (wh *Webhook) serveInject(w http.ResponseWriter, r *http.Request) {
@@ -1047,4 +1096,51 @@ func parseInjectEnvs(path string) map[string]string {
 func handleError(message string) {
 	log.Errorf(message)
 	totalFailedInjections.Increment()
+}
+
+// modifies the pod to ensure that the proxy runs with the given proxyUID instead of 1337
+func replaceProxyRunAsUserID(pod *corev1.Pod, proxyUID *int64) {
+	if proxyUID == nil {
+		return
+	}
+	for i, c := range pod.Spec.InitContainers {
+		if c.Name == InitContainerName || c.Name == ValidationContainerName {
+			for j, arg := range c.Args {
+				if arg == "-u" {
+					pod.Spec.InitContainers[i].Args[j+1] = strconv.FormatInt(*proxyUID, 10)
+					break
+				}
+			}
+			if c.Name == ValidationContainerName {
+				if c.SecurityContext == nil {
+					securityContext := corev1.SecurityContext{}
+					pod.Spec.InitContainers[i].SecurityContext = &securityContext
+				}
+				pod.Spec.InitContainers[i].SecurityContext.RunAsUser = proxyUID
+			}
+		}
+	}
+	for i, c := range pod.Spec.Containers {
+		if c.Name == ProxyContainerName {
+			if c.SecurityContext == nil {
+				securityContext := corev1.SecurityContext{}
+				pod.Spec.Containers[i].SecurityContext = &securityContext
+			}
+			pod.Spec.Containers[i].SecurityContext.RunAsUser = proxyUID
+			break
+		}
+	}
+}
+
+func getProxyUIDFromAnnotation(pod corev1.Pod) (*int64, error) {
+	if pod.Annotations != nil {
+		if annotationValue, found := pod.Annotations[ProxyUIDAnnotation]; found {
+			proxyUID, err := strconv.ParseInt(annotationValue, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			return &proxyUID, nil
+		}
+	}
+	return nil, nil
 }

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -894,35 +894,61 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	var err error
 	var proxyUID *int64
 	var proxyGID *int64
-	tproxyInterceptionMode := pod.Annotations != nil && pod.Annotations["sidecar.istio.io/interceptionMode"] == string(model.InterceptionTproxy)
-	if !tproxyInterceptionMode && !hasOnlyIstioProxyContainer(pod) {
-		proxyUID, err = getProxyUIDFromAnnotation(pod)
-		if err != nil {
-			log.Infof("Could not get proxyUID from annotation: %v", err)
-		}
-		if proxyUID == nil {
-			if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
-				proxyUID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsUser + 1)
-				// valid GID for fsGroup defaults to first int in UID range in OCP's restricted SCC
-				proxyGID = pod.Spec.SecurityContext.RunAsUser
+	if hasOnlyIstioProxyContainer(pod) {
+		if pod.Spec.SecurityContext != nil {
+			if pod.Spec.SecurityContext.RunAsUser != nil {
+				proxyUID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsUser)
+				proxyGID = pointer.Int64Ptr(*proxyUID)
 			}
-			for _, c := range pod.Spec.Containers {
-				if c.Name != ProxyContainerName && c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
-					uid := *c.SecurityContext.RunAsUser + 1
-					if proxyUID == nil || uid > *proxyUID {
-						proxyUID = &uid
-					}
+			if pod.Spec.SecurityContext.RunAsGroup != nil {
+				proxyGID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsGroup)
+			}
+		}
+		for _, c := range pod.Spec.Containers {
+			if c.Name == ProxyContainerName && c.SecurityContext != nil {
+				if c.SecurityContext.RunAsUser != nil {
+					proxyUID = pointer.Int64Ptr(*c.SecurityContext.RunAsUser)
 					if proxyGID == nil {
-						proxyGID = c.SecurityContext.RunAsUser
+						proxyGID = pointer.Int64Ptr(*proxyUID)
+					}
+				}
+				if c.SecurityContext.RunAsGroup != nil {
+					proxyGID = pointer.Int64Ptr(*c.SecurityContext.RunAsGroup)
+				}
+				break
+			}
+		}
+	} else {
+		tproxyInterceptionMode := pod.Annotations != nil && pod.Annotations["sidecar.istio.io/interceptionMode"] == string(model.InterceptionTproxy)
+		if !tproxyInterceptionMode {
+			proxyUID, err = getProxyUIDFromAnnotation(pod)
+			if err != nil {
+				log.Infof("Could not get proxyUID from annotation: %v", err)
+			}
+			if proxyUID == nil {
+				if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
+					proxyUID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsUser + 1)
+					// valid GID for fsGroup defaults to first int in UID range in OCP's restricted SCC
+					proxyGID = pod.Spec.SecurityContext.RunAsUser
+				}
+				for _, c := range pod.Spec.Containers {
+					if c.Name != ProxyContainerName && c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
+						uid := *c.SecurityContext.RunAsUser + 1
+						if proxyUID == nil || uid > *proxyUID {
+							proxyUID = &uid
+						}
+						if proxyGID == nil {
+							proxyGID = c.SecurityContext.RunAsUser
+						}
 					}
 				}
 			}
-		}
-		if proxyUID == nil {
-			proxyUID = pointer.Int64Ptr(DefaultSidecarProxyUID)
-		}
-		if proxyGID == nil {
-			proxyGID = pointer.Int64Ptr(DefaultSidecarProxyUID)
+			if proxyUID == nil {
+				proxyUID = pointer.Int64Ptr(DefaultSidecarProxyUID)
+			}
+			if proxyGID == nil {
+				proxyGID = pointer.Int64Ptr(DefaultSidecarProxyUID)
+			}
 		}
 	}
 

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -970,7 +970,10 @@ func TestRunAndServe(t *testing.T) {
     "path": "/spec/containers/1",
     "value": {
         "name": "istio-proxy",
-        "resources": {}
+        "resources": {},
+		"securityContext": {
+		    "runAsUser": 1337
+		}
     }
 },
 {


### PR DESCRIPTION
(#230) (#541)

Squashed commit, incorporates changes from:

  * MAISTRA-551 Run sidecar with a dynamically-determined runAsUser ID

  * MAISTRA-611 Partial injection of just the annotation and runAsUser id

  * MAISTRA-668 Fix expected output of webhook injection

  The sidecar injector now sets the securityContext.runAsUser field
  regardless if it is specified in the sidecar template or not. This is
  to allow the sidecar template to not include the field, which is
  required to ensure that istioctl kube-inject outputs manifests that
  pass the SCC admission controller (if the runAsUser is specified, the
  SCC controller will reject the pod, as the uid won't be in the proper
  range). The sidecar injector then injects the correct runAsUser id even
  if it isn't specified in the template.

  * MAISTRA-1751: Set securityContext.fsGroup to comply with restricted SCC (#256)

  This is a rewrite of 46f0f4a for the Maistra 2.1 / Istio 1.8 rebase.

  * MAISTRA-2452 Apply dynamically-determined user ID to the istio-validation init container

  * OSSM-1847 ensure ProxyUID and ProxyGID are initialized when using gateway injection template #618 
    * do not default ProxyUID and ProxyGID for gateways
    * initialize ProxyGID appropriately for gateway injection

Co-authored-by: rcernich <rcernich@redhat.com>
Co-authored-by: Marko Lukša <marko.luksa@gmail.com>
Co-authored-by: Brad Ison <bison@coreos.com>
Co-authored-by: Brian Avery <bavery@redhat.com>
Co-authored-by: Marko Lukša <marko.luksa@gmail.com>

