### PR TITLE
OSSM-2382 Fix istio-cni issue on RHEL9 (#762)

### DIFF
--- a/cni/pkg/plugin/iptables.go
+++ b/cni/pkg/plugin/iptables.go
@@ -16,13 +16,6 @@
 // parses prevResult according to the cniVersion
 package plugin
 
-import (
-	"istio.io/pkg/env"
-)
-
-var dryRunFilePath = env.RegisterStringVar("DRY_RUN_FILE_PATH", "",
-	"If provided, CNI will dry run iptables rule apply, and print the applied rules to the given file.")
-
 type iptables struct{}
 
 func newIPTables() InterceptRuleMgr {

--- a/cni/pkg/plugin/iptables_linux.go
+++ b/cni/pkg/plugin/iptables_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"istio.io/istio/tools/istio-iptables/pkg/cmd"
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
+	"istio.io/istio/tools/istio-iptables/pkg/dependencies"
 	"istio.io/pkg/log"
 )
 
@@ -47,9 +48,7 @@ func (ipt *iptables) Program(podName, netns string, rdrct *Redirect) error {
 	viper.Set(constants.OutboundPorts, rdrct.includeOutboundPorts)
 	viper.Set(constants.ServiceExcludeCidr, rdrct.excludeIPCidrs)
 	viper.Set(constants.KubeVirtInterfaces, rdrct.kubevirtInterfaces)
-	drf := dryRunFilePath.Get()
-	viper.Set(constants.DryRun, drf != "")
-	viper.Set(constants.OutputPath, drf)
+	viper.Set(constants.DryRun, dependencies.DryRunFilePath.Get() != "")
 	viper.Set(constants.RedirectDNS, rdrct.dnsRedirect)
 	viper.Set(constants.CaptureAllDNS, rdrct.dnsRedirect)
 	viper.Set(constants.DropInvalid, rdrct.invalidDrop)

--- a/cni/pkg/plugin/plugin_dryrun_test.go
+++ b/cni/pkg/plugin/plugin_dryrun_test.go
@@ -37,6 +37,7 @@ import (
 	diff "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tools/istio-iptables/pkg/cmd"
+	"istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
 type k8sPodInfoFunc func(*kubernetes.Clientset, string, string) (*PodInfo, error)
@@ -173,14 +174,14 @@ func TestIPTablesRuleGeneration(t *testing.T) {
 			if _, err := os.Create(outputFilePath); err != nil {
 				t.Fatalf("Failed to create temp file for IPTables rule output: %v", err)
 			}
-			os.Setenv(dryRunFilePath.Name, outputFilePath)
+			os.Setenv(dependencies.DryRunFilePath.Name, outputFilePath)
 			_, _, err := testutils.CmdAddWithArgs(
 				&skel.CmdArgs{
 					Netns:     sandboxDirectory,
 					IfName:    ifname,
 					StdinData: []byte(cniConf),
 				}, func() error { return CmdAdd(args) })
-			os.Unsetenv(dryRunFilePath.Name)
+			os.Unsetenv(dependencies.DryRunFilePath.Name)
 			if err != nil {
 				t.Fatalf("CNI cmdAdd failed with error: %v", err)
 			}

--- a/releasenotes/notes/43945.yaml
+++ b/releasenotes/notes/43945.yaml
@@ -1,0 +1,12 @@
+
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 42485
+
+releaseNotes:
+- |
+  **Fixed** SELinux issue on CentOS9/RHEL9 where iptables-restore isn't allowed
+  to open files in /tmp. Rules passed to iptables-restore are no longer written
+  to a file, but are passed via stdin.

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup.go
@@ -44,17 +44,17 @@ func NewIptablesCleaner(cfg *config.Config, ext dep.Dependencies) *IptablesClean
 
 func flushAndDeleteChains(ext dep.Dependencies, cmd string, table string, chains []string) {
 	for _, chain := range chains {
-		ext.RunQuietlyAndIgnore(cmd, "-t", table, "-F", chain)
-		ext.RunQuietlyAndIgnore(cmd, "-t", table, "-X", chain)
+		ext.RunQuietlyAndIgnore(cmd, nil, "-t", table, "-F", chain)
+		ext.RunQuietlyAndIgnore(cmd, nil, "-t", table, "-X", chain)
 	}
 }
 
 func removeOldChains(cfg *config.Config, ext dep.Dependencies, cmd string) {
 	// Remove the old TCP rules
 	for _, table := range []string{constants.NAT, constants.MANGLE} {
-		ext.RunQuietlyAndIgnore(cmd, "-t", table, "-D", constants.PREROUTING, "-p", constants.TCP, "-j", constants.ISTIOINBOUND)
+		ext.RunQuietlyAndIgnore(cmd, nil, "-t", table, "-D", constants.PREROUTING, "-p", constants.TCP, "-j", constants.ISTIOINBOUND)
 	}
-	ext.RunQuietlyAndIgnore(cmd, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.TCP, "-j", constants.ISTIOOUTPUT)
+	ext.RunQuietlyAndIgnore(cmd, nil, "-t", constants.NAT, "-D", constants.OUTPUT, "-p", constants.TCP, "-j", constants.ISTIOOUTPUT)
 
 	redirectDNS := cfg.RedirectDNS
 	// Remove the old DNS UDP rules
@@ -81,7 +81,7 @@ func (c *IptablesCleaner) Run() {
 	defer func() {
 		for _, cmd := range []string{constants.IPTABLESSAVE, constants.IP6TABLESSAVE} {
 			// iptables-save is best efforts
-			_ = c.ext.Run(cmd)
+			_ = c.ext.Run(cmd, nil)
 		}
 	}()
 

--- a/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
+++ b/tools/istio-clean-iptables/pkg/cmd/cleanup_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -114,16 +115,16 @@ type DependenciesStub struct {
 	ExecutedAll      []string
 }
 
-func (s *DependenciesStub) RunOrFail(cmd string, args ...string) {
+func (s *DependenciesStub) RunOrFail(cmd string, stdin io.ReadSeeker, args ...string) {
 	s.execute(false /*quietly*/, cmd, args...)
 }
 
-func (s *DependenciesStub) Run(cmd string, args ...string) error {
+func (s *DependenciesStub) Run(cmd string, stdin io.ReadSeeker, args ...string) error {
 	s.execute(false /*quietly*/, cmd, args...)
 	return nil
 }
 
-func (s *DependenciesStub) RunQuietlyAndIgnore(cmd string, args ...string) {
+func (s *DependenciesStub) RunQuietlyAndIgnore(cmd string, stdin io.ReadSeeker, args ...string) {
 	s.execute(true /*quietly*/, cmd, args...)
 }
 

--- a/tools/istio-iptables/pkg/capture/run.go
+++ b/tools/istio-iptables/pkg/capture/run.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,10 @@
 package capture
 
 import (
-	"bufio"
 	"fmt"
 	"net"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/vishvananda/netlink"
 
@@ -270,7 +268,7 @@ func ConfigureRoutes(cfg *config.Config, ext dep.Dependencies) error {
 	}
 	if ext != nil && cfg.CNIMode {
 		command := os.Args[0]
-		return ext.Run(command, constants.CommandConfigureRoutes)
+		return ext.Run(command, nil, constants.CommandConfigureRoutes)
 	}
 	if err := configureIPv6Addresses(cfg); err != nil {
 		return err
@@ -311,9 +309,9 @@ func configureIPv6Addresses(cfg *config.Config) error {
 func (cfg *IptablesConfigurator) Run() {
 	defer func() {
 		// Best effort since we don't know if the commands exist
-		_ = cfg.ext.Run(constants.IPTABLESSAVE)
+		_ = cfg.ext.Run(constants.IPTABLESSAVE, nil)
 		if cfg.cfg.EnableInboundIPv6 {
-			_ = cfg.ext.Run(constants.IP6TABLESSAVE)
+			_ = cfg.ext.Run(constants.IP6TABLESSAVE, nil)
 		}
 	}()
 
@@ -583,7 +581,7 @@ func (f UDPRuleApplier) RunV4(args ...string) {
 	case DeleteOps:
 		deleteArgs := []string{"-t", f.table, opsToString[f.ops], f.chain}
 		deleteArgs = append(deleteArgs, args...)
-		f.ext.RunQuietlyAndIgnore(f.cmd, deleteArgs...)
+		f.ext.RunQuietlyAndIgnore(f.cmd, nil, deleteArgs...)
 	}
 }
 
@@ -594,7 +592,7 @@ func (f UDPRuleApplier) RunV6(args ...string) {
 	case DeleteOps:
 		deleteArgs := []string{"-t", f.table, opsToString[f.ops], f.chain}
 		deleteArgs = append(deleteArgs, args...)
-		f.ext.RunQuietlyAndIgnore(f.cmd, deleteArgs...)
+		f.ext.RunQuietlyAndIgnore(f.cmd, nil, deleteArgs...)
 	}
 }
 
@@ -747,77 +745,37 @@ func (cfg *IptablesConfigurator) handleCaptureByOwnerGroup(filter config.Interce
 	}
 }
 
-func (cfg *IptablesConfigurator) createRulesFile(f *os.File, contents string) error {
-	defer f.Close()
-	log.Infof("Writing following contents to rules file: %v\n%v", f.Name(), strings.TrimSpace(contents))
-	writer := bufio.NewWriter(f)
-	_, err := writer.WriteString(contents)
-	if err != nil {
-		return fmt.Errorf("unable to write iptables-restore file: %v", err)
-	}
-	err = writer.Flush()
-	return err
-}
-
 func (cfg *IptablesConfigurator) executeIptablesCommands(commands [][]string) {
 	for _, cmd := range commands {
 		if len(cmd) > 1 {
-			cfg.ext.RunOrFail(cmd[0], cmd[1:]...)
+			cfg.ext.RunOrFail(cmd[0], nil, cmd[1:]...)
 		} else {
-			cfg.ext.RunOrFail(cmd[0])
+			cfg.ext.RunOrFail(cmd[0], nil)
 		}
 	}
 }
 
-func (cfg *IptablesConfigurator) executeIptablesRestoreCommand(isIpv4 bool) error {
-	var data, filename, cmd string
+func (cfg *IptablesConfigurator) executeIptablesRestoreCommand(isIpv4 bool) {
+	var data, cmd string
 	if isIpv4 {
 		data = cfg.iptables.BuildV4Restore()
-		filename = fmt.Sprintf("iptables-rules-%d.txt", time.Now().UnixNano())
 		cmd = constants.IPTABLESRESTORE
 	} else {
 		data = cfg.iptables.BuildV6Restore()
-		filename = fmt.Sprintf("ip6tables-rules-%d.txt", time.Now().UnixNano())
 		cmd = constants.IP6TABLESRESTORE
 	}
-	var rulesFile *os.File
-	var err error
-	if cfg.cfg.OutputPath != "" {
-		// Print the iptables rules into the given output file.
-		rulesFile, err = os.OpenFile(cfg.cfg.OutputPath, os.O_CREATE|os.O_WRONLY, 0o644)
-		if err != nil {
-			return fmt.Errorf("unable to open iptables rules output file %v: %v", cfg.cfg.OutputPath, err)
-		}
-	} else {
-		// Otherwise create a temporary file to write iptables rules to, which will be cleaned up at the end.
-		rulesFile, err = os.CreateTemp("", filename)
-		if err != nil {
-			return fmt.Errorf("unable to create iptables-restore file: %v", err)
-		}
-		defer os.Remove(rulesFile.Name())
-	}
-	if err := cfg.createRulesFile(rulesFile, data); err != nil {
-		return err
-	}
+
+	log.Infof("Running %s with the following input:\n%v", cmd, strings.TrimSpace(data))
 	// --noflush to prevent flushing/deleting previous contents from table
-	cfg.ext.RunOrFail(cmd, "--noflush", rulesFile.Name())
-	return nil
+	cfg.ext.RunOrFail(cmd, strings.NewReader(data), "--noflush")
 }
 
 func (cfg *IptablesConfigurator) executeCommands() {
 	if cfg.cfg.RestoreFormat {
 		// Execute iptables-restore
-		err := cfg.executeIptablesRestoreCommand(true)
-		if err != nil {
-			log.Errorf("Failed to execute iptables-restore command: %v", err)
-			os.Exit(1)
-		}
+		cfg.executeIptablesRestoreCommand(true)
 		// Execute ip6tables-restore
-		err = cfg.executeIptablesRestoreCommand(false)
-		if err != nil {
-			log.Errorf("Failed to execute iptables-restore command: %v", err)
-			os.Exit(1)
-		}
+		cfg.executeIptablesRestoreCommand(false)
 	} else {
 		// Execute iptables commands
 		cfg.executeIptablesCommands(cfg.iptables.BuildV4())

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -139,7 +139,6 @@ func constructConfig() *config.Config {
 		RedirectDNS:             viper.GetBool(constants.RedirectDNS),
 		DropInvalid:             viper.GetBool(constants.DropInvalid),
 		CaptureAllDNS:           viper.GetBool(constants.CaptureAllDNS),
-		OutputPath:              viper.GetString(constants.OutputPath),
 		NetworkNamespace:        viper.GetString(constants.NetworkNamespace),
 		CNIMode:                 viper.GetBool(constants.CNIMode),
 	}
@@ -358,11 +357,6 @@ func bindFlags(cmd *cobra.Command, args []string) {
 	}
 	viper.SetDefault(constants.CaptureAllDNS, false)
 
-	if err := viper.BindPFlag(constants.OutputPath, cmd.Flags().Lookup(constants.OutputPath)); err != nil {
-		handleError(err)
-	}
-	viper.SetDefault(constants.OutputPath, "")
-
 	if err := viper.BindPFlag(constants.NetworkNamespace, cmd.Flags().Lookup(constants.NetworkNamespace)); err != nil {
 		handleError(err)
 	}
@@ -452,8 +446,6 @@ func bindCmdlineFlags(rootCmd *cobra.Command) {
 
 	rootCmd.Flags().Bool(constants.CaptureAllDNS, false,
 		"Instead of only capturing DNS traffic to DNS server IP, capture all DNS traffic at port 53. This setting is only effective when redirect dns is enabled.")
-
-	rootCmd.Flags().String(constants.OutputPath, "", "A file path to write the applied iptables rules to.")
 
 	rootCmd.Flags().String(constants.NetworkNamespace, "", "The network namespace that iptables rules should be applied to.")
 

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -57,7 +57,6 @@ type Config struct {
 	EnableInboundIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
 	DNSServersV4            []string      `json:"DNS_SERVERS_V4"`
 	DNSServersV6            []string      `json:"DNS_SERVERS_V6"`
-	OutputPath              string        `json:"OUTPUT_PATH"`
 	NetworkNamespace        string        `json:"NETWORK_NAMESPACE"`
 	CNIMode                 bool          `json:"CNI_MODE"`
 	TraceLogging            bool          `json:"IPTABLES_TRACE_LOGGING"`
@@ -95,7 +94,6 @@ func (c *Config) Print() {
 	b.WriteString(fmt.Sprintf("DROP_INVALID=%t\n", c.DropInvalid))
 	b.WriteString(fmt.Sprintf("CAPTURE_ALL_DNS=%t\n", c.CaptureAllDNS))
 	b.WriteString(fmt.Sprintf("DNS_SERVERS=%s,%s\n", c.DNSServersV4, c.DNSServersV6))
-	b.WriteString(fmt.Sprintf("OUTPUT_PATH=%s\n", c.OutputPath))
 	b.WriteString(fmt.Sprintf("NETWORK_NAMESPACE=%s\n", c.NetworkNamespace))
 	b.WriteString(fmt.Sprintf("CNI_MODE=%s\n", strconv.FormatBool(c.CNIMode)))
 	b.WriteString(fmt.Sprintf("EXCLUDE_INTERFACES=%s\n", c.ExcludeInterfaces))

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -105,7 +105,6 @@ const (
 	RedirectDNS               = "redirect-dns"
 	DropInvalid               = "drop-invalid"
 	CaptureAllDNS             = "capture-all-dns"
-	OutputPath                = "output-paths"
 	NetworkNamespace          = "network-namespace"
 	CNIMode                   = "cni-mode"
 )

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -17,6 +17,7 @@ package dependencies
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -70,7 +71,7 @@ type RealDependencies struct {
 	CNIMode          bool
 }
 
-func (r *RealDependencies) execute(cmd string, ignoreErrors bool, args ...string) error {
+func (r *RealDependencies) execute(cmd string, ignoreErrors bool, stdin io.Reader, args ...string) error {
 	if r.CNIMode {
 		originalCmd := cmd
 		cmd = constants.NSENTER
@@ -82,6 +83,7 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, args ...string
 	stderr := &bytes.Buffer{}
 	externalCommand.Stdout = stdout
 	externalCommand.Stderr = stderr
+	externalCommand.Stdin = stdin
 
 	// Grab all viper config and propagate it as environment variables to the child process
 	repl := strings.NewReplacer("-", "_")
@@ -106,7 +108,7 @@ func (r *RealDependencies) execute(cmd string, ignoreErrors bool, args ...string
 	return err
 }
 
-func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, args ...string) error {
+func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, stdin io.ReadSeeker, args ...string) error {
 	if r.CNIMode {
 		originalCmd := cmd
 		cmd = constants.NSENTER
@@ -127,6 +129,12 @@ func (r *RealDependencies) executeXTables(cmd string, ignoreErrors bool, args ..
 		stderr = &bytes.Buffer{}
 		externalCommand.Stdout = stdout
 		externalCommand.Stderr = stderr
+		externalCommand.Stdin = stdin
+		if stdin != nil {
+			if _, err := stdin.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+		}
 		err = externalCommand.Run()
 		exitCode, ok := exitCode(err)
 		if !ok {
@@ -228,12 +236,12 @@ func exitCode(err error) (int, bool) {
 }
 
 // RunOrFail runs a command and exits with an error message, if it fails
-func (r *RealDependencies) RunOrFail(cmd string, args ...string) {
+func (r *RealDependencies) RunOrFail(cmd string, stdin io.ReadSeeker, args ...string) {
 	var err error
 	if XTablesCmds.Contains(cmd) {
-		err = r.executeXTables(cmd, false, args...)
+		err = r.executeXTables(cmd, false, stdin, args...)
 	} else {
-		err = r.execute(cmd, false, args...)
+		err = r.execute(cmd, false, stdin, args...)
 	}
 	if err != nil {
 		log.Errorf("Failed to execute: %s %s, %v", cmd, strings.Join(args, " "), err)
@@ -242,20 +250,20 @@ func (r *RealDependencies) RunOrFail(cmd string, args ...string) {
 }
 
 // Run runs a command
-func (r *RealDependencies) Run(cmd string, args ...string) (err error) {
+func (r *RealDependencies) Run(cmd string, stdin io.ReadSeeker, args ...string) (err error) {
 	if XTablesCmds.Contains(cmd) {
-		err = r.executeXTables(cmd, false, args...)
+		err = r.executeXTables(cmd, false, stdin, args...)
 	} else {
-		err = r.execute(cmd, false, args...)
+		err = r.execute(cmd, false, stdin, args...)
 	}
 	return err
 }
 
 // RunQuietlyAndIgnore runs a command quietly and ignores errors
-func (r *RealDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
+func (r *RealDependencies) RunQuietlyAndIgnore(cmd string, stdin io.ReadSeeker, args ...string) {
 	if XTablesCmds.Contains(cmd) {
-		_ = r.executeXTables(cmd, true, args...)
+		_ = r.executeXTables(cmd, true, stdin, args...)
 	} else {
-		_ = r.execute(cmd, true, args...)
+		_ = r.execute(cmd, true, stdin, args...)
 	}
 }

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -14,12 +14,14 @@
 
 package dependencies
 
+import "io"
+
 // Dependencies is used as abstraction for the commands used from the operating system
 type Dependencies interface {
-	// RunOrFail runs a command and panics, if it fails
-	RunOrFail(cmd string, args ...string)
+	// RunOrFail runs a command and panics, if it fails. Stdin may be nil.
+	RunOrFail(cmd string, stdin io.ReadSeeker, args ...string)
 	// Run runs a command
-	Run(cmd string, args ...string) error
+	Run(cmd string, stdin io.ReadSeeker, args ...string) error
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors
-	RunQuietlyAndIgnore(cmd string, args ...string)
+	RunQuietlyAndIgnore(cmd string, stdin io.ReadSeeker, args ...string)
 }

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -15,26 +15,48 @@
 package dependencies
 
 import (
+	"fmt"
+	"io"
+	"os"
 	"strings"
 
+	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
+
+var DryRunFilePath = env.RegisterStringVar("DRY_RUN_FILE_PATH", "", "If provided, StdoutStubDependencies will write the input from stdin to the given file.")
 
 // StdoutStubDependencies implementation of interface Dependencies, which is used for testing
 type StdoutStubDependencies struct{}
 
 // RunOrFail runs a command and panics, if it fails
-func (s *StdoutStubDependencies) RunOrFail(cmd string, args ...string) {
+func (s *StdoutStubDependencies) RunOrFail(cmd string, stdin io.ReadSeeker, args ...string) {
 	log.Infof("%s %s", cmd, strings.Join(args, " "))
+
+	path := DryRunFilePath.Get()
+	if path != "" {
+		// Print the input into the given output file.
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			panic(fmt.Errorf("unable to open dry run output file %v: %v", path, err))
+		}
+
+		defer f.Close()
+		if stdin != nil {
+			if _, err = io.Copy(f, stdin); err != nil {
+				panic(fmt.Errorf("unable to write dry run output file: %v", err))
+			}
+		}
+	}
 }
 
 // Run runs a command
-func (s *StdoutStubDependencies) Run(cmd string, args ...string) error {
-	log.Infof("%s %s", cmd, strings.Join(args, " "))
+func (s *StdoutStubDependencies) Run(cmd string, stdin io.ReadSeeker, args ...string) error {
+	s.RunOrFail(cmd, stdin, args...)
 	return nil
 }
 
 // RunQuietlyAndIgnore runs a command quietly and ignores errors
-func (s *StdoutStubDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
-	log.Infof("%s %s", cmd, strings.Join(args, " "))
+func (s *StdoutStubDependencies) RunQuietlyAndIgnore(cmd string, stdin io.ReadSeeker, args ...string) {
+	s.RunOrFail(cmd, stdin, args...)
 }


### PR DESCRIPTION
* Pass rules to iptables-restore via stdin instead of a file (#43945)

* Pass rules to iptables-restore via stdin instead of a file

This fixes the SELinux issue on RHEL9 where iptables-restore isn't allowed to open files in /tmp.

* Remove OutputPath option from iptables

(cherry picked from commit 64fc19e8e101a7a2e2760dca2521b481b5946d66)

* Fix MacOS build (#43963)

(cherry picked from commit 325fcd90342577483071ccbd22c5d5fd5b38d70b)