### PR TITLE
OSSM-3980: Fix gateway deployment controller in multi-tenant mode

### DIFF
--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	maistrav1beta1 "github.com/maistra/xns-informer/pkg/generated/gatewayapi/apis/v1beta1"
+	appsxnsinformersv1 "github.com/maistra/xns-informer/pkg/generated/kube/apps/v1"
+	xnsinformers "github.com/maistra/xns-informer/pkg/informers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,6 +87,7 @@ type DeploymentController struct {
 	gatewayLister      lister.GatewayLister
 	gatewayClassLister lister.GatewayClassLister
 	defaultLabels      map[string]string
+	namespaces         xnsinformers.NamespaceSet
 }
 
 // Patcher is a function that abstracts patching logic. This is largely because client-go fakes do not handle patching
@@ -129,8 +132,21 @@ func NewDeploymentController(client kube.Client) *DeploymentController {
 	client.KubeInformer().Core().V1().Services().Informer().
 		AddEventHandler(handler)
 
+	if client.GetMemberRoll() != nil {
+		dc.namespaces = xnsinformers.NewNamespaceSet()
+		client.GetMemberRoll().Register(dc.namespaces, "gateway-deployment-controller")
+	}
+
 	// For Deployments, this is the only controller watching. We can filter to just the deployments we care about
 	deployInformer := client.KubeInformer().InformerFor(&appsv1.Deployment{}, func(k kubernetes.Interface, resync time.Duration) cache.SharedIndexInformer {
+		if client.GetMemberRoll() != nil {
+			return appsxnsinformersv1.NewFilteredDeploymentInformer(
+				k, dc.namespaces, resync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				func(options *metav1.ListOptions) {
+					options.LabelSelector = ManagedByControllerLabel + "=" + ManagedByControllerValue
+				},
+			)
+		}
 		return appsinformersv1.NewFilteredDeploymentInformer(
 			k, metav1.NamespaceAll, resync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			func(options *metav1.ListOptions) {

--- a/tests/integration/servicemesh/maistra/testdata/clusterrole.yaml
+++ b/tests/integration/servicemesh/maistra/testdata/clusterrole.yaml
@@ -16,20 +16,6 @@ rules:
     resources: [ "validatingwebhookconfigurations" ]
     verbs: [ "get", "list", "watch", "update" ]
 
-  # Istiod and bootstrap.
-  - apiGroups: ["certificates.k8s.io"]
-    resources:
-      - "certificatesigningrequests"
-      - "certificatesigningrequests/approval"
-      - "certificatesigningrequests/status"
-    verbs: ["update", "create", "get", "delete", "watch"]
-  - apiGroups: ["certificates.k8s.io"]
-    resources:
-      - "signers"
-    resourceNames:
-      - "kubernetes.io/legacy-unknown"
-    verbs: ["approve"]
-
   # Used by Istiod to verify the JWT tokens
   - apiGroups: [ "authentication.k8s.io" ]
     resources: [ "tokenreviews" ]
@@ -39,21 +25,6 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
-
-  - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
-    verbs: [ "get", "list" ]
-
-  # Use for Kubernetes Service APIs
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-    resources: ["*"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-    resources: ["*"] # TODO: should be on just */status but wildcard is not supported
-    verbs: ["update", "patch"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gatewayclasses"]
-    verbs: ["create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/integration/servicemesh/maistra/testdata/role.yaml
+++ b/tests/integration/servicemesh/maistra/testdata/role.yaml
@@ -44,13 +44,21 @@ rules:
     resources: ["configmaps"]
     verbs: ["create", "get", "list", "watch", "update"]
 
+#  # Use for Kubernetes Service APIs
+#  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
+#    resources: ["gateways", "httproutes", "tcproutes", "tlsroutes", "udproutes", "referencepolicies", "referencegrants"]
+#    verbs: ["get", "watch", "list"]
+#  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
+#    resources: ["gateways/status", "httproutes/status", "tcproutes/status", "tlsroutes/status", "udproutes/status", "referencepolicies/status"]
+#    verbs: ["update", "patch"]
+
   # Use for Kubernetes Service APIs
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-    resources: ["gateways", "httproutes", "tcproutes", "tlsroutes", "udproutes", "referencepolicies", "referencegrants"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-    resources: ["gateways/status", "httproutes/status", "tcproutes/status", "tlsroutes/status", "udproutes/status", "referencepolicies/status"]
-    verbs: ["update", "patch"]
+  - apiGroups: [ "networking.x-k8s.io", "gateway.networking.k8s.io" ]
+    resources: [ "*" ]
+    verbs: [ "get", "watch", "list" ]
+  - apiGroups: [ "networking.x-k8s.io", "gateway.networking.k8s.io" ]
+    resources: [ "*" ] # TODO: should be on just */status but wildcard is not supported
+    verbs: [ "update", "patch" ]
 
   # Needed for multicluster secret reading, possibly ingress certs in the future
   - apiGroups: [""]

--- a/tests/integration/servicemesh/maistra/testdata/role.yaml
+++ b/tests/integration/servicemesh/maistra/testdata/role.yaml
@@ -44,21 +44,13 @@ rules:
     resources: ["configmaps"]
     verbs: ["create", "get", "list", "watch", "update"]
 
-#  # Use for Kubernetes Service APIs
-#  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-#    resources: ["gateways", "httproutes", "tcproutes", "tlsroutes", "udproutes", "referencepolicies", "referencegrants"]
-#    verbs: ["get", "watch", "list"]
-#  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
-#    resources: ["gateways/status", "httproutes/status", "tcproutes/status", "tlsroutes/status", "udproutes/status", "referencepolicies/status"]
-#    verbs: ["update", "patch"]
-
   # Use for Kubernetes Service APIs
-  - apiGroups: [ "networking.x-k8s.io", "gateway.networking.k8s.io" ]
-    resources: [ "*" ]
-    verbs: [ "get", "watch", "list" ]
-  - apiGroups: [ "networking.x-k8s.io", "gateway.networking.k8s.io" ]
-    resources: [ "*" ] # TODO: should be on just */status but wildcard is not supported
-    verbs: [ "update", "patch" ]
+  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["networking.x-k8s.io", "gateway.networking.k8s.io"]
+    resources: ["*"] # TODO: should be on just */status but wildcard is not supported
+    verbs: ["update", "patch"]
 
   # Needed for multicluster secret reading, possibly ingress certs in the future
   - apiGroups: [""]


### PR DESCRIPTION
Gateway deployment controller was logging errors in multi-tenant mode, because it was not using xns-informers for watching deployments.
```
2023-05-17T22:52:32.649678Z	error	klog	github.com/maistra/xns-informer/pkg/generated/kube/factory.go:135: Failed to watch *v1.Deployment: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:istio-system:istiod-basic" cannot list resource "deployments" in API group "apps" at the cluster scope
```
We didn't find this problem in integration tests, because existing cluster role bindings were not removed before applying role bindings for multi-tenant deployment.