### PR TITLE
[istiod] OSSM-2294 Add --logKubernetesApiRequests option to istiod 

### DIFF
--- a/pilot/cmd/pilot-discovery/app/cmd.go
+++ b/pilot/cmd/pilot-discovery/app/cmd.go
@@ -196,6 +196,9 @@ func addFlags(c *cobra.Command) {
 	c.PersistentFlags().IntVar(&serverArgs.RegistryOptions.KubeOptions.KubernetesAPIBurst, "kubernetesApiBurst", 160,
 		"Maximum burst for throttle when communicating with the kubernetes API")
 
+	c.PersistentFlags().BoolVar(&serverArgs.RegistryOptions.KubeOptions.LogKubernetesAPIRequests, "logKubernetesApiRequests", false,
+		"Log requests sent to the kubernetes API")
+
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(c)
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -546,6 +546,9 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 		kubeRestConfig, err := kubelib.DefaultRestConfig(args.RegistryOptions.KubeConfig, "", func(config *rest.Config) {
 			config.QPS = args.RegistryOptions.KubeOptions.KubernetesAPIQPS
 			config.Burst = args.RegistryOptions.KubeOptions.KubernetesAPIBurst
+			if args.RegistryOptions.KubeOptions.LogKubernetesAPIRequests {
+				installRequestLogger(config)
+			}
 		})
 		if err != nil {
 			return fmt.Errorf("failed creating kube config: %v", err)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -142,6 +142,9 @@ type Options struct {
 	// Maximum burst for throttle when communicating with the kubernetes API
 	KubernetesAPIBurst int
 
+	// Whether to log requests sent to the kubernetes API
+	LogKubernetesAPIRequests bool
+
 	// SyncTimeout, if set, causes HasSynced to be returned when timeout.
 	SyncTimeout time.Duration
 


### PR DESCRIPTION
This option logs each individual request sent to the Kubernetes API. In addition to enabling this option, you need to set the log level to INFO.

Based on #625
