### PR TITLE
OSSM-3599 Federation egress-gateway gets wrong network gateway endpoints

### DIFF
--- a/pilot/pkg/serviceregistry/federation/controller.go
+++ b/pilot/pkg/serviceregistry/federation/controller.go
@@ -622,7 +622,7 @@ func (c *Controller) GetService(hostname host.Name) *model.Service {
 func (c *Controller) NetworkGateways() []model.NetworkGateway {
 	c.storeLock.RLock()
 	defer c.storeLock.RUnlock()
-	return c.gatewayStore
+	return nil
 }
 
 func (c *Controller) MCSServices() []model.MCSServiceInfo {

--- a/pilot/pkg/serviceregistry/federation/controller.go
+++ b/pilot/pkg/serviceregistry/federation/controller.go
@@ -479,14 +479,6 @@ func (c *Controller) getImportNameForService(exportedService *model.Service) *fe
 
 func (c *Controller) updateGateways(serviceList *federationmodel.ServiceListMessage) {
 	c.gatewayStore = c.gatewayForNetworkAddress()
-	if serviceList != nil {
-		for _, gateway := range serviceList.NetworkGatewayEndpoints {
-			c.gatewayStore = append(c.gatewayStore, model.NetworkGateway{
-				Addr: gateway.Hostname,
-				Port: uint32(gateway.Port),
-			})
-		}
-	}
 	c.egressGateways, c.egressSAs = c.getEgressServiceAddrs()
 }
 

--- a/pilot/pkg/serviceregistry/federation/controller.go
+++ b/pilot/pkg/serviceregistry/federation/controller.go
@@ -477,7 +477,7 @@ func (c *Controller) getImportNameForService(exportedService *model.Service) *fe
 	return c.importNameMapper.NameForService(exportedService)
 }
 
-func (c *Controller) updateGateways(serviceList *federationmodel.ServiceListMessage) {
+func (c *Controller) updateGateways() {
 	c.gatewayStore = c.gatewayForNetworkAddress()
 	c.egressGateways, c.egressSAs = c.getEgressServiceAddrs()
 }
@@ -1080,7 +1080,7 @@ func (c *Controller) resync() uint64 {
 		c.logger.Warnf("resync failed: %s", err)
 		return 0
 	}
-	c.updateGateways(svcList)
+	c.updateGateways()
 	if svcList != nil {
 		c.convertServices(svcList)
 		c.statusHandler.FullSyncComplete()

--- a/pkg/servicemesh/federation/model/model.go
+++ b/pkg/servicemesh/federation/model/model.go
@@ -23,9 +23,8 @@ type ServiceKey struct {
 }
 
 type ServiceListMessage struct {
-	Checksum                uint64             `json:"checksum" hash:"ignore"`
-	NetworkGatewayEndpoints []*ServiceEndpoint `json:"networkGatewayEndpoints,omitempty" hash:"set"`
-	Services                []*ServiceMessage  `json:"services,omitempty" hash:"set"`
+	Checksum uint64            `json:"checksum" hash:"ignore"`
+	Services []*ServiceMessage `json:"services,omitempty" hash:"set"`
 }
 
 type ServiceMessage struct {

--- a/pkg/servicemesh/federation/server/server.go
+++ b/pkg/servicemesh/federation/server/server.go
@@ -231,16 +231,6 @@ func (s *Server) Run(stopCh <-chan struct{}) {
 }
 
 func (s *Server) UpdateService(svc *model.Service, event model.Event) {
-	// this might be a NetworkGateway
-	if svc != nil {
-		s.meshes.Range(func(_, value interface{}) bool {
-			value.(*meshServer).pushWatchEvent(&federationmodel.WatchEvent{
-				Action:  federationmodel.ActionUpdate,
-				Service: nil,
-			})
-			return true
-		})
-	}
 	s.meshes.Range(func(_, value interface{}) bool {
 		value.(*meshServer).serviceUpdated(svc, event)
 		return true

--- a/pkg/servicemesh/federation/server/server_test.go
+++ b/pkg/servicemesh/federation/server/server_test.go
@@ -579,7 +579,6 @@ func TestServiceList(t *testing.T) {
 			stopCh := make(chan struct{})
 			go s.Run(stopCh)
 			defer close(stopCh)
-			s.resyncNetworkGateways()
 			s.AddPeer(federation, tc.serviceExports, &common.FakeStatusHandler{})
 			for _, e := range tc.serviceEvents {
 				s.UpdateService(e.svc, e.event)
@@ -957,7 +956,6 @@ func TestWatch(t *testing.T) {
 			stopCh := make(chan struct{})
 			go s.Run(stopCh)
 			defer close(stopCh)
-			s.resyncNetworkGateways()
 			s.AddPeer(federation, tc.serviceExports, &common.FakeStatusHandler{})
 			req, err := http.NewRequest("GET", "https://"+s.Addr()+"/v1/watch/"+tc.remoteName, nil)
 			if err != nil {

--- a/pkg/servicemesh/federation/server/server_test.go
+++ b/pkg/servicemesh/federation/server/server_test.go
@@ -242,12 +242,6 @@ func TestServiceList(t *testing.T) {
 				},
 			},
 			expectedMessage: federationmodel.ServiceListMessage{
-				NetworkGatewayEndpoints: []*federationmodel.ServiceEndpoint{
-					{
-						Port:     8080,
-						Hostname: "127.0.0.1",
-					},
-				},
 				Services: []*federationmodel.ServiceMessage{
 					{
 						ServiceKey: federationmodel.ServiceKey{
@@ -329,12 +323,6 @@ func TestServiceList(t *testing.T) {
 				},
 			},
 			expectedMessage: federationmodel.ServiceListMessage{
-				NetworkGatewayEndpoints: []*federationmodel.ServiceEndpoint{
-					{
-						Port:     8080,
-						Hostname: "127.0.0.1",
-					},
-				},
 				Services: []*federationmodel.ServiceMessage{
 					{
 						ServiceKey: federationmodel.ServiceKey{
@@ -891,12 +879,7 @@ func TestWatch(t *testing.T) {
 					},
 				},
 			},
-			expectedWatchEvents: []*federationmodel.WatchEvent{
-				{
-					Action:  federationmodel.ActionUpdate,
-					Service: nil,
-				},
-			},
+			expectedWatchEvents: nil,
 		},
 		{
 			name:           "service export removed",


### PR DESCRIPTION
**Please provide a description of this PR:**
It would remove the adding of extra endpoints (IPs from the local ingress) in the egress gateway


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
