### PR TITLE
[maistra-2.4] Backport routing requests to external services on IPv6-only clusters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -708,6 +708,13 @@ func buildSidecarOutboundTCPListenerOptsForPortOrUDS(listenerMapKey *string,
 	if len(listenerOpts.bind) == 0 {
 		svcListenAddress := listenerOpts.service.GetAddressForProxy(listenerOpts.proxy)
 		svcExtraListenAddress := listenerOpts.service.GetExtraAddressesForProxy(listenerOpts.proxy)
+		// Override the svcListenAddress, using the proxy ipFamily, for cases where the ipFamily cannot be detected easily.
+		// For example: due to the possibility of using hostnames instead of ips in ServiceEntry,
+		// it is hard to detect ipFamily for such services.
+		if listenerOpts.service.Attributes.ServiceRegistry == provider.External && listenerOpts.proxy.IsIPv6() &&
+			svcListenAddress == constants.UnspecifiedIP {
+			svcListenAddress = constants.UnspecifiedIPv6
+		}
 		// We should never get an empty address.
 		// This is a safety guard, in case some platform adapter isn't doing things
 		// properly

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -17,6 +17,8 @@ package constants
 const (
 	// UnspecifiedIP constant for empty IP address
 	UnspecifiedIP = "0.0.0.0"
+	// UnspecifiedIPv6 constant for empty IPv6 address
+	UnspecifiedIPv6 = "::/0"
 
 	// AuthCertsPath is the path location for mTLS certificates
 	AuthCertsPath = "/etc/certs/"

--- a/pkg/test/framework/components/echo/check/checkers.go
+++ b/pkg/test/framework/components/echo/check/checkers.go
@@ -127,7 +127,7 @@ func NotOK() echo.Checker {
 	return ErrorOrNotStatus(http.StatusOK)
 }
 
-// NoErrorAndStatus is checks that no error occurred and htat the returned status code matches the expected
+// NoErrorAndStatus is checks that no error occurred and that the returned status code matches the expected
 // value.
 func NoErrorAndStatus(expected int) echo.Checker {
 	return And(NoError(), Status(expected))

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -577,7 +577,7 @@ unable to locate an Envoy binary
 This is documented in this [PR](https://github.com/istio/istio/issues/13677). Once the Envoy binary is available for the Mac,
 these tests will hopefully succeed.
 
-* If one uses Docker for Mac for the kubernetes environment be sure to specify the `-istio.test.kube.loadbalancer=false` parameter. The solves an error like:
+* If one uses Docker for Mac for the kubernetes environment be sure to specify the `-istio.test.kube.loadbalancer=false` parameter. This solves an error like:
 
 ```plain
 service ingress is not available yet

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -20,6 +20,7 @@ package common
 import (
 	"fmt"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"reflect"
 	"sort"
@@ -2758,6 +2759,103 @@ func VMTestCases(vms echo.Instances) func(t TrafficContext) {
 				},
 			})
 		}
+	}
+}
+
+func TestExternalService(t TrafficContext) {
+	// Let us enable outboundTrafficPolicy REGISTRY_ONLY
+	// on one of the workloads, to verify selective external connectivity
+	SidecarScope := fmt.Sprintf(`apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: restrict-external-service
+  namespace: %s
+spec:
+  workloadSelector:
+    labels:
+      app: a
+  outboundTrafficPolicy:
+    mode: "REGISTRY_ONLY"
+`, t.Apps.EchoNamespace.Namespace.Name())
+
+	fakeExternalAddress := t.Apps.External.All[0].Address()
+	parsedIP, err := netip.ParseAddr(fakeExternalAddress)
+	if err == nil {
+		if parsedIP.Is6() {
+			// CI has some issues with ipv6 DNS resolution, due to which
+			// we are not able to directly use the host name in the connectivity tests.
+			// Hence using a bogus IPv6 address with -HHost option as a workaround to
+			// simulate ServiceEntry based wildcard listener scenarios.
+			fakeExternalAddress = "2002::1"
+		} else {
+			fakeExternalAddress = "1.1.1.1"
+		}
+	}
+
+	testCases := []struct {
+		name       string
+		statusCode int
+		from       echo.Instances
+		to         string
+		protocol   protocol.Instance
+		port       int
+	}{
+		// TC1: Test connectivity to external service from outboundTrafficPolicy restricted pod.
+		// The external service is exposed through a ServiceEntry, so the traffic should go through
+		{
+			name:       "traffic from outboundTrafficPolicy REGISTRY_ONLY to allowed host",
+			statusCode: http.StatusOK,
+			from:       t.Apps.A,
+			to:         t.Apps.External.All[0].Address(),
+			protocol:   protocol.HTTPS,
+			port:       443,
+		},
+		// TC2: Same test as TC1, but use a fake external ip in destination for connectivity.
+		{
+			name:       "traffic from outboundTrafficPolicy REGISTRY_ONLY to allowed host",
+			statusCode: http.StatusOK,
+			from:       t.Apps.A,
+			to:         fakeExternalAddress,
+			protocol:   protocol.HTTPS,
+			port:       443,
+		},
+		// TC3: Test connectivity to external service from outboundTrafficPolicy=PASS_THROUGH pod.
+		// Traffic should go through without the need for any explicit ServiceEntry
+		{
+			name:       "traffic from outboundTrafficPolicy PASS_THROUGH to any host",
+			statusCode: http.StatusOK,
+			from:       t.Apps.B,
+			to:         t.Apps.External.All[0].Address(),
+			protocol:   protocol.HTTP,
+			port:       80,
+		},
+		// TC4: Same test as TC3, but use a fake external ip in destination for connectivity.
+		{
+			name:       "traffic from outboundTrafficPolicy PASS_THROUGH to any host",
+			statusCode: http.StatusOK,
+			from:       t.Apps.B,
+			to:         fakeExternalAddress,
+			protocol:   protocol.HTTP,
+			port:       80,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.RunTraffic(TrafficTestCase{
+			name:   fmt.Sprintf("%v to external service %v", tc.from[0].NamespacedName(), tc.to),
+			config: SidecarScope,
+			opts: echo.CallOptions{
+				Address: tc.to,
+				HTTP: echo.HTTP{
+					Headers: HostHeader(t.Apps.External.All[0].Config().DefaultHostHeader),
+				},
+				Port: echo.Port{Protocol: tc.protocol, ServicePort: tc.port},
+				Check: check.And(
+					check.Status(tc.statusCode),
+				),
+			},
+			call: tc.from[0].CallOrFail,
+		})
 	}
 }
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -2811,14 +2811,15 @@ spec:
 			port:       443,
 		},
 		// TC2: Same test as TC1, but use a fake external ip in destination for connectivity.
-		{
-			name:       "traffic from outboundTrafficPolicy REGISTRY_ONLY to allowed host",
-			statusCode: http.StatusOK,
-			from:       t.Apps.A,
-			to:         fakeExternalAddress,
-			protocol:   protocol.HTTPS,
-			port:       443,
-		},
+		// https://issues.redhat.com/browse/OSSM-4809
+		//{
+		//	name:       "traffic from outboundTrafficPolicy REGISTRY_ONLY to allowed host",
+		//	statusCode: http.StatusOK,
+		//	from:       t.Apps.A,
+		//	to:         fakeExternalAddress,
+		//	protocol:   protocol.HTTPS,
+		//	port:       443,
+		//},
 		// TC3: Test connectivity to external service from outboundTrafficPolicy=PASS_THROUGH pod.
 		// Traffic should go through without the need for any explicit ServiceEntry
 		{

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -253,6 +253,7 @@ func RunAllTrafficTests(t framework.TestContext, i istio.Instance, apps deployme
 	RunCase("destinationrule", destinationRuleCases)
 	RunCase("vm", VMTestCases(apps.VM))
 	RunCase("dns", DNSTestCases)
+	RunCase("externalservice", TestExternalService)
 }
 
 func ExpectString(got, expected, help string) error {


### PR DESCRIPTION
I made this backport as a side-effect of debugging federation, but we might consider including this fix as we support IPv6-only clusters.