### PR TITLE
OSSM-2338: Remove env ISTIO_META_ROUTER_MODE from federation test

### DIFF
--- a/tests/integration/servicemesh/federation/federation.go
+++ b/tests/integration/servicemesh/federation/federation.go
@@ -48,9 +48,6 @@ components:
     label:
       unique: ingress
     k8s:
-      env:
-      - name: ISTIO_META_ROUTER_MODE
-        value: sni-dnat
       service:
         ports:
         # required for handling service requests from mesh2
@@ -66,9 +63,6 @@ components:
     label:
       unique: egress
     k8s:
-      env:
-      - name: ISTIO_META_ROUTER_MODE
-        value: sni-dnat
       service:
         ports:
         # required for handling service requests from mesh2


### PR DESCRIPTION
This is a manual cherry-pick of #705.