### PR TITLE
Restore the istio_version container variable

### DIFF
--- a/maistra/Dockerfile.proxyv2
+++ b/maistra/Dockerfile.proxyv2
@@ -1,14 +1,14 @@
 FROM quay.io/centos/centos:stream8
 
 ARG MAISTRA_VERSION
-ARG ISTIO_VERSION
 ARG proxy_version
+ARG istio_version
 ARG SIDECAR=envoy
 
 LABEL com.redhat.component="openshift-istio-proxy-ubi8-container"
 LABEL name="openshift-service-mesh/istio-proxy-ubi8"
 LABEL version="${MAISTRA_VERSION}"
-LABEL istio_version="${ISTIO_VERSION}"
+LABEL istio_version="$istio_version"
 LABEL summary="Maistra Proxy OpenShift container image"
 LABEL description="Maistra Proxy OpenShift container image"
 LABEL io.k8s.display-name="Maistra Proxy"
@@ -37,7 +37,7 @@ COPY ${TARGETARCH:-amd64}/${SIDECAR} /usr/local/bin/${SIDECAR}
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging
-ENV ISTIO_META_ISTIO_VERSION ${ISTIO_VERSION}
+ENV ISTIO_META_ISTIO_VERSION $istio_version
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/pilot-agent /usr/local/bin/pilot-agent

--- a/maistra/maistra.mk
+++ b/maistra/maistra.mk
@@ -14,7 +14,7 @@ MAISTRA_PRE_BUILD ?= time ($(MAISTRA_PRE_BUILD_SCRIPT))
 MAISTRA_POST_BUILD ?= time (HUB=$(HUB) TAG=$(TAG) BASE_DISTRIBUTION=$(BASE_DISTRIBUTION) $(MAISTRA_POST_BUILD_SCRIPT) $(ISTIO_COMPONENT))
 
 .PHONY: maistra-image.pilot
-maistra-image.pilot: VERSION=$(MAISTRA_VERSION)
+maistra-image.pilot: MAISTRA_VERSION=$(MAISTRA_VERSION)
 maistra-image.pilot: ISTIO_COMPONENT=$(subst maistra-image.,,$@)
 maistra-image.pilot: 
 	$(MAISTRA_PRE_BUILD)
@@ -22,7 +22,7 @@ maistra-image.pilot:
 	$(MAISTRA_POST_BUILD)
 
 .PHONY: maistra-image.proxyv2
-maistra-image.proxyv2: VERSION=$(MAISTRA_VERSION)
+maistra-image.proxyv2: MAISTRA_VERSION=$(MAISTRA_VERSION)
 maistra-image.proxyv2: ISTIO_COMPONENT=$(subst maistra-image.,,$@)
 maistra-image.proxyv2: 
 	$(MAISTRA_PRE_BUILD)
@@ -30,7 +30,7 @@ maistra-image.proxyv2:
 	$(MAISTRA_POST_BUILD)
 
 .PHONY: maistra-image.istio-cni
-maistra-image.istio-cni: VERSION=$(MAISTRA_VERSION)
+maistra-image.istio-cni: MAISTRA_VERSION=$(MAISTRA_VERSION)
 maistra-image.istio-cni: ISTIO_COMPONENT=$(subst maistra-image.,,$@)
 maistra-image.istio-cni: 
 	$(MAISTRA_PRE_BUILD)


### PR DESCRIPTION
It's missing in our **daily images**.

```
$ docker inspect quay.io/maistra-dev/proxyv2-ubi8:2.4-latest | grep ISTIO_META
                "ISTIO_META_ISTIO_PROXY_SHA=a8c37f4cb7eca48973ac236bd7def87d266c896c",
                "ISTIO_META_ISTIO_VERSION="
```

This PR restores it to their upstream value (e.g. `1.16-dev`).
