### PR TITLE
OSSM-2376: Don't start federation controllers until informers have synced (#717)

### DIFF
--- a/pkg/servicemesh/federation/common/resources.go
+++ b/pkg/servicemesh/federation/common/resources.go
@@ -17,6 +17,8 @@ package common
 import (
 	"reflect"
 
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
+	discoveryinformersv1 "k8s.io/client-go/informers/discovery/v1"
 	maistrainformersfederationv1 "maistra.io/api/client/informers/externalversions/federation/v1"
 	maistraclient "maistra.io/api/client/versioned"
 	maistraxnsinformer "maistra.io/api/client/xnsinformer"
@@ -27,7 +29,10 @@ import (
 
 type ResourceManager interface {
 	MaistraClientSet() maistraclient.Interface
-	KubeClient() kube.Client
+	ConfigMapInformer() coreinformersv1.ConfigMapInformer
+	EndpointSliceInformer() discoveryinformersv1.EndpointSliceInformer
+	PodInformer() coreinformersv1.PodInformer
+	ServiceInformer() coreinformersv1.ServiceInformer
 	PeerInformer() maistrainformersfederationv1.ServiceMeshPeerInformer
 	ExportsInformer() maistrainformersfederationv1.ExportedServiceSetInformer
 	ImportsInformer() maistrainformersfederationv1.ImportedServiceSetInformer
@@ -54,12 +59,20 @@ func NewResourceManager(opts ControllerOptions, mrc memberroll.MemberRollControl
 		mcs:  opts.MaistraCS,
 		kc:   opts.KubeClient,
 		inff: informerFactory,
-		pi:   informerFactory.Federation().V1().ServiceMeshPeers(),
+		cmi:  opts.KubeClient.KubeInformer().Core().V1().ConfigMaps(),
+		esi:  opts.KubeClient.KubeInformer().Discovery().V1().EndpointSlices(),
+		pi:   opts.KubeClient.KubeInformer().Core().V1().Pods(),
+		si:   opts.KubeClient.KubeInformer().Core().V1().Services(),
+		smpi: informerFactory.Federation().V1().ServiceMeshPeers(),
 		sei:  informerFactory.Federation().V1().ExportedServiceSets(),
 		sii:  informerFactory.Federation().V1().ImportedServiceSets(),
 	}
 	// create the informers now, so they're registered with the factory
+	rm.cmi.Informer()
+	rm.esi.Informer()
 	rm.pi.Informer()
+	rm.si.Informer()
+	rm.smpi.Informer()
 	rm.sei.Informer()
 	rm.sii.Informer()
 	return rm, nil
@@ -69,7 +82,11 @@ type resourceManager struct {
 	mcs  maistraclient.Interface
 	kc   kube.Client
 	inff maistraxnsinformer.SharedInformerFactory
-	pi   maistrainformersfederationv1.ServiceMeshPeerInformer
+	cmi  coreinformersv1.ConfigMapInformer
+	esi  discoveryinformersv1.EndpointSliceInformer
+	pi   coreinformersv1.PodInformer
+	si   coreinformersv1.ServiceInformer
+	smpi maistrainformersfederationv1.ServiceMeshPeerInformer
 	sei  maistrainformersfederationv1.ExportedServiceSetInformer
 	sii  maistrainformersfederationv1.ImportedServiceSetInformer
 }
@@ -80,24 +97,42 @@ func (rm *resourceManager) MaistraClientSet() maistraclient.Interface {
 	return rm.mcs
 }
 
-func (rm *resourceManager) KubeClient() kube.Client {
-	return rm.kc
-}
-
 func (rm *resourceManager) Start(stopCh <-chan struct{}) {
 	rm.inff.Start(stopCh)
 }
 
 func (rm *resourceManager) HasSynced() bool {
-	return rm.pi.Informer().HasSynced() && rm.sei.Informer().HasSynced() && rm.sii.Informer().HasSynced()
+	return rm.cmi.Informer().HasSynced() &&
+		rm.esi.Informer().HasSynced() &&
+		rm.pi.Informer().HasSynced() &&
+		rm.si.Informer().HasSynced() &&
+		rm.smpi.Informer().HasSynced() &&
+		rm.sei.Informer().HasSynced() &&
+		rm.sii.Informer().HasSynced()
 }
 
 func (rm *resourceManager) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
 	return rm.inff.WaitForCacheSync(stopCh)
 }
 
-func (rm *resourceManager) PeerInformer() maistrainformersfederationv1.ServiceMeshPeerInformer {
+func (rm *resourceManager) ConfigMapInformer() coreinformersv1.ConfigMapInformer {
+	return rm.cmi
+}
+
+func (rm *resourceManager) EndpointSliceInformer() discoveryinformersv1.EndpointSliceInformer {
+	return rm.esi
+}
+
+func (rm *resourceManager) PodInformer() coreinformersv1.PodInformer {
 	return rm.pi
+}
+
+func (rm *resourceManager) ServiceInformer() coreinformersv1.ServiceInformer {
+	return rm.si
+}
+
+func (rm *resourceManager) PeerInformer() maistrainformersfederationv1.ServiceMeshPeerInformer {
+	return rm.smpi
 }
 
 func (rm *resourceManager) ExportsInformer() maistrainformersfederationv1.ExportedServiceSetInformer {

--- a/pkg/servicemesh/federation/discovery/controller.go
+++ b/pkg/servicemesh/federation/discovery/controller.go
@@ -101,6 +101,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       logger,
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 
@@ -114,10 +115,6 @@ func (c *Controller) Run(stopChan <-chan struct{}) {
 	for _, registryStopCh := range c.stopChannels {
 		close(registryStopCh)
 	}
-}
-
-func (c *Controller) HasSynced() bool {
-	return c.Controller.HasSynced()
 }
 
 func (c *Controller) RunInformer(_ <-chan struct{}) {
@@ -211,16 +208,16 @@ func (c *Controller) update(ctx context.Context, instance *v1.ServiceMeshPeer) e
 		c.Logger.Infof("initializing Federation service registry for %q at %s", instance.Name, instance.Spec.Remote.Addresses)
 		// create a registry instance
 		options := federationregistry.Options{
-			KubeClient:     c.rm.KubeClient(),
-			ConfigStore:    c.ConfigStoreController,
-			StatusHandler:  statusHandler,
-			XDSUpdater:     c.xds,
-			ResyncPeriod:   time.Minute * 5,
-			DomainSuffix:   c.env.DomainSuffix,
-			LocalClusterID: c.localClusterID,
-			LocalNetwork:   c.localNetwork,
-			ClusterID:      instance.Name,
-			Network:        fmt.Sprintf("network-%s", instance.Name),
+			ResourceManager: c.rm,
+			ConfigStore:     c.ConfigStoreController,
+			StatusHandler:   statusHandler,
+			XDSUpdater:      c.xds,
+			ResyncPeriod:    time.Minute * 5,
+			DomainSuffix:    c.env.DomainSuffix,
+			LocalClusterID:  c.localClusterID,
+			LocalNetwork:    c.localNetwork,
+			ClusterID:       instance.Name,
+			Network:         fmt.Sprintf("network-%s", instance.Name),
 		}
 		registry = federationregistry.NewController(options, instance, importConfig)
 		// register the new instance
@@ -320,7 +317,7 @@ func (c *Controller) getRootCertForMesh(instance *v1.ServiceMeshPeer) (string, e
 	entryKey := common.DefaultFederationRootCertName
 	switch instance.Spec.Security.CertificateChain.Kind {
 	case "", "ConfigMap":
-		cm, err := c.rm.KubeClient().KubeInformer().Core().V1().ConfigMaps().Lister().ConfigMaps(instance.Namespace).Get(name)
+		cm, err := c.rm.ConfigMapInformer().Lister().ConfigMaps(instance.Namespace).Get(name)
 		if err != nil {
 			return "", fmt.Errorf("error getting configmap %s in namespace %s: %v", name, instance.Namespace, err)
 		}

--- a/pkg/servicemesh/federation/discovery/controller_test.go
+++ b/pkg/servicemesh/federation/discovery/controller_test.go
@@ -23,6 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
+	discoveryinformersv1 "k8s.io/client-go/informers/discovery/v1"
 	"k8s.io/client-go/tools/cache"
 	maistrainformersfederationv1 "maistra.io/api/client/informers/externalversions/federation/v1"
 	maistraclient "maistra.io/api/client/versioned"
@@ -80,7 +82,19 @@ func (m *fakeResourceManager) MaistraClientSet() maistraclient.Interface {
 	panic("not implemented") // TODO: Implement
 }
 
-func (m *fakeResourceManager) KubeClient() kube.Client {
+func (m *fakeResourceManager) ConfigMapInformer() coreinformersv1.ConfigMapInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) EndpointSliceInformer() discoveryinformersv1.EndpointSliceInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) PodInformer() coreinformersv1.PodInformer {
+	panic("not implemented") // TODO: Implement
+}
+
+func (m *fakeResourceManager) ServiceInformer() coreinformersv1.ServiceInformer {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/pkg/servicemesh/federation/exports/controller.go
+++ b/pkg/servicemesh/federation/exports/controller.go
@@ -60,6 +60,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       common.Logger.WithLabels("component", controllerName),
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 

--- a/pkg/servicemesh/federation/federation.go
+++ b/pkg/servicemesh/federation/federation.go
@@ -72,6 +72,7 @@ type Options struct {
 
 type Federation struct {
 	configStore         model.ConfigStoreController
+	resourceManager     common.ResourceManager
 	server              *server.Server
 	exportController    *exports.Controller
 	importController    *imports.Controller
@@ -152,6 +153,7 @@ func internalNew(opt Options, cs maistraclient.Interface) (*Federation, error) {
 		importController:    importController,
 		discoveryController: discoveryController,
 		leaderElection:      leaderElection,
+		resourceManager:     resourceManager,
 	}
 	return federation, nil
 }
@@ -176,7 +178,7 @@ func (f *Federation) StartControllers(stopCh <-chan struct{}) {
 }
 
 func (f *Federation) HasSynced() bool {
-	return f.importController.HasSynced() && f.exportController.HasSynced() && f.discoveryController.HasSynced()
+	return f.resourceManager.HasSynced()
 }
 
 func (f *Federation) StartServer(stopCh <-chan struct{}) {

--- a/pkg/servicemesh/federation/imports/controller.go
+++ b/pkg/servicemesh/federation/imports/controller.go
@@ -61,6 +61,7 @@ func NewController(opt Options) (*Controller, error) {
 		Logger:       logger,
 		ResyncPeriod: opt.ResyncPeriod,
 		Reconciler:   controller.reconcile,
+		HasSynced:    opt.ResourceManager.HasSynced,
 	})
 	controller.Controller = internalController
 

--- a/pkg/servicemesh/federation/status/handler.go
+++ b/pkg/servicemesh/federation/status/handler.go
@@ -600,7 +600,7 @@ func (h *handler) removeDeadPods(statuses []v1.PodPeerDiscoveryStatus) []v1.PodP
 	for index, status := range statuses {
 		// XXX: this shouldn't be necessary, but patching isn't working correctly
 		if index == 0 || statuses[index].Pod != statuses[index-1].Pod {
-			if _, err := h.manager.rm.KubeClient().KubeInformer().Core().V1().Pods().Lister().Pods(h.manager.name.Namespace).Get(status.Pod); err == nil {
+			if _, err := h.manager.rm.PodInformer().Lister().Pods(h.manager.name.Namespace).Get(status.Pod); err == nil {
 				filteredStatuses = append(filteredStatuses, status)
 			}
 		}


### PR DESCRIPTION
This is a manual cherry-pick of #717, because an automated one has failed for some reason.