### PR TITLE
OSSM-2376: Don't start federation controllers until informers have synced (#717)

### DIFF
--- a/pkg/servicemesh/federation/discovery/controller_test.go
+++ b/pkg/servicemesh/federation/discovery/controller_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	maistrainformersfederationv1 "maistra.io/api/client/informers/externalversions/federation/v1"
 	maistraclient "maistra.io/api/client/versioned"
@@ -80,7 +81,19 @@ func (m *fakeResourceManager) MaistraClientSet() maistraclient.Interface {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *fakeResourceManager) KubeClient() kube.Client {
+func (m *fakeResourceManager) ConfigMapInformer() coreinformersv1.ConfigMapInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) EndpointsInformer() coreinformersv1.EndpointsInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) PodInformer() coreinformersv1.PodInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) ServiceInformer() coreinformersv1.ServiceInformer {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/servicemesh/federation/exports/controller.go
+++ b/pkg/servicemesh/federation/exports/controller.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	v1 "maistra.io/api/federation/v1"
 
-	kubecontroller "istio.io/istio/pkg/kube/controller"
 	"istio.io/istio/pkg/servicemesh/federation/common"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 )
 
 const controllerName = "federation-exports-controller"
@@ -63,6 +63,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       logger,
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 

--- a/pkg/servicemesh/federation/federation.go
+++ b/pkg/servicemesh/federation/federation.go
@@ -72,6 +72,7 @@ type Options struct {
 
 type Federation struct {
 	configStore         model.ConfigStoreCache
+	resourceManager     common.ResourceManager
 	server              *server.Server
 	exportController    *exports.Controller
 	importController    *imports.Controller
@@ -152,6 +153,7 @@ func internalNew(opt Options, cs maistraclient.Interface) (*Federation, error) {
 		importController:    importController,
 		discoveryController: discoveryController,
 		leaderElection:      leaderElection,
+		resourceManager:     resourceManager,
 	}
 	return federation, nil
 }
@@ -176,7 +178,7 @@ func (f *Federation) StartControllers(stopCh <-chan struct{}) {
 }
 
 func (f *Federation) HasSynced() bool {
-	return f.importController.HasSynced() && f.exportController.HasSynced() && f.discoveryController.HasSynced()
+	return f.resourceManager.HasSynced()
 }
 
 func (f *Federation) StartServer(stopCh <-chan struct{}) {

--- a/pkg/servicemesh/federation/imports/controller.go
+++ b/pkg/servicemesh/federation/imports/controller.go
@@ -26,8 +26,8 @@ import (
 
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/federation"
-	kubecontroller "istio.io/istio/pkg/kube/controller"
 	"istio.io/istio/pkg/servicemesh/federation/common"
+	kubecontroller "istio.io/istio/pkg/servicemesh/federation/kube"
 )
 
 const controllerName = "federation-imports-controller"
@@ -61,6 +61,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       logger,
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 

--- a/pkg/servicemesh/federation/status/handler.go
+++ b/pkg/servicemesh/federation/status/handler.go
@@ -622,7 +622,7 @@ func (h *handler) removeDeadPods(statuses []v1.PodPeerDiscoveryStatus) []v1.PodP
 	for index, status := range statuses {
 		// XXX: this shouldn't be necessary, but patching isn't working correctly
 		if index == 0 || statuses[index].Pod != statuses[index-1].Pod {
-			if _, err := h.manager.rm.KubeClient().KubeInformer().Core().V1().Pods().Lister().Pods(h.manager.name.Namespace).Get(status.Pod); err == nil {
+			if _, err := h.manager.rm.PodInformer().Lister().Pods(h.manager.name.Namespace).Get(status.Pod); err == nil {
 				filteredStatuses = append(filteredStatuses, status)
 			}
 		}


### PR DESCRIPTION
This is a manual cherry-pick of #717, because an automated one has failed.

This PR slightly differs from the original, because in maistra-2.2 federation controller uses Endpoints instead of EndpointSlices.