### PR TITLE
Fix the CRD lookup

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -170,17 +170,18 @@ func NewForSchemas(client kube.Client, opts Option, schemas collection.Schemas) 
 		client:           client,
 		istioClient:      client.Istio(),
 		gatewayAPIClient: client.GatewayAPI(),
-		crdMetadataInformer: client.MetadataInformer().ForResource(collections.K8SApiextensionsK8SIoV1Customresourcedefinitions.Resource().
-			GroupVersionResource()).Informer(),
 		beginSync:        atomic.NewBool(false),
 		initialSync:      atomic.NewBool(false),
 		logger:           scope.WithLabels("controller", opts.Identifier),
 		namespacesFilter: opts.NamespacesFilter,
 	}
-	_ = out.crdMetadataInformer.SetTransform(kube.StripUnusedFields)
 
 	var known map[string]struct{}
 	if opts.EnableCRDScan {
+		out.crdMetadataInformer = client.MetadataInformer().ForResource(collections.K8SApiextensionsK8SIoV1Customresourcedefinitions.Resource().
+			GroupVersionResource()).Informer()
+		_ = out.crdMetadataInformer.SetTransform(kube.StripUnusedFields)
+
 		var err error
 		known, err = knownCRDs(client.Ext())
 		if err != nil {


### PR DESCRIPTION
This fixes the issue:
```
2022-12-21T19:30:44.914241Z	error	klog	k8s.io/client-go@v0.25.1/tools/cache/reflector.go:169: Failed to watch *v1.PartialObjectMetadata: failed to list *v1.PartialObjectMetadata: customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:istio-system:istiod-minimal" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

Complements OSSM-2233
