### PR TITLE
OSSM-3599 Federation egress-gateway gets wrong network gateway endpoints (cherry-pick)

### DIFF
--- a/pilot/pkg/serviceregistry/federation/controller.go
+++ b/pilot/pkg/serviceregistry/federation/controller.go
@@ -477,16 +477,8 @@ func (c *Controller) getImportNameForService(exportedService *model.Service) *fe
 	return c.importNameMapper.NameForService(exportedService)
 }
 
-func (c *Controller) updateGateways(serviceList *federationmodel.ServiceListMessage) {
+func (c *Controller) updateGateways() {
 	c.gatewayStore = c.gatewayForNetworkAddress()
-	if serviceList != nil {
-		for _, gateway := range serviceList.NetworkGatewayEndpoints {
-			c.gatewayStore = append(c.gatewayStore, model.NetworkGateway{
-				Addr: gateway.Hostname,
-				Port: uint32(gateway.Port),
-			})
-		}
-	}
 	c.egressGateways, c.egressSAs = c.getEgressServiceAddrs()
 }
 
@@ -630,7 +622,7 @@ func (c *Controller) GetService(hostname host.Name) *model.Service {
 func (c *Controller) NetworkGateways() []model.NetworkGateway {
 	c.storeLock.RLock()
 	defer c.storeLock.RUnlock()
-	return c.gatewayStore
+	return nil
 }
 
 func (c *Controller) MCSServices() []model.MCSServiceInfo {
@@ -1088,7 +1080,7 @@ func (c *Controller) resync() uint64 {
 		c.logger.Warnf("resync failed: %s", err)
 		return 0
 	}
-	c.updateGateways(svcList)
+	c.updateGateways()
 	if svcList != nil {
 		c.convertServices(svcList)
 		c.statusHandler.FullSyncComplete()

--- a/pkg/servicemesh/federation/model/model.go
+++ b/pkg/servicemesh/federation/model/model.go
@@ -23,9 +23,8 @@ type ServiceKey struct {
 }
 
 type ServiceListMessage struct {
-	Checksum                uint64             `json:"checksum" hash:"ignore"`
-	NetworkGatewayEndpoints []*ServiceEndpoint `json:"networkGatewayEndpoints,omitempty" hash:"set"`
-	Services                []*ServiceMessage  `json:"services,omitempty" hash:"set"`
+	Checksum uint64            `json:"checksum" hash:"ignore"`
+	Services []*ServiceMessage `json:"services,omitempty" hash:"set"`
 }
 
 type ServiceMessage struct {

--- a/pkg/servicemesh/federation/server/server.go
+++ b/pkg/servicemesh/federation/server/server.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	hashstructure "github.com/mitchellh/hashstructure/v2"
 	"k8s.io/apimachinery/pkg/util/errors"
 	v1 "maistra.io/api/federation/v1"
 
@@ -78,8 +77,6 @@ type Server struct {
 	// us to know what the workload identifiers were so we could manage the
 	// routing config for each mesh.  This may or may not be possible.
 	network string
-
-	currentGatewayEndpoints []*federationmodel.ServiceEndpoint
 }
 
 var _ FederationManager = (*Server)(nil)
@@ -132,15 +129,14 @@ func (s *Server) AddPeer(mesh *v1.ServiceMeshPeer, exports *v1.ExportedServiceSe
 		return fmt.Errorf("exporter already exists for federation %s", mesh.Name)
 	}
 	meshServer := &meshServer{
-		GatewayEndpointsProvider: s,
-		logger:                   s.logger.WithLabels("mesh", mesh.Name),
-		env:                      s.env,
-		mesh:                     mesh,
-		exportConfig:             exportConfig,
-		statusHandler:            statusHandler,
-		configStore:              s.configStore,
-		ingressService:           s.ingressServiceName(mesh),
-		currentServices:          make(map[federationmodel.ServiceKey]*federationmodel.ServiceMessage),
+		logger:          s.logger.WithLabels("mesh", mesh.Name),
+		env:             s.env,
+		mesh:            mesh,
+		exportConfig:    exportConfig,
+		statusHandler:   statusHandler,
+		configStore:     s.configStore,
+		ingressService:  s.ingressServiceName(mesh),
+		currentServices: make(map[federationmodel.ServiceKey]*federationmodel.ServiceMessage),
 	}
 	if _, loaded := s.meshes.LoadOrStore(mesh.Name, meshServer); !loaded {
 		meshServer.resync()
@@ -234,75 +230,11 @@ func (s *Server) Run(stopCh <-chan struct{}) {
 	_ = s.httpServer.Shutdown(context.TODO())
 }
 
-func (s *Server) GetGatewayEndpoints() []*federationmodel.ServiceEndpoint {
-	s.Lock()
-	defer s.Unlock()
-	return append([]*federationmodel.ServiceEndpoint(nil), s.currentGatewayEndpoints...)
-}
-
-func (s *Server) resyncNetworkGateways() (bool, error) {
-	s.Lock()
-	defer s.Unlock()
-
-	gatewayEndpoints := []*federationmodel.ServiceEndpoint{}
-	for _, gateway := range s.env.NetworkGateways() {
-		gatewayEndpoints = append(gatewayEndpoints, &federationmodel.ServiceEndpoint{
-			Port:     int(gateway.Port),
-			Hostname: gateway.Addr,
-		})
-	}
-
-	newGatewayChecksum, err := hashstructure.Hash(gatewayEndpoints, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	if err != nil {
-		return false, err
-	}
-
-	oldGatewayChecksum, err := hashstructure.Hash(s.currentGatewayEndpoints, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	if err != nil {
-		return false, err
-	}
-	if oldGatewayChecksum != newGatewayChecksum {
-		s.currentGatewayEndpoints = gatewayEndpoints
-		return true, nil
-	}
-	return false, nil
-}
-
 func (s *Server) UpdateService(svc *model.Service, event model.Event) {
-	// this might be a NetworkGateway
-	if svc != nil {
-		networkGatewaysChanged, _ := s.resyncNetworkGateways()
-		if networkGatewaysChanged {
-			s.meshes.Range(func(_, value interface{}) bool {
-				value.(*meshServer).resync()
-				return true
-			})
-			s.meshes.Range(func(_, value interface{}) bool {
-				value.(*meshServer).pushWatchEvent(&federationmodel.WatchEvent{
-					Action:  federationmodel.ActionUpdate,
-					Service: nil,
-				})
-				return true
-			})
-		}
-	}
 	s.meshes.Range(func(_, value interface{}) bool {
 		value.(*meshServer).serviceUpdated(svc, event)
 		return true
 	})
-}
-
-// resync ensures the export lists are current.  used for testing
-func (s *Server) resync() {
-	_, _ = s.resyncNetworkGateways()
-	s.meshes.Range(func(_, value interface{}) bool {
-		value.(*meshServer).resync()
-		return true
-	})
-}
-
-type GatewayEndpointsProvider interface {
-	GetGatewayEndpoints() []*federationmodel.ServiceEndpoint
 }
 
 func serviceKeyForService(svc *model.Service) federationmodel.ServiceKey {
@@ -314,7 +246,6 @@ func serviceKeyForService(svc *model.Service) federationmodel.ServiceKey {
 }
 
 type meshServer struct {
-	GatewayEndpointsProvider
 	sync.RWMutex
 
 	logger *log.Scope
@@ -378,9 +309,8 @@ func (s *meshServer) getServiceMessage(svc *model.Service, exportedName *federat
 // s has to be Lock()ed
 func (s *meshServer) getServiceListMessage() *federationmodel.ServiceListMessage {
 	ret := &federationmodel.ServiceListMessage{
-		NetworkGatewayEndpoints: s.GetGatewayEndpoints(),
+		Services: []*federationmodel.ServiceMessage{},
 	}
-	ret.Services = []*federationmodel.ServiceMessage{}
 	for _, svcMessage := range s.currentServices {
 		ret.Services = append(ret.Services, svcMessage)
 	}

--- a/pkg/servicemesh/federation/server/server_test.go
+++ b/pkg/servicemesh/federation/server/server_test.go
@@ -243,12 +243,6 @@ func TestServiceList(t *testing.T) {
 				},
 			},
 			expectedMessage: federationmodel.ServiceListMessage{
-				NetworkGatewayEndpoints: []*federationmodel.ServiceEndpoint{
-					{
-						Port:     8080,
-						Hostname: "127.0.0.1",
-					},
-				},
 				Services: []*federationmodel.ServiceMessage{
 					{
 						ServiceKey: federationmodel.ServiceKey{
@@ -330,12 +324,6 @@ func TestServiceList(t *testing.T) {
 				},
 			},
 			expectedMessage: federationmodel.ServiceListMessage{
-				NetworkGatewayEndpoints: []*federationmodel.ServiceEndpoint{
-					{
-						Port:     8080,
-						Hostname: "127.0.0.1",
-					},
-				},
 				Services: []*federationmodel.ServiceMessage{
 					{
 						ServiceKey: federationmodel.ServiceKey{
@@ -580,7 +568,6 @@ func TestServiceList(t *testing.T) {
 			stopCh := make(chan struct{})
 			go s.Run(stopCh)
 			defer close(stopCh)
-			s.resyncNetworkGateways()
 			s.AddPeer(federation, tc.serviceExports, &common.FakeStatusHandler{})
 			for _, e := range tc.serviceEvents {
 				s.UpdateService(e.svc, e.event)
@@ -893,12 +880,7 @@ func TestWatch(t *testing.T) {
 					},
 				},
 			},
-			expectedWatchEvents: []*federationmodel.WatchEvent{
-				{
-					Action:  federationmodel.ActionUpdate,
-					Service: nil,
-				},
-			},
+			expectedWatchEvents: nil,
 		},
 		{
 			name:           "service export removed",
@@ -958,7 +940,6 @@ func TestWatch(t *testing.T) {
 			stopCh := make(chan struct{})
 			go s.Run(stopCh)
 			defer close(stopCh)
-			s.resyncNetworkGateways()
 			s.AddPeer(federation, tc.serviceExports, &common.FakeStatusHandler{})
 			req, err := http.NewRequest("GET", "https://"+s.Addr()+"/v1/watch/"+tc.remoteName, nil)
 			if err != nil {


### PR DESCRIPTION
…nts (#775)

* OSSM-3599 Federation egress-gateway gets wrong update of network gateway endpoints

* Deprecate GatewayEndpoints on server side

* Remove resyncNetworkGateways in unit tests

* Fix lint

* Deprecate NetworkGatewayEndpoints and fix tests

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
