### PR TITLE
Fix IOR wrongly copying argocd internal annotation from Gateway to route

### DIFF
--- a/pilot/pkg/config/kube/ior/controller.go
+++ b/pilot/pkg/config/kube/ior/controller.go
@@ -126,6 +126,21 @@ func (r *routeController) deleteRoute(route *v1.Route) error {
 	return nil
 }
 
+func filteredRouteAnnotation(routeAnnotation string) bool {
+	filteredPrefixes := [...]string{
+		ShouldManageRouteAnnotation,
+		"kubectl.kubernetes.io",
+		"argocd.argoproj.io",
+	}
+
+	for _, prefix := range filteredPrefixes {
+		if strings.HasPrefix(routeAnnotation, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func buildRoute(metadata config.Meta, originalHost string, tls *networking.ServerTLSSettings, serviceNamespace string, serviceName string) *v1.Route {
 	actualHost, wildcard := getActualHost(originalHost, true)
 
@@ -144,7 +159,7 @@ func buildRoute(metadata config.Meta, originalHost string, tls *networking.Serve
 		originalHostAnnotation: originalHost,
 	}
 	for keyName, keyValue := range metadata.Annotations {
-		if !strings.HasPrefix(keyName, "kubectl.kubernetes.io") && keyName != ShouldManageRouteAnnotation {
+		if !filteredRouteAnnotation(keyName) {
 			annotationMap[keyName] = keyValue
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

When IOR creates a route from a Gateway, it copies all annotations, including annotations managed by argoCD (https://argo-cd.readthedocs.io/en/stable/).
As a consequence, when deploying the Gateway with argocd, the argocd.argoproj.io/instance (used by argoCD to track the objects it manages) is copied in the route. From this point ArgoCD constantly deletes the route (since it is not part of the desired manifest). This makes it impossible to deploy Gateway with argoCD, unless IOR automatic route creation is disabled.

This PR filter the argocd annotations when generating routes from Gateways.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
