### PR TITLE
OSSM-2338: Do not configure sni-dnat router for federation deployment

### DIFF
--- a/samples/federation/baremetal-zap/export/smcp-bare-metal.yaml
+++ b/samples/federation/baremetal-zap/export/smcp-bare-metal.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh2's network
         - network-mesh2
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -60,7 +59,6 @@ spec:
       # ingress gateway definition for handing requests from mesh2
       mesh2-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: NodePort
           metadata:

--- a/samples/federation/baremetal-zap/export/smcp-multihost.yaml
+++ b/samples/federation/baremetal-zap/export/smcp-multihost.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh2's network
         - network-mesh2
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -60,7 +59,6 @@ spec:
       # ingress gateway definition for handing requests from mesh2
       mesh2-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: NodePort
           metadata:

--- a/samples/federation/baremetal-zap/export/smcp.yaml
+++ b/samples/federation/baremetal-zap/export/smcp.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh2's network
         - network-mesh2
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -60,7 +59,6 @@ spec:
       # ingress gateway definition for handing requests from mesh2
       mesh2-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: LoadBalancer
           metadata:

--- a/samples/federation/baremetal-zap/import/smcp-bare-metal.yaml
+++ b/samples/federation/baremetal-zap/import/smcp-bare-metal.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh1's network
         - network-mesh1
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -60,7 +59,6 @@ spec:
       # ingress gateway definition for handing requests from mesh1
       mesh1-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: NodePort
           metadata:

--- a/samples/federation/baremetal-zap/import/smcp-multihost.yaml
+++ b/samples/federation/baremetal-zap/import/smcp-multihost.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh1's network
         - network-mesh1
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -62,7 +61,6 @@ spec:
       # ingress gateway definition for handing requests from mesh1
       mesh1-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: NodePort
           metadata:

--- a/samples/federation/baremetal-zap/import/smcp.yaml
+++ b/samples/federation/baremetal-zap/import/smcp.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh1's network
         - network-mesh1
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -60,7 +59,6 @@ spec:
       # ingress gateway definition for handing requests from mesh1
       mesh1-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: LoadBalancer
           metadata:

--- a/samples/federation/base/export/smcp.yaml
+++ b/samples/federation/base/export/smcp.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh2's network
         - network-mesh2
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -60,7 +59,6 @@ spec:
       # ingress gateway definition for handing requests from mesh2
       mesh2-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: LoadBalancer
           metadata:

--- a/samples/federation/base/import/smcp.yaml
+++ b/samples/federation/base/import/smcp.yaml
@@ -32,7 +32,6 @@ spec:
         requestedNetworkView:
         # we want to view services on mesh1's network
         - network-mesh1
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -60,7 +59,6 @@ spec:
       # ingress gateway definition for handing requests from mesh1
       mesh1-ingress:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: LoadBalancer
           metadata:

--- a/tests/integration/servicemesh/federation/federation.go
+++ b/tests/integration/servicemesh/federation/federation.go
@@ -109,9 +109,6 @@ components:
     label:
       unique: ingress
     k8s:
-      env:
-      - name: ISTIO_META_ROUTER_MODE
-        value: sni-dnat
       service:
         ports:
         # required for handling service requests from mesh2
@@ -127,9 +124,6 @@ components:
     label:
       unique: egress
     k8s:
-      env:
-      - name: ISTIO_META_ROUTER_MODE
-        value: sni-dnat
       service:
         ports:
         # required for handling service requests from mesh2


### PR DESCRIPTION
ISTIO_META_ROUTER_MODE is ignored since Istio 1.11.