### PR TITLE
Fix bookinfo

### DIFF
--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM node:12.18.1-slim
+FROM node:18.16-slim
 
 #hadolint ignore=DL3008
 RUN apt-get update \


### PR DESCRIPTION
We need a newer node image to be able to build the image. This is in line with upstream.