### PR TITLE
[maistra-2.5] OSSM-4056: Backport setting `istio.alpn_override: "false"` for SIMPLE and MUTUAL TLS

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -249,6 +249,7 @@ func (cb *ClusterBuilder) buildSubsetCluster(opts buildClusterOpts, destRule *co
 	// basis in buildDefaultCluster, so we can just insert without a copy.
 	subsetCluster.cluster.Metadata = util.AddConfigInfoMetadata(subsetCluster.cluster.Metadata, destRule.Meta)
 	util.AddSubsetToMetadata(subsetCluster.cluster.Metadata, subset.Name)
+	subsetCluster.cluster.Metadata = util.AddALPNOverrideToMetadata(subsetCluster.cluster.Metadata, opts.policy.GetTls().GetMode())
 	return subsetCluster.build()
 }
 
@@ -294,11 +295,7 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *MutableCluster, clusterMode C
 
 	if destRule != nil {
 		mc.cluster.Metadata = util.AddConfigInfoMetadata(mc.cluster.Metadata, destRule.Meta)
-
-		// ALPN header rewrite starts Istio-managed mTLS. Skip if TLS mode is SIMPLE or MUTUAL
-		if trafficPolicy.GetTls() != nil {
-			mc.cluster.Metadata = configureALPNOverride(trafficPolicy.Tls.Mode, mc.cluster.Metadata)
-		}
+		mc.cluster.Metadata = util.AddALPNOverrideToMetadata(mc.cluster.Metadata, opts.policy.GetTls().GetMode())
 	}
 	subsetClusters := make([]*cluster.Cluster, 0)
 	for _, subset := range destinationRule.GetSubsets() {
@@ -1430,14 +1427,4 @@ func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster 
 		},
 	}
 	return c
-}
-
-// configureALPNOverride determines whether alpn_override should be added to metadata
-func configureALPNOverride(tlsMode networking.ClientTLSSettings_TLSmode, md *core.Metadata) *core.Metadata {
-	alpnOverride := (tlsMode != networking.ClientTLSSettings_SIMPLE) && (tlsMode != networking.ClientTLSSettings_MUTUAL)
-	// Only write to metadata if alpnOverride is false
-	if !alpnOverride {
-		return util.AddALPNOverrideToMetadata(md, alpnOverride)
-	}
-	return md
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -294,6 +294,11 @@ func (cb *ClusterBuilder) applyDestinationRule(mc *MutableCluster, clusterMode C
 
 	if destRule != nil {
 		mc.cluster.Metadata = util.AddConfigInfoMetadata(mc.cluster.Metadata, destRule.Meta)
+
+		// ALPN header rewrite starts Istio-managed mTLS. Skip if TLS mode is SIMPLE or MUTUAL
+		if trafficPolicy.GetTls() != nil {
+			mc.cluster.Metadata = configureALPNOverride(trafficPolicy.Tls.Mode, mc.cluster.Metadata)
+		}
 	}
 	subsetClusters := make([]*cluster.Cluster, 0)
 	for _, subset := range destinationRule.GetSubsets() {
@@ -1425,4 +1430,14 @@ func (cb *ClusterBuilder) buildExternalSDSCluster(addr string) *cluster.Cluster 
 		},
 	}
 	return c
+}
+
+// configureALPNOverride determines whether alpn_override should be added to metadata
+func configureALPNOverride(tlsMode networking.ClientTLSSettings_TLSmode, md *core.Metadata) *core.Metadata {
+	alpnOverride := (tlsMode != networking.ClientTLSSettings_SIMPLE) && (tlsMode != networking.ClientTLSSettings_MUTUAL)
+	// Only write to metadata if alpnOverride is false
+	if !alpnOverride {
+		return util.AddALPNOverrideToMetadata(md, alpnOverride)
+	}
+	return md
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -478,6 +478,51 @@ func TestApplyDestinationRule(t *testing.T) {
 			},
 			expectedSubsetClusters: []*cluster.Cluster{},
 		},
+		{
+			name:        "destination rule with tls mode SIMPLE",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_SIMPLE},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
+			name:        "destination rule with tls mode MUTUAL",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_MUTUAL},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
+			name:        "destination rule with tls mode ISTIO_MUTUAL",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_ISTIO_MUTUAL},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
 	}
 
 	for _, tt := range cases {
@@ -554,6 +599,39 @@ func TestApplyDestinationRule(t *testing.T) {
 				if ec.httpProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.GetValue() !=
 					uint32(tt.destRule.TrafficPolicy.GetConnectionPool().GetHttp().MaxRequestsPerConnection) {
 					t.Errorf("Unexpected max_requests_per_connection found")
+				}
+			}
+
+			// Validate that alpn_override is correctly configured on cluster given a TLS mode.
+			if tt.destRule != nil && tt.destRule.TrafficPolicy != nil && tt.destRule.TrafficPolicy.Tls != nil {
+				tlsMode := tt.destRule.TrafficPolicy.Tls.Mode
+				if tlsMode == networking.ClientTLSSettings_SIMPLE || tlsMode == networking.ClientTLSSettings_MUTUAL {
+					md := tt.cluster.Metadata
+					istio, ok := md.FilterMetadata[util.IstioMetadataKey]
+					if !ok {
+						t.Errorf("Istio metadata not found")
+					}
+					alpnOverride, found := istio.Fields[util.AlpnOverrideMetadataKey]
+
+					if found {
+						if alpnOverride.GetStringValue() != "false" {
+							t.Errorf("alpn_override:%s tlsMode:%s, should be false for either TLS mode SIMPLE or MUTUAL", alpnOverride, tlsMode)
+						}
+					} else {
+						t.Errorf("alpn_override metadata should be written for either TLS mode SIMPLE or MUTUAL")
+					}
+				} else {
+					// If TLS settings are not found, alpn_override metadata should not be written
+					md := tt.cluster.Metadata
+					istio, ok := md.FilterMetadata[util.IstioMetadataKey]
+					if ok {
+						alpnOverride, found := istio.Fields[util.AlpnOverrideMetadataKey]
+						if found {
+							// nolint: lll
+							t.Errorf("alpn_override:%s tlsMode:%s, alpn_override metadata should not be written if TLS mode is neither SIMPLE nor MUTUAL", alpnOverride.GetStringValue(), tlsMode)
+						}
+
+					}
 				}
 
 			}
@@ -3762,6 +3840,113 @@ func TestBuildExternalSDSClusters(t *testing.T) {
 			}
 			if path != tt.expectedPath {
 				t.Errorf("Unexpected path, got: %v, want: %v", path, tt.expectedPath)
+			}
+		})
+	}
+}
+
+func TestConfigureALPNOverride(t *testing.T) {
+	cases := []struct {
+		name     string
+		tlsMode  networking.ClientTLSSettings_TLSmode
+		metadata *core.Metadata
+		want     *core.Metadata
+	}{
+		{
+			name:     "tlsMode SIMPLE, metadata nil",
+			tlsMode:  networking.ClientTLSSettings_SIMPLE,
+			metadata: nil,
+			want: &core.Metadata{
+				FilterMetadata: map[string]*structpb.Struct{
+					util.IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							util.AlpnOverrideMetadataKey: {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "false",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "tlsMode MUTUAL, metadata not nil",
+			tlsMode: networking.ClientTLSSettings_MUTUAL,
+			metadata: &core.Metadata{
+				FilterMetadata: map[string]*structpb.Struct{
+					util.IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							"other-config": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "other-config",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &core.Metadata{
+				FilterMetadata: map[string]*structpb.Struct{
+					util.IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							"other-config": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "other-config",
+								},
+							},
+							util.AlpnOverrideMetadataKey: {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "false",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "tlsMode ISTIO_MUTUAL, metadata nil",
+			tlsMode:  networking.ClientTLSSettings_ISTIO_MUTUAL,
+			metadata: nil,
+			want:     nil,
+		},
+		{
+			name:    "tlsMode ISTIO_MUTUAL, metadata not nil",
+			tlsMode: networking.ClientTLSSettings_ISTIO_MUTUAL,
+			metadata: &core.Metadata{
+				FilterMetadata: map[string]*structpb.Struct{
+					util.IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							"other-config": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "other-config",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &core.Metadata{
+				FilterMetadata: map[string]*structpb.Struct{
+					util.IstioMetadataKey: {
+						Fields: map[string]*structpb.Value{
+							"other-config": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "other-config",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			newMetadata := configureALPNOverride(tt.tlsMode, tt.metadata)
+			if diff := cmp.Diff(newMetadata, tt.want, protocmp.Transform()); diff != "" {
+				t.Errorf("configureALPNOverride(%s, %v) produced incorrect result:\ngot: %v\nwant: %v\nDiff: %s", tt.tlsMode, tt.metadata, newMetadata, tt.want, diff)
 			}
 		})
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -523,6 +523,138 @@ func TestApplyDestinationRule(t *testing.T) {
 			},
 			expectedSubsetClusters: []*cluster.Cluster{},
 		},
+		{
+			name:        "port level destination rule with tls mode SIMPLE",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+						{
+							Port: &networking.PortSelector{Number: uint32(servicePort[0].Port)},
+							Tls:  &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_SIMPLE},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
+			name:        "port level destination rule with tls mode MUTUAL",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+						{
+							Port: &networking.PortSelector{Number: uint32(servicePort[0].Port)},
+							Tls:  &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_MUTUAL},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
+			name:        "port level destination rule with tls mode ISTIO_MUTUAL",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				TrafficPolicy: &networking.TrafficPolicy{
+					PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+						{
+							Port: &networking.PortSelector{Number: uint32(servicePort[0].Port)},
+							Tls:  &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_ISTIO_MUTUAL},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{},
+		},
+		{
+			name:        "subset destination rule with tls mode SIMPLE",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				Subsets: []*networking.Subset{
+					{
+						Name: "v1",
+						TrafficPolicy: &networking.TrafficPolicy{
+							Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_SIMPLE},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{{
+				Name:                 "outbound|8080|v1|foo.default.svc.cluster.local",
+				ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
+				EdsClusterConfig:     &cluster.Cluster_EdsClusterConfig{ServiceName: "outbound|8080|v1|foo.default.svc.cluster.local"},
+			}},
+		},
+		{
+			name:        "subset destination rule with tls mode MUTUAL",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				Subsets: []*networking.Subset{
+					{
+						Name: "v1",
+						TrafficPolicy: &networking.TrafficPolicy{
+							Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_MUTUAL},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{{
+				Name:                 "outbound|8080|v1|foo.default.svc.cluster.local",
+				ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
+				EdsClusterConfig:     &cluster.Cluster_EdsClusterConfig{ServiceName: "outbound|8080|v1|foo.default.svc.cluster.local"},
+			}},
+		},
+		{
+			name:        "subset destination rule with tls mode MUTUAL",
+			cluster:     &cluster.Cluster{Name: "foo", ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxyView:   model.ProxyViewAll,
+			destRule: &networking.DestinationRule{
+				Host: "foo.default.svc.cluster.local",
+				Subsets: []*networking.Subset{
+					{
+						Name: "v1",
+						TrafficPolicy: &networking.TrafficPolicy{
+							Tls: &networking.ClientTLSSettings{Mode: networking.ClientTLSSettings_ISTIO_MUTUAL},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*cluster.Cluster{{
+				Name:                 "outbound|8080|v1|foo.default.svc.cluster.local",
+				ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
+				EdsClusterConfig:     &cluster.Cluster_EdsClusterConfig{ServiceName: "outbound|8080|v1|foo.default.svc.cluster.local"},
+			}},
+		},
 	}
 
 	for _, tt := range cases {
@@ -603,37 +735,25 @@ func TestApplyDestinationRule(t *testing.T) {
 			}
 
 			// Validate that alpn_override is correctly configured on cluster given a TLS mode.
-			if tt.destRule != nil && tt.destRule.TrafficPolicy != nil && tt.destRule.TrafficPolicy.Tls != nil {
-				tlsMode := tt.destRule.TrafficPolicy.Tls.Mode
-				if tlsMode == networking.ClientTLSSettings_SIMPLE || tlsMode == networking.ClientTLSSettings_MUTUAL {
-					md := tt.cluster.Metadata
-					istio, ok := md.FilterMetadata[util.IstioMetadataKey]
-					if !ok {
-						t.Errorf("Istio metadata not found")
-					}
-					alpnOverride, found := istio.Fields[util.AlpnOverrideMetadataKey]
-
-					if found {
-						if alpnOverride.GetStringValue() != "false" {
-							t.Errorf("alpn_override:%s tlsMode:%s, should be false for either TLS mode SIMPLE or MUTUAL", alpnOverride, tlsMode)
-						}
+			if tt.destRule.GetTrafficPolicy().GetTls() != nil {
+				verifyALPNOverride(t, tt.cluster.Metadata, tt.destRule.TrafficPolicy.Tls.Mode)
+			}
+			if len(tt.destRule.GetSubsets()) > 0 {
+				for _, c := range subsetClusters {
+					var subsetName string
+					if tt.clusterMode == DefaultClusterMode {
+						subsetName = strings.Split(c.Name, "|")[2]
 					} else {
-						t.Errorf("alpn_override metadata should be written for either TLS mode SIMPLE or MUTUAL")
+						subsetName = strings.Split(c.Name, ".")[2]
 					}
-				} else {
-					// If TLS settings are not found, alpn_override metadata should not be written
-					md := tt.cluster.Metadata
-					istio, ok := md.FilterMetadata[util.IstioMetadataKey]
-					if ok {
-						alpnOverride, found := istio.Fields[util.AlpnOverrideMetadataKey]
-						if found {
-							// nolint: lll
-							t.Errorf("alpn_override:%s tlsMode:%s, alpn_override metadata should not be written if TLS mode is neither SIMPLE nor MUTUAL", alpnOverride.GetStringValue(), tlsMode)
+					for _, subset := range tt.destRule.Subsets {
+						if subset.Name == subsetName {
+							if subset.GetTrafficPolicy().GetTls() != nil {
+								verifyALPNOverride(t, c.Metadata, subset.TrafficPolicy.Tls.Mode)
+							}
 						}
-
 					}
 				}
-
 			}
 
 			// Validate that ORIGINAL_DST cluster does not have load assignments
@@ -664,6 +784,29 @@ func compareClusters(t *testing.T, ec *cluster.Cluster, gc *cluster.Cluster) {
 	if ec.CircuitBreakers != nil {
 		if ec.CircuitBreakers.Thresholds[0].MaxRetries.Value != gc.CircuitBreakers.Thresholds[0].MaxRetries.Value {
 			t.Errorf("Unexpected circuit breaker thresholds want %v, got %v", ec.CircuitBreakers.Thresholds[0].MaxRetries, gc.CircuitBreakers.Thresholds[0].MaxRetries)
+		}
+	}
+}
+
+func verifyALPNOverride(t *testing.T, md *core.Metadata, tlsMode networking.ClientTLSSettings_TLSmode) {
+	istio, ok := md.FilterMetadata[util.IstioMetadataKey]
+	if tlsMode == networking.ClientTLSSettings_SIMPLE || tlsMode == networking.ClientTLSSettings_MUTUAL {
+		if !ok {
+			t.Errorf("Istio metadata not found")
+		}
+		alpnOverride, found := istio.Fields[util.AlpnOverrideMetadataKey]
+		if found {
+			if alpnOverride.GetStringValue() != "false" {
+				t.Errorf("alpn_override:%s tlsMode:%s, should be false for either TLS mode SIMPLE or MUTUAL", alpnOverride, tlsMode)
+			}
+		} else {
+			t.Errorf("alpn_override metadata should be written for either TLS mode SIMPLE or MUTUAL")
+		}
+	} else if ok {
+		alpnOverride, found := istio.Fields[util.AlpnOverrideMetadataKey]
+		if found {
+			t.Errorf("alpn_override:%s tlsMode:%s, alpn_override metadata should not be written if TLS mode is neither SIMPLE nor MUTUAL",
+				alpnOverride.GetStringValue(), tlsMode)
 		}
 	}
 }
@@ -3840,113 +3983,6 @@ func TestBuildExternalSDSClusters(t *testing.T) {
 			}
 			if path != tt.expectedPath {
 				t.Errorf("Unexpected path, got: %v, want: %v", path, tt.expectedPath)
-			}
-		})
-	}
-}
-
-func TestConfigureALPNOverride(t *testing.T) {
-	cases := []struct {
-		name     string
-		tlsMode  networking.ClientTLSSettings_TLSmode
-		metadata *core.Metadata
-		want     *core.Metadata
-	}{
-		{
-			name:     "tlsMode SIMPLE, metadata nil",
-			tlsMode:  networking.ClientTLSSettings_SIMPLE,
-			metadata: nil,
-			want: &core.Metadata{
-				FilterMetadata: map[string]*structpb.Struct{
-					util.IstioMetadataKey: {
-						Fields: map[string]*structpb.Value{
-							util.AlpnOverrideMetadataKey: {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "false",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:    "tlsMode MUTUAL, metadata not nil",
-			tlsMode: networking.ClientTLSSettings_MUTUAL,
-			metadata: &core.Metadata{
-				FilterMetadata: map[string]*structpb.Struct{
-					util.IstioMetadataKey: {
-						Fields: map[string]*structpb.Value{
-							"other-config": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "other-config",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &core.Metadata{
-				FilterMetadata: map[string]*structpb.Struct{
-					util.IstioMetadataKey: {
-						Fields: map[string]*structpb.Value{
-							"other-config": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "other-config",
-								},
-							},
-							util.AlpnOverrideMetadataKey: {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "false",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:     "tlsMode ISTIO_MUTUAL, metadata nil",
-			tlsMode:  networking.ClientTLSSettings_ISTIO_MUTUAL,
-			metadata: nil,
-			want:     nil,
-		},
-		{
-			name:    "tlsMode ISTIO_MUTUAL, metadata not nil",
-			tlsMode: networking.ClientTLSSettings_ISTIO_MUTUAL,
-			metadata: &core.Metadata{
-				FilterMetadata: map[string]*structpb.Struct{
-					util.IstioMetadataKey: {
-						Fields: map[string]*structpb.Value{
-							"other-config": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "other-config",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: &core.Metadata{
-				FilterMetadata: map[string]*structpb.Struct{
-					util.IstioMetadataKey: {
-						Fields: map[string]*structpb.Value{
-							"other-config": {
-								Kind: &structpb.Value_StringValue{
-									StringValue: "other-config",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			newMetadata := configureALPNOverride(tt.tlsMode, tt.metadata)
-			if diff := cmp.Diff(newMetadata, tt.want, protocmp.Transform()); diff != "" {
-				t.Errorf("configureALPNOverride(%s, %v) produced incorrect result:\ngot: %v\nwant: %v\nDiff: %s", tt.tlsMode, tt.metadata, newMetadata, tt.want, diff)
 			}
 		})
 	}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -90,6 +90,10 @@ const (
 	// Envoy Stateful Session Filter
 	// TODO: Move to well known.
 	StatefulSessionFilter = "envoy.filters.http.stateful_session"
+
+	// AlpnOverrideMetadataKey is the key under which metadata is added
+	// to indicate whether Istio rewrite the ALPN headers
+	AlpnOverrideMetadataKey = "alpn_override"
 )
 
 // ALPNH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
@@ -433,6 +437,30 @@ func AddSubsetToMetadata(md *core.Metadata, subset string) {
 			},
 		}
 	}
+}
+
+// AddALPNOverrideToMetadata adds whether the the ALPN prefix should be added to the header
+// to the given core.Metadata struct, if metadata is not initialized, build a new metadata.
+func AddALPNOverrideToMetadata(metadata *core.Metadata, alpnOverride bool) *core.Metadata {
+	if metadata == nil {
+		metadata = &core.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{},
+		}
+	}
+
+	if _, ok := metadata.FilterMetadata[IstioMetadataKey]; !ok {
+		metadata.FilterMetadata[IstioMetadataKey] = &structpb.Struct{
+			Fields: map[string]*structpb.Value{},
+		}
+	}
+
+	metadata.FilterMetadata[IstioMetadataKey].Fields["alpn_override"] = &structpb.Value{
+		Kind: &structpb.Value_StringValue{
+			StringValue: strconv.FormatBool(alpnOverride),
+		},
+	}
+
+	return metadata
 }
 
 // IsHTTPFilterChain returns true if the filter chain contains a HTTP connection manager filter

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -439,9 +439,13 @@ func AddSubsetToMetadata(md *core.Metadata, subset string) {
 	}
 }
 
-// AddALPNOverrideToMetadata adds whether the the ALPN prefix should be added to the header
-// to the given core.Metadata struct, if metadata is not initialized, build a new metadata.
-func AddALPNOverrideToMetadata(metadata *core.Metadata, alpnOverride bool) *core.Metadata {
+// AddALPNOverrideToMetadata sets filter metadata `istio.alpn_override: "false"` in the given core.Metadata struct,
+// when TLS mode is SIMPLE or MUTUAL. If metadata is not initialized, builds a new metadata.
+func AddALPNOverrideToMetadata(metadata *core.Metadata, tlsMode networking.ClientTLSSettings_TLSmode) *core.Metadata {
+	if tlsMode != networking.ClientTLSSettings_SIMPLE && tlsMode != networking.ClientTLSSettings_MUTUAL {
+		return metadata
+	}
+
 	if metadata == nil {
 		metadata = &core.Metadata{
 			FilterMetadata: map[string]*structpb.Struct{},
@@ -456,7 +460,7 @@ func AddALPNOverrideToMetadata(metadata *core.Metadata, alpnOverride bool) *core
 
 	metadata.FilterMetadata[IstioMetadataKey].Fields["alpn_override"] = &structpb.Value{
 		Kind: &structpb.Value_StringValue{
-			StringValue: strconv.FormatBool(alpnOverride),
+			StringValue: "false",
 		},
 	}
 

--- a/releasenotes/notes/40680.yaml
+++ b/releasenotes/notes/40680.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 40680
+releaseNotes:
+  - |
+    **Fixed** configuring istio.alpn filter for non-Istio mTLS.


### PR DESCRIPTION
Don't merge it until we have maistra/proxy 2.5.