### PR TITLE
OSSM-3703: Fix AUTO_RELOAD_PLUGIN_CERTS in multi-tenant mode

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -144,13 +144,12 @@ func (nc *NamespaceController) startCaBundleWatcher(stop <-chan struct{}) {
 	for {
 		select {
 		case <-watchCh:
-			var namespaceList []*v1.Namespace
 			if nc.usesMemberRollController {
 				for _, ns := range nc.namespaces.List() {
 					nc.syncNamespaceByName(ns)
 				}
 			} else {
-				namespaceList, _ = nc.namespaceLister.List(labels.Everything())
+				namespaceList, _ := nc.namespaceLister.List(labels.Everything())
 				for _, ns := range namespaceList {
 					nc.namespaceChange(ns)
 				}


### PR DESCRIPTION
Namespace controller crashes on secret update, because uninitialized namespace lister is called. In cluster-scoped deployment this failure should not happen, because initializing of the namespace lister is skipped only when SMMR controller is enabled.

```
2023-04-05T17:13:53.643387Z	info	ads	XDS: Incremental Pushing:2023-04-05T17:11:50Z/2 ConnectedEndpoints:3 Version:2023-04-05T17:11:50Z/2
2023-04-05T17:13:53.820263Z	info	ads	Push debounce stable[4] 2 for config Secret/istio-system/cacerts and 1 more configs: 100.411771ms since last change, 159.288056ms since last push, full=false
2023-04-05T17:13:53.820393Z	info	ads	XDS: Incremental Pushing:2023-04-05T17:11:50Z/2 ConnectedEndpoints:3 Version:2023-04-05T17:11:50Z/2
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x2984f6e]

goroutine 1070 [running]:
istio.io/istio/pilot/pkg/serviceregistry/kube/controller.(*NamespaceController).startCaBundleWatcher(0xc000735080, 0xc000e8d500)
	istio.io/istio/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go:147 +0x10e
created by istio.io/istio/pilot/pkg/serviceregistry/kube/controller.(*NamespaceController).Run
	istio.io/istio/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go:136 +0x20a
```

Logs of fixed istiod:
```
2023-04-05T19:34:14.678724Z info Update Istiod cacerts
2023-04-05T19:34:14.678825Z info Using kubernetes.io/tls secret type for signing ca files
2023-04-05T19:34:14.813470Z info Istiod has detected the newly added intermediate CA and updated its key and certs accordingly
2023-04-05T19:34:14.813707Z info x509 cert - Issuer: "CN=istiod-basic.istio-system.svc", Subject: "", SN: 2e3c5a56bc5913b8b634e144c79e61c3, NotBefore: "2023-04-05T19:32:14Z", NotAfter: "2033-04-02T19:34:14Z"
2023-04-05T19:34:14.813770Z info x509 cert - Issuer: "CN=root-ca.my-company.net,O=my-company.net", Subject: "CN=istiod-basic.istio-system.svc", SN: adc72370c45bb0cb71c0f8d5da97244c, NotBefore: "2023-04-05T19:33:37Z", NotAfter: "2023-05-07T11:33:37Z"
2023-04-05T19:34:14.813803Z info x509 cert - Issuer: "CN=root-ca.my-company.net,O=my-company.net", Subject: "CN=root-ca.my-company.net,O=my-company.net", SN: 352d9e6c05c500d887b433e367f97273, NotBefore: "2023-04-05T14:35:01Z", NotAfter: "2025-09-21T14:35:01Z"
2023-04-05T19:34:14.813810Z info Istiod certificates are reloaded
```