### PR TITLE
Change base image of extauthz to redhat/ubi8-micro to support ppc64le and s390x

### DIFF
--- a/samples/extauthz/docker/Dockerfile
+++ b/samples/extauthz/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-micro
+FROM redhat/ubi8-micro:8.7
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/extauthz /usr/local/bin/extauthz

--- a/samples/extauthz/docker/Dockerfile
+++ b/samples/extauthz/docker/Dockerfile
@@ -1,6 +1,4 @@
-ARG BASE_VERSION=latest
-
-FROM gcr.io/istio-release/base:${BASE_VERSION}
+FROM redhat/ubi8-micro
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/extauthz /usr/local/bin/extauthz


### PR DESCRIPTION
This change makes it possible to test external authorization on ppc64le and s390x architectures, which are not supported by `gcr.io/istio-release/base`.
