### PR TITLE
Revert "OSSM-3887 fix duplicate response_code entry in envoy_bootstrap.json"

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
+++ b/pkg/bootstrap/testdata/metrics_no_statsd_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -44,7 +44,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -44,7 +44,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_none_golden.json
+++ b/pkg/bootstrap/testdata/tracing_none_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -39,7 +39,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -54,7 +54,11 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+        "regex": "(response_code=\\.=(.+?);\\.;)",
+        "tag_name": "response_code"
+      },
+      {
+        "regex": "_rq(_(\\d{3}))$",
         "tag_name": "response_code"
       },
       {


### PR DESCRIPTION
Reverts maistra/istio#796

The proxy pulls the bootsrap from the istio project and the issue was that we were using a 1.14 proxy with a 1.16 bootstrap.  Building 1.16 proxy fixes the issue.