### PR TITLE
OSSM-2376: Don't start federation controllers until informers have synced

### DIFF
--- a/pilot/pkg/serviceregistry/federation/controller.go
+++ b/pilot/pkg/serviceregistry/federation/controller.go
@@ -42,7 +42,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
-	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/servicemesh/federation/common"
 	federationmodel "istio.io/istio/pkg/servicemesh/federation/model"
@@ -78,7 +77,7 @@ type Controller struct {
 
 	logger *log.Scope
 
-	kubeClient    kube.Client
+	rm            common.ResourceManager
 	statusHandler status.Handler
 	configStore   model.ConfigStoreController
 	xdsUpdater    model.XDSUpdater
@@ -114,16 +113,16 @@ type existingImport struct {
 }
 
 type Options struct {
-	DomainSuffix   string
-	LocalClusterID string
-	LocalNetwork   string
-	ClusterID      string
-	Network        string
-	KubeClient     kube.Client
-	StatusHandler  status.Handler
-	ConfigStore    model.ConfigStoreController
-	XDSUpdater     model.XDSUpdater
-	ResyncPeriod   time.Duration
+	DomainSuffix    string
+	LocalClusterID  string
+	LocalNetwork    string
+	ClusterID       string
+	Network         string
+	ResourceManager common.ResourceManager
+	StatusHandler   status.Handler
+	ConfigStore     model.ConfigStoreController
+	XDSUpdater      model.XDSUpdater
+	ResyncPeriod    time.Duration
 }
 
 func defaultDomainSuffixForMesh(mesh *v1.ServiceMeshPeer) string {
@@ -180,10 +179,10 @@ func NewController(opt Options, mesh *v1.ServiceMeshPeer, importConfig *v1.Impor
 		clusterID:         cluster.ID(opt.ClusterID),
 		networkID:         network.ID(opt.Network),
 		localDomainSuffix: localDomainSuffix,
+		rm:                opt.ResourceManager,
 		imports:           map[federationmodel.ServiceKey]*existingImport{},
 		serviceStore:      map[host.Name]*model.Service{},
 		instanceStore:     map[host.Name][]*model.ServiceInstance{},
-		kubeClient:        opt.KubeClient,
 		statusHandler:     opt.StatusHandler,
 		configStore:       opt.ConfigStore,
 		xdsUpdater:        opt.XDSUpdater,
@@ -492,14 +491,14 @@ func (c *Controller) updateGateways(serviceList *federationmodel.ServiceListMess
 }
 
 func (c *Controller) getEgressServiceAddrs() ([]model.NetworkGateway, []string) {
-	endpointSlices, err := common.EndpointSlicesForService(c.kubeClient, c.egressName, c.namespace)
+	endpointSlices, err := common.EndpointSlicesForService(c.rm.EndpointSliceInformer(), c.egressName, c.namespace)
 	if err != nil {
 		c.logger.Errorf("failed to retrieve EndpointSlices for federation egress gateway %s: %s", c.egressName, err)
 		return nil, nil
 	}
 	serviceAccountByIP := map[string]string{}
 	if !c.useDirectCalls {
-		serviceAccountByIP, err = common.ServiceAccountsForService(c.kubeClient, c.egressName, c.namespace)
+		serviceAccountByIP, err = common.ServiceAccountsForService(c.rm.ServiceInformer(), c.rm.PodInformer(), c.egressName, c.namespace)
 		if err != nil {
 			c.logger.Warnf("failed to retrieve ServiceAccount information for imported services accessed through %s: %s",
 				c.egressName, err)

--- a/pkg/kube/controller/controller.go
+++ b/pkg/kube/controller/controller.go
@@ -99,6 +99,10 @@ func NewController(opt Options) *Controller {
 }
 
 func (c *Controller) Start(stopChan <-chan struct{}) {
+	c.StartController(stopChan, c.HasSynced)
+}
+
+func (c *Controller) StartController(stopChan <-chan struct{}, hasSynced func() bool) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
@@ -107,7 +111,7 @@ func (c *Controller) Start(stopChan <-chan struct{}) {
 
 	c.RunInformer(stopChan)
 
-	cache.WaitForCacheSync(stopChan, c.HasSynced)
+	cache.WaitForCacheSync(stopChan, hasSynced)
 	c.Logger.Infof("Controller synced in %s", time.Since(t0))
 
 	c.Logger.Info("Starting workers")

--- a/pkg/servicemesh/federation/common/resources.go
+++ b/pkg/servicemesh/federation/common/resources.go
@@ -17,6 +17,8 @@ package common
 import (
 	"reflect"
 
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
+	discoveryinformersv1 "k8s.io/client-go/informers/discovery/v1"
 	maistrainformersfederationv1 "maistra.io/api/client/informers/externalversions/federation/v1"
 	maistraclient "maistra.io/api/client/versioned"
 	maistraxnsinformer "maistra.io/api/client/xnsinformer"
@@ -27,7 +29,10 @@ import (
 
 type ResourceManager interface {
 	MaistraClientSet() maistraclient.Interface
-	KubeClient() kube.Client
+	ConfigMapInformer() coreinformersv1.ConfigMapInformer
+	EndpointSliceInformer() discoveryinformersv1.EndpointSliceInformer
+	PodInformer() coreinformersv1.PodInformer
+	ServiceInformer() coreinformersv1.ServiceInformer
 	PeerInformer() maistrainformersfederationv1.ServiceMeshPeerInformer
 	ExportsInformer() maistrainformersfederationv1.ExportedServiceSetInformer
 	ImportsInformer() maistrainformersfederationv1.ImportedServiceSetInformer
@@ -54,12 +59,20 @@ func NewResourceManager(opts ControllerOptions, mrc memberroll.MemberRollControl
 		mcs:  opts.MaistraCS,
 		kc:   opts.KubeClient,
 		inff: informerFactory,
-		pi:   informerFactory.Federation().V1().ServiceMeshPeers(),
+		cmi:  opts.KubeClient.KubeInformer().Core().V1().ConfigMaps(),
+		esi:  opts.KubeClient.KubeInformer().Discovery().V1().EndpointSlices(),
+		pi:   opts.KubeClient.KubeInformer().Core().V1().Pods(),
+		si:   opts.KubeClient.KubeInformer().Core().V1().Services(),
+		smpi: informerFactory.Federation().V1().ServiceMeshPeers(),
 		sei:  informerFactory.Federation().V1().ExportedServiceSets(),
 		sii:  informerFactory.Federation().V1().ImportedServiceSets(),
 	}
 	// create the informers now, so they're registered with the factory
+	rm.cmi.Informer()
+	rm.esi.Informer()
 	rm.pi.Informer()
+	rm.si.Informer()
+	rm.smpi.Informer()
 	rm.sei.Informer()
 	rm.sii.Informer()
 	return rm, nil
@@ -69,7 +82,11 @@ type resourceManager struct {
 	mcs  maistraclient.Interface
 	kc   kube.Client
 	inff maistraxnsinformer.SharedInformerFactory
-	pi   maistrainformersfederationv1.ServiceMeshPeerInformer
+	cmi  coreinformersv1.ConfigMapInformer
+	esi  discoveryinformersv1.EndpointSliceInformer
+	pi   coreinformersv1.PodInformer
+	si   coreinformersv1.ServiceInformer
+	smpi maistrainformersfederationv1.ServiceMeshPeerInformer
 	sei  maistrainformersfederationv1.ExportedServiceSetInformer
 	sii  maistrainformersfederationv1.ImportedServiceSetInformer
 }
@@ -80,24 +97,42 @@ func (rm *resourceManager) MaistraClientSet() maistraclient.Interface {
 	return rm.mcs
 }
 
-func (rm *resourceManager) KubeClient() kube.Client {
-	return rm.kc
-}
-
 func (rm *resourceManager) Start(stopCh <-chan struct{}) {
 	rm.inff.Start(stopCh)
 }
 
 func (rm *resourceManager) HasSynced() bool {
-	return rm.pi.Informer().HasSynced() && rm.sei.Informer().HasSynced() && rm.sii.Informer().HasSynced()
+	return rm.cmi.Informer().HasSynced() &&
+		rm.esi.Informer().HasSynced() &&
+		rm.pi.Informer().HasSynced() &&
+		rm.si.Informer().HasSynced() &&
+		rm.smpi.Informer().HasSynced() &&
+		rm.sei.Informer().HasSynced() &&
+		rm.sii.Informer().HasSynced()
 }
 
 func (rm *resourceManager) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	return rm.inff.WaitForCacheSync(stopCh)
 }
 
-func (rm *resourceManager) PeerInformer() maistrainformersfederationv1.ServiceMeshPeerInformer {
+func (rm *resourceManager) ConfigMapInformer() coreinformersv1.ConfigMapInformer {
+	return rm.cmi
+}
+
+func (rm *resourceManager) EndpointSliceInformer() discoveryinformersv1.EndpointSliceInformer {
+	return rm.esi
+}
+
+func (rm *resourceManager) PodInformer() coreinformersv1.PodInformer {
 	return rm.pi
+}
+
+func (rm *resourceManager) ServiceInformer() coreinformersv1.ServiceInformer {
+	return rm.si
+}
+
+func (rm *resourceManager) PeerInformer() maistrainformersfederationv1.ServiceMeshPeerInformer {
+	return rm.smpi
 }
 
 func (rm *resourceManager) ExportsInformer() maistrainformersfederationv1.ExportedServiceSetInformer {

--- a/pkg/servicemesh/federation/discovery/controller.go
+++ b/pkg/servicemesh/federation/discovery/controller.go
@@ -101,6 +101,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       logger,
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 
@@ -114,14 +115,6 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 	for _, registryStopCh := range c.stopChannels {
 		close(registryStopCh)
 	}
-}
-
-func (c *Controller) Start(stopChan <-chan struct{}) {
-	c.Controller.StartController(stopChan, c.HasSynced)
-}
-
-func (c *Controller) HasSynced() bool {
-	return c.Controller.HasSynced() && c.rm.HasSynced()
 }
 
 func (c *Controller) RunInformer(_ <-chan struct{}) {

--- a/pkg/servicemesh/federation/discovery/controller.go
+++ b/pkg/servicemesh/federation/discovery/controller.go
@@ -116,8 +116,12 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 	}
 }
 
+func (c *Controller) Start(stopChan <-chan struct{}) {
+	c.Controller.StartController(stopChan, c.HasSynced)
+}
+
 func (c *Controller) HasSynced() bool {
-	return c.Controller.HasSynced()
+	return c.Controller.HasSynced() && c.rm.KubeClient().KubeInformer().Core().V1().ConfigMaps().Informer().HasSynced()
 }
 
 func (c *Controller) RunInformer(_ <-chan struct{}) {

--- a/pkg/servicemesh/federation/discovery/controller.go
+++ b/pkg/servicemesh/federation/discovery/controller.go
@@ -33,8 +33,8 @@ import (
 	federationregistry "istio.io/istio/pilot/pkg/serviceregistry/federation"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
-	kubecontroller "istio.io/istio/pkg/kube/controller"
 	"istio.io/istio/pkg/servicemesh/federation/common"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 	"istio.io/istio/pkg/servicemesh/federation/server"
 	"istio.io/istio/pkg/servicemesh/federation/status"
 )

--- a/pkg/servicemesh/federation/discovery/controller.go
+++ b/pkg/servicemesh/federation/discovery/controller.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	corev1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	v1 "maistra.io/api/federation/v1"
 
@@ -60,6 +61,7 @@ type Controller struct {
 	localNetwork      string
 	localClusterID    string
 	rm                common.ResourceManager
+	configMapInformer corev1.ConfigMapInformer
 	env               *model.Environment
 	federationManager server.FederationManager
 	statusManager     status.Manager
@@ -88,6 +90,7 @@ func NewController(opt Options) (*Controller, error) {
 		localClusterID:        opt.LocalClusterID,
 		localNetwork:          opt.LocalNetwork,
 		rm:                    opt.ResourceManager,
+		configMapInformer:     opt.ResourceManager.KubeClient().KubeInformer().Core().V1().ConfigMaps(),
 		env:                   opt.Env,
 		sc:                    opt.ServiceController,
 		stopChannels:          make(map[cluster.ID]chan struct{}),
@@ -121,7 +124,7 @@ func (c *Controller) Start(stopChan <-chan struct{}) {
 }
 
 func (c *Controller) HasSynced() bool {
-	return c.Controller.HasSynced() && c.rm.KubeClient().KubeInformer().Core().V1().ConfigMaps().Informer().HasSynced()
+	return c.Controller.HasSynced() && c.configMapInformer.Informer().HasSynced()
 }
 
 func (c *Controller) RunInformer(_ <-chan struct{}) {
@@ -324,7 +327,7 @@ func (c *Controller) getRootCertForMesh(instance *v1.ServiceMeshPeer) (string, e
 	entryKey := common.DefaultFederationRootCertName
 	switch instance.Spec.Security.CertificateChain.Kind {
 	case "", "ConfigMap":
-		cm, err := c.rm.KubeClient().KubeInformer().Core().V1().ConfigMaps().Lister().ConfigMaps(instance.Namespace).Get(name)
+		cm, err := c.configMapInformer.Lister().ConfigMaps(instance.Namespace).Get(name)
 		if err != nil {
 			return "", fmt.Errorf("error getting configmap %s in namespace %s: %v", name, instance.Namespace, err)
 		}

--- a/pkg/servicemesh/federation/discovery/controller_test.go
+++ b/pkg/servicemesh/federation/discovery/controller_test.go
@@ -23,6 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
+	discoveryinformersv1 "k8s.io/client-go/informers/discovery/v1"
 	"k8s.io/client-go/tools/cache"
 	maistrainformersfederationv1 "maistra.io/api/client/informers/externalversions/federation/v1"
 	maistraclient "maistra.io/api/client/versioned"
@@ -80,7 +82,19 @@ func (m *fakeResourceManager) MaistraClientSet() maistraclient.Interface {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *fakeResourceManager) KubeClient() kube.Client {
+func (m *fakeResourceManager) ConfigMapInformer() coreinformersv1.ConfigMapInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) EndpointSliceInformer() discoveryinformersv1.EndpointSliceInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) PodInformer() coreinformersv1.PodInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) ServiceInformer() coreinformersv1.ServiceInformer {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/servicemesh/federation/exports/controller.go
+++ b/pkg/servicemesh/federation/exports/controller.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	v1 "maistra.io/api/federation/v1"
 
-	kubecontroller "istio.io/istio/pkg/kube/controller"
 	"istio.io/istio/pkg/servicemesh/federation/common"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 )
 
 const controllerName = "federation-exports-controller"

--- a/pkg/servicemesh/federation/exports/controller.go
+++ b/pkg/servicemesh/federation/exports/controller.go
@@ -60,6 +60,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       common.Logger.WithLabels("component", controllerName),
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 
@@ -68,14 +69,6 @@ func NewController(opt Options) (*Controller, error) {
 
 func (c *Controller) RunInformer(stopChan <-chan struct{}) {
 	// no-op, informer is started by the shared factory in Federation.Start()
-}
-
-func (c *Controller) Start(stopChan <-chan struct{}) {
-	c.Controller.StartController(stopChan, c.HasSynced)
-}
-
-func (c *Controller) HasSynced() bool {
-	return c.Controller.HasSynced() && c.rm.HasSynced()
 }
 
 func (c *Controller) reconcile(resourceName string) error {

--- a/pkg/servicemesh/federation/exports/controller.go
+++ b/pkg/servicemesh/federation/exports/controller.go
@@ -70,6 +70,14 @@ func (c *Controller) RunInformer(stopChan <-chan struct{}) {
 	// no-op, informer is started by the shared factory in Federation.Start()
 }
 
+func (c *Controller) Start(stopChan <-chan struct{}) {
+	c.Controller.StartController(stopChan, c.HasSynced)
+}
+
+func (c *Controller) HasSynced() bool {
+	return c.Controller.HasSynced() && c.rm.HasSynced()
+}
+
 func (c *Controller) reconcile(resourceName string) error {
 	c.Logger.Debugf("Reconciling ServiceExports %s", resourceName)
 	defer func() {

--- a/pkg/servicemesh/federation/federation.go
+++ b/pkg/servicemesh/federation/federation.go
@@ -72,6 +72,7 @@ type Options struct {
 
 type Federation struct {
 	configStore         model.ConfigStoreController
+	resourceManager     common.ResourceManager
 	server              *server.Server
 	exportController    *exports.Controller
 	importController    *imports.Controller
@@ -152,6 +153,7 @@ func internalNew(opt Options, cs maistraclient.Interface) (*Federation, error) {
 		importController:    importController,
 		discoveryController: discoveryController,
 		leaderElection:      leaderElection,
+		resourceManager:     resourceManager,
 	}
 	return federation, nil
 }
@@ -176,7 +178,7 @@ func (f *Federation) StartControllers(stopCh <-chan struct{}) {
 }
 
 func (f *Federation) HasSynced() bool {
-	return f.importController.HasSynced() && f.exportController.HasSynced() && f.discoveryController.HasSynced()
+	return f.resourceManager.HasSynced()
 }
 
 func (f *Federation) StartServer(stopCh <-chan struct{}) {

--- a/pkg/servicemesh/federation/imports/controller.go
+++ b/pkg/servicemesh/federation/imports/controller.go
@@ -71,6 +71,14 @@ func (c *Controller) RunInformer(stopChan <-chan struct{}) {
 	// no-op, informer is started by the shared factory in Federation.Start()
 }
 
+func (c *Controller) Start(stopChan <-chan struct{}) {
+	c.Controller.StartController(stopChan, c.HasSynced)
+}
+
+func (c *Controller) HasSynced() bool {
+	return c.Controller.HasSynced() && c.rm.HasSynced()
+}
+
 func (c *Controller) reconcile(resourceName string) error {
 	c.Logger.Debugf("Reconciling ServiceImports %s", resourceName)
 	defer func() {

--- a/pkg/servicemesh/federation/imports/controller.go
+++ b/pkg/servicemesh/federation/imports/controller.go
@@ -26,8 +26,8 @@ import (
 
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/federation"
-	kubecontroller "istio.io/istio/pkg/kube/controller"
 	"istio.io/istio/pkg/servicemesh/federation/common"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 )
 
 const controllerName = "federation-imports-controller"

--- a/pkg/servicemesh/federation/imports/controller.go
+++ b/pkg/servicemesh/federation/imports/controller.go
@@ -61,6 +61,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       logger,
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 
@@ -69,14 +70,6 @@ func NewController(opt Options) (*Controller, error) {
 
 func (c *Controller) RunInformer(stopChan <-chan struct{}) {
 	// no-op, informer is started by the shared factory in Federation.Start()
-}
-
-func (c *Controller) Start(stopChan <-chan struct{}) {
-	c.Controller.StartController(stopChan, c.HasSynced)
-}
-
-func (c *Controller) HasSynced() bool {
-	return c.Controller.HasSynced() && c.rm.HasSynced()
 }
 
 func (c *Controller) reconcile(resourceName string) error {

--- a/pkg/servicemesh/federation/kube/controller.go
+++ b/pkg/servicemesh/federation/kube/controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package kube
 
 import (
 	"time"

--- a/pkg/servicemesh/federation/status/handler.go
+++ b/pkg/servicemesh/federation/status/handler.go
@@ -622,7 +622,7 @@ func (h *handler) removeDeadPods(statuses []v1.PodPeerDiscoveryStatus) []v1.PodP
 	for index, status := range statuses {
 		// XXX: this shouldn't be necessary, but patching isn't working correctly
 		if index == 0 || statuses[index].Pod != statuses[index-1].Pod {
-			if _, err := h.manager.rm.KubeClient().KubeInformer().Core().V1().Pods().Lister().Pods(h.manager.name.Namespace).Get(status.Pod); err == nil {
+			if _, err := h.manager.rm.PodInformer().Lister().Pods(h.manager.name.Namespace).Get(status.Pod); err == nil {
 				filteredStatuses = append(filteredStatuses, status)
 			}
 		}


### PR DESCRIPTION
Federation discovery controller fetches config map with a remote CA root cert, so if the controller started before the informer has synced, it would fail to fetch the config map.

Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>