### PR TITLE
OSSM-2376: Move kube controller to the federation package

### DIFF
--- a/pkg/servicemesh/federation/discovery/controller.go
+++ b/pkg/servicemesh/federation/discovery/controller.go
@@ -34,9 +34,9 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/servicemesh/federation/common"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 	"istio.io/istio/pkg/servicemesh/federation/server"
 	"istio.io/istio/pkg/servicemesh/federation/status"
-	kubecontroller "istio.io/istio/pkg/servicemesh/kube/controller/controller"
 )
 
 const controllerName = "federation-discovery-controller"

--- a/pkg/servicemesh/federation/exports/controller.go
+++ b/pkg/servicemesh/federation/exports/controller.go
@@ -24,7 +24,7 @@ import (
 	v1 "maistra.io/api/federation/v1"
 
 	"istio.io/istio/pkg/servicemesh/federation/common"
-	kubecontroller "istio.io/istio/pkg/servicemesh/kube/controller/controller"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 )
 
 const controllerName = "federation-exports-controller"

--- a/pkg/servicemesh/federation/imports/controller.go
+++ b/pkg/servicemesh/federation/imports/controller.go
@@ -27,7 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/federation"
 	"istio.io/istio/pkg/servicemesh/federation/common"
-	kubecontroller "istio.io/istio/pkg/servicemesh/kube/controller/controller"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 )
 
 const controllerName = "federation-imports-controller"

--- a/pkg/servicemesh/federation/kube/controller.go
+++ b/pkg/servicemesh/federation/kube/controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package kube
 
 import (
 	"time"


### PR DESCRIPTION
It's a follow-up to #717.