### PR TITLE
[build] OSSM-2297 Improve Maistra container images build

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -474,3 +474,8 @@ include tools/packaging/packaging.mk
 include tests/integration/tests.mk
 
 include common/Makefile.common.mk
+
+#-----------------------------------------------------------------------------
+# Maistra
+#-----------------------------------------------------------------------------
+include maistra/maistra.mk

--- a/maistra/Dockerfile.istio-cni
+++ b/maistra/Dockerfile.istio-cni
@@ -1,0 +1,31 @@
+FROM quay.io/centos/centos:stream8 as centos
+
+ARG MAISTRA_VERSION
+ARG ISTIO_VERSION
+
+LABEL com.redhat.component="openshift-istio-cni-ubi8-container"
+LABEL name="openshift-service-mesh/istio-cni-ubi8"
+LABEL version="${MAISTRA_VERSION}"
+LABEL istio_version="${ISTIO_VERSION}"
+LABEL summary="Maistra CNI plugin installer OpenShift container image"
+LABEL description="Maistra CNI plugin installer OpenShift container image"
+LABEL io.k8s.display-name="Maistra CNI plugin installer"
+LABEL io.openshift.tags="istio"
+LABEL io.openshift.expose-services=""
+LABEL maintainer="Istio Feedback <istio-feedback@redhat.com>"
+
+ENV container="oci"
+ENV ISTIO_VERSION="${ISTIO_VERSION}"
+
+RUN dnf update -y && dnf clean all
+
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/istio-cni /opt/cni/bin/istio-cni
+COPY ${TARGETARCH:-amd64}/install-cni /usr/local/bin/install-cni
+
+# Copy over the Taint binary
+COPY ${TARGETARCH:-amd64}/istio-cni-taint /opt/local/bin/istio-cni-taint
+
+ENV PATH=$PATH:/opt/cni/bin
+WORKDIR /opt/cni/bin
+CMD ["/usr/local/bin/install-cni"]

--- a/maistra/Dockerfile.pilot
+++ b/maistra/Dockerfile.pilot
@@ -1,0 +1,33 @@
+FROM quay.io/centos/centos:stream8 as centos
+
+ARG MAISTRA_VERSION
+ARG ISTIO_VERSION
+
+LABEL com.redhat.component="openshift-istio-pilot-ubi8-container"
+LABEL name="openshift-service-mesh/pilot-ubi8"
+LABEL version="${MAISTRA_VERSION}"
+LABEL istio_version="${ISTIO_VERSION}"
+LABEL summary="Maistra Pilot OpenShift container image"
+LABEL description="Maistra Pilot OpenShift container image"
+LABEL io.k8s.display-name="Maistra Pilot"
+LABEL io.openshift.tags="istio"
+LABEL io.openshift.expose-services="15003:tcp,15005:tcp,15007:tcp,15010:tcp,15011:tcp,8080:tcp,9093:tcp"
+LABEL maintainer="Istio Feedback <istio-feedback@redhat.com>"
+
+ENV container="oci"
+ENV ISTIO_VERSION="${ISTIO_VERSION}"
+
+RUN dnf update -y && \
+  dnf install -y podman-docker util-linux && \
+  dnf clean all
+
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/pilot-discovery /usr/local/bin/pilot-discovery
+
+# Copy templates for bootstrap generation.
+COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+
+USER 1337:1337
+
+ENTRYPOINT ["/usr/local/bin/pilot-discovery"]

--- a/maistra/Dockerfile.proxyv2
+++ b/maistra/Dockerfile.proxyv2
@@ -1,0 +1,51 @@
+FROM quay.io/centos/centos:stream8
+
+ARG MAISTRA_VERSION
+ARG ISTIO_VERSION
+ARG proxy_version
+ARG SIDECAR=envoy
+
+LABEL com.redhat.component="openshift-istio-proxy-ubi8-container"
+LABEL name="openshift-service-mesh/istio-proxy-ubi8"
+LABEL version="${MAISTRA_VERSION}"
+LABEL istio_version="${ISTIO_VERSION}"
+LABEL summary="Maistra Proxy OpenShift container image"
+LABEL description="Maistra Proxy OpenShift container image"
+LABEL io.k8s.display-name="Maistra Proxy"
+LABEL io.openshift.tags="istio"
+LABEL io.openshift.expose-services=""
+LABEL maintainer="Istio Feedback <istio-feedback@redhat.com>"
+
+# hadolint ignore=DL3039,DL3041
+RUN dnf -y upgrade --refresh --nobest && \
+    dnf -y install iptables iproute openssl && \
+    dnf -y clean all
+
+WORKDIR /
+
+# Copy Envoy bootstrap templates used by pilot-agent
+COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+
+RUN useradd -m --uid 1337 istio-proxy
+RUN chown -R istio-proxy /var/lib/istio
+
+# Install Envoy.
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/${SIDECAR} /usr/local/bin/${SIDECAR}
+
+# Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
+ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
+# Environment variable indicating the exact build, for debugging
+ENV ISTIO_META_ISTIO_VERSION ${ISTIO_VERSION}
+
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/pilot-agent /usr/local/bin/pilot-agent
+
+COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
+COPY stats-filter.compiled.wasm /etc/istio/extensions/stats-filter.compiled.wasm
+COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
+COPY metadata-exchange-filter.compiled.wasm /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+
+# The pilot-agent will bootstrap Envoy.
+ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/maistra/docker.yaml
+++ b/maistra/docker.yaml
@@ -1,0 +1,157 @@
+# docker.yaml provides details about each Dockerfile in the repo.
+# Unlike standard Dockerfiles, Istio builds artifacts outside of docker and then copies them to a temp folder;
+# This folder is then passed as the docker context. This avoids complex .dockerignore or large context loads.
+
+# Example image config
+example:
+- name: helloworld # Name of the image. Will end up pushed to <HUB>/helloworld:<TAG>
+  dockerfile: helloworld/Dockerfile.proxyv2
+  files:
+  # Include a static file
+  # Inside the Dockerfile, this is referenced by the base name (README.md), not the full name.
+  - samples/README.md
+  targets:
+  # Build a file with make, then include as a static file
+  - ${TARGET_OUT_LINUX}/helloworld
+
+images:
+
+# Base images
+- name: base
+  dockerfile: docker/Dockerfile.base
+  base: true
+
+- name: distroless
+  dockerfile: docker/Dockerfile.distroless
+  base: true
+
+# Production images
+- name: istioctl
+  dockerfile: istioctl/docker/Dockerfile.istioctl
+  targets:
+  - ${TARGET_OUT_LINUX}/istioctl
+
+- name: operator
+  dockerfile: operator/docker/Dockerfile.operator
+  files:
+  - manifests
+  targets:
+  - ${TARGET_OUT_LINUX}/operator
+
+# Test images
+- name: app
+  dockerfile: pkg/test/echo/docker/Dockerfile.app
+  files:
+  - tests/testdata/certs
+  targets:
+  - ${TARGET_OUT_LINUX}/client
+  - ${TARGET_OUT_LINUX}/server
+
+# Sample authz server
+- name: ext-authz
+  dockerfile: samples/extauthz/docker/Dockerfile
+  targets:
+    - ${TARGET_OUT_LINUX}/extauthz
+
+# TODO(https://github.com/istio/istio/issues/38224)
+#- name: app_sidecar_rockylinux_8
+#  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_centos_8
+#  files:
+#  - tools/packaging/common/envoy_bootstrap.json
+#  - tests/testdata/certs
+#  - pkg/test/echo/docker/echo-start.sh
+#  - pkg/test/echo/docker/sudoers
+#  targets:
+#  - ${TARGET_OUT_LINUX}/release/istio-sidecar.rpm
+#  - ${TARGET_OUT_LINUX}/client
+#  - ${TARGET_OUT_LINUX}/server
+- name: app_sidecar_centos_7
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_centos_7
+  files:
+  - tools/packaging/common/envoy_bootstrap.json
+  - tests/testdata/certs
+  - pkg/test/echo/docker/echo-start.sh
+  - pkg/test/echo/docker/sudoers
+  targets:
+  - ${TARGET_OUT_LINUX}/release/istio-sidecar-centos-7.rpm
+  - ${TARGET_OUT_LINUX}/client
+  - ${TARGET_OUT_LINUX}/server
+- name: app_sidecar_debian_11
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar
+  files:
+  - tools/packaging/common/envoy_bootstrap.json
+  - tests/testdata/certs
+  - pkg/test/echo/docker/echo-start.sh
+  - pkg/test/echo/docker/sudoers
+  targets:
+  - ${TARGET_OUT_LINUX}/release/istio-sidecar.deb
+  - ${TARGET_OUT_LINUX}/client
+  - ${TARGET_OUT_LINUX}/server
+- name: app_sidecar_ubuntu_jammy
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar
+  files:
+  - tools/packaging/common/envoy_bootstrap.json
+  - tests/testdata/certs
+  - pkg/test/echo/docker/echo-start.sh
+  - pkg/test/echo/docker/sudoers
+  targets:
+  - ${TARGET_OUT_LINUX}/release/istio-sidecar.deb
+  - ${TARGET_OUT_LINUX}/client
+  - ${TARGET_OUT_LINUX}/server
+- name: app_sidecar_ubuntu_xenial
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar
+  files:
+  - tools/packaging/common/envoy_bootstrap.json
+  - tests/testdata/certs
+  - pkg/test/echo/docker/echo-start.sh
+  - pkg/test/echo/docker/sudoers
+  targets:
+  - ${TARGET_OUT_LINUX}/release/istio-sidecar.deb
+  - ${TARGET_OUT_LINUX}/client
+  - ${TARGET_OUT_LINUX}/server
+
+# Test base images
+- name: app_sidecar_base_debian_11 # latest debian
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_base
+  base: true
+- name: app_sidecar_base_ubuntu_jammy # newest ubuntu
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_base
+  base: true
+- name: app_sidecar_base_ubuntu_xenial # oldest supported ubuntu
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_base
+  base: true
+#  TODO(https://github.com/istio/istio/issues/38224)
+#- name: app_sidecar_base_rockylinux_8 # newest RHEL-based
+#  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_base_centos
+#  base: true
+- name: app_sidecar_base_centos_7 # oldest supported RHEL-based
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_base_centos
+  base: true
+
+# Maistra images
+- name: proxyv2
+  dockerfile: maistra/Dockerfile.proxyv2
+  files:
+  - tools/packaging/common/envoy_bootstrap.json
+  - tools/packaging/common/gcp_envoy_bootstrap.json
+  - ${TARGET_OUT_LINUX}/release/${SIDECAR}
+  - ${TARGET_OUT_LINUX}/release/stats-filter.wasm
+  - ${TARGET_OUT_LINUX}/release/stats-filter.compiled.wasm
+  - ${TARGET_OUT_LINUX}/release/metadata-exchange-filter.wasm
+  - ${TARGET_OUT_LINUX}/release/metadata-exchange-filter.compiled.wasm
+  targets:
+  - ${TARGET_OUT_LINUX}/pilot-agent
+- name: pilot
+  dockerfile: maistra/Dockerfile.pilot
+  files:
+  - tools/packaging/common/envoy_bootstrap.json
+  - tools/packaging/common/gcp_envoy_bootstrap.json
+  targets:
+  - ${TARGET_OUT_LINUX}/pilot-discovery
+- name: install-cni
+  dockerfile: maistra/Dockerfile.istio-cni
+  targets:
+  - ${TARGET_OUT_LINUX}/istio-cni
+  - ${TARGET_OUT_LINUX}/istio-iptables
+  - ${TARGET_OUT_LINUX}/install-cni
+  - ${TARGET_OUT_LINUX}/istio-cni-taint  

--- a/maistra/maistra.mk
+++ b/maistra/maistra.mk
@@ -1,6 +1,6 @@
 # Container images labels
-MAISTRA_VERSION ?= 2.3.0
-ISTIO_VERSION ?= 1.14.3
+MAISTRA_VERSION ?= 2.4.0
+ISTIO_VERSION ?= 1.16.0
 
 BASE_DISTRIBUTION ?= ubi8
 

--- a/maistra/maistra.mk
+++ b/maistra/maistra.mk
@@ -53,11 +53,3 @@ $(foreach TGT,$(MAISTRA_IMAGES),$(eval PUSH_MAISTRA_IMAGES+=push.$(TGT)))
 # This target will build and push all the container images
 .PHONY: maistra-image.push
 maistra-image.push: $(PUSH_MAISTRA_IMAGES)
-
-.PHONY: vendor
-vendor:
-	@echo "updating vendor"
-	@go mod vendor
-	@echo "done updating vendor"
-
-gen: vendor

--- a/maistra/maistra.mk
+++ b/maistra/maistra.mk
@@ -1,0 +1,63 @@
+# Container images labels
+MAISTRA_VERSION ?= 2.3.0
+ISTIO_VERSION ?= 1.14.3
+
+BASE_DISTRIBUTION ?= ubi8
+
+# Maistra specific vars
+MAISTRA_IMAGES ?= maistra-image.pilot maistra-image.proxyv2 maistra-image.istio-cni
+
+# Pre-build and post-build tasks
+MAISTRA_PRE_BUILD_SCRIPT ?= ./maistra/scripts/pre-build.sh
+MAISTRA_POST_BUILD_SCRIPT ?= ./maistra/scripts/post-build.sh
+MAISTRA_PRE_BUILD ?= time ($(MAISTRA_PRE_BUILD_SCRIPT))
+MAISTRA_POST_BUILD ?= time (HUB=$(HUB) TAG=$(TAG) BASE_DISTRIBUTION=$(BASE_DISTRIBUTION) $(MAISTRA_POST_BUILD_SCRIPT) $(ISTIO_COMPONENT))
+
+.PHONY: maistra-image.pilot
+maistra-image.pilot: VERSION=$(MAISTRA_VERSION)
+maistra-image.pilot: ISTIO_COMPONENT=$(subst maistra-image.,,$@)
+maistra-image.pilot: 
+	$(MAISTRA_PRE_BUILD)
+	$(MAKE) docker.pilot
+	$(MAISTRA_POST_BUILD)
+
+.PHONY: maistra-image.proxyv2
+maistra-image.proxyv2: VERSION=$(MAISTRA_VERSION)
+maistra-image.proxyv2: ISTIO_COMPONENT=$(subst maistra-image.,,$@)
+maistra-image.proxyv2: 
+	$(MAISTRA_PRE_BUILD)
+	$(MAKE) docker.proxyv2
+	$(MAISTRA_POST_BUILD)
+
+.PHONY: maistra-image.istio-cni
+maistra-image.istio-cni: VERSION=$(MAISTRA_VERSION)
+maistra-image.istio-cni: ISTIO_COMPONENT=$(subst maistra-image.,,$@)
+maistra-image.istio-cni: 
+	$(MAISTRA_PRE_BUILD)
+	$(MAKE) docker.install-cni
+	$(MAISTRA_POST_BUILD)
+
+# for each maistra-image.XXX target create a push.maistra-image.XXX target that pushes
+# the local container image to another hub
+# a possible optimization is to use tag.$(TGT) as a dependency to do the tag for us
+$(foreach TGT,$(MAISTRA_IMAGES),$(eval push.$(TGT): | $(TGT) ; \
+	time (set -e; $(CONTAINER_CLI) push $(HUB)/$(subst maistra-image.,,$(TGT))-$(BASE_DISTRIBUTION):$(TAG);)))
+
+# This target will build locally all the container images
+.PHONY: maistra-image
+maistra-image: $(MAISTRA_IMAGES)
+
+PUSH_MAISTRA_IMAGES:=
+$(foreach TGT,$(MAISTRA_IMAGES),$(eval PUSH_MAISTRA_IMAGES+=push.$(TGT)))
+
+# This target will build and push all the container images
+.PHONY: maistra-image.push
+maistra-image.push: $(PUSH_MAISTRA_IMAGES)
+
+.PHONY: vendor
+vendor:
+	@echo "updating vendor"
+	@go mod vendor
+	@echo "done updating vendor"
+
+gen: vendor

--- a/maistra/scripts/post-build.sh
+++ b/maistra/scripts/post-build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright Maistra Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+function image_retag() {
+  if [ "$#" -ne 1 ]; then
+    echo "Usage: image_retag component"
+    exit 2
+  fi
+
+  local istio_component="${1}"
+  local istio_src_component="${istio_component}"
+
+  if [ "${istio_component}" = "istio-cni" ]; then
+      istio_src_component="install-cni"
+  fi
+
+  "${CONTAINER_CLI}" tag "${HUB}/${istio_src_component}:${TAG}" "${HUB}/${istio_component}-${BASE_DISTRIBUTION}:${TAG}"
+  "${CONTAINER_CLI}" rmi "${HUB}/${istio_src_component}:${TAG}"
+}
+
+function cleanup() {
+  if [ -f "${DIR}"/../../tools/docker.yaml.upstream ]; then
+    mv "${DIR}"/../../tools/docker.yaml.upstream "${DIR}"/../../tools/docker.yaml
+  fi
+}
+
+## Main
+if [ "$#" -ne 1 ]; then
+  echo "Usage: post-build.sh component"
+  exit 1
+fi
+
+image_retag "${1}"
+cleanup

--- a/maistra/scripts/pre-build.sh
+++ b/maistra/scripts/pre-build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright Maistra Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+function backup() {
+  mv "${DIR}"/../../tools/docker.yaml "${DIR}"/../../tools/docker.yaml.upstream && cp "${DIR}"/../docker.yaml "${DIR}"/../../tools/docker.yaml
+}
+
+## Main
+backup


### PR DESCRIPTION
* OSSM-742 Improve Maistra container images build (#534)

* OSSM-742 Improve Maistra container images build

* Simplify make rules and Dockerfiles

* Fix dockerfiles lint issues

* Reorganize files and apply image naming convention

* Update MAISTRA_VERSION and ISTIO_VERSION

* Adapt images builds relying on upstream build tool

* Add copyright and license into scripts

Derived from #606
