### PR TITLE
WIP: OSSM-2341: Backport Disable full push on scale from 1->0->1 (#40866)

### DIFF
--- a/pilot/pkg/model/endpointshards.go
+++ b/pilot/pkg/model/endpointshards.go
@@ -199,14 +199,6 @@ func (e *EndpointIndex) deleteServiceInner(shard ShardKey, serviceName, namespac
 	epShards := e.shardsBySvc[serviceName][namespace]
 	epShards.Lock()
 	delete(epShards.Shards, shard)
-	epShards.ServiceAccounts = sets.Set{}
-	for _, shard := range epShards.Shards {
-		for _, ep := range shard {
-			if ep.ServiceAccount != "" {
-				epShards.ServiceAccounts.Insert(ep.ServiceAccount)
-			}
-		}
-	}
 	// Clear the cache here to avoid race in cache writes.
 	e.clearCacheForService(serviceName, namespace)
 	if !preserveKeys {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,6 +46,7 @@ import (
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/pkg/log"
 )
@@ -554,58 +555,87 @@ func TestEDSServiceResolutionUpdate(t *testing.T) {
 
 // Validate that when endpoints of a service flipflop between 1 and 0 does not trigger a full push.
 func TestEndpointFlipFlops(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
-	addEdsCluster(s, "flipflop.com", "http", "10.0.0.53", 8080)
-
-	adscConn := s.Connect(nil, nil, watchAll)
-
-	// Validate that endpoints are pushed correctly.
-	testEndpoints("10.0.0.53", "outbound|8080||flipflop.com", adscConn, t)
-
-	// Clear the endpoint and validate it does not trigger a full push.
-	s.Discovery.MemRegistry.SetEndpoints("flipflop.com", "", []*model.IstioEndpoint{})
-
-	upd, _ := adscConn.Wait(5*time.Second, v3.EndpointType)
-
-	if contains(upd, "cds") {
-		t.Fatalf("Expecting only EDS update as part of a partial push. But received CDS also %v", upd)
+	cases := []struct {
+		name           string
+		newSa          string
+		expectFullPush bool
+	}{
+		{
+			name:           "same service account",
+			newSa:          "sa",
+			expectFullPush: false,
+		},
+		{
+			name:           "different service account",
+			newSa:          "new-sa",
+			expectFullPush: true,
+		},
 	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+			addEdsCluster(s, "flipflop.com", "http", "10.0.0.53", 8080)
 
-	if len(upd) > 0 && !contains(upd, v3.EndpointType) {
-		t.Fatalf("Expecting EDS push as part of a partial push. But received %v", upd)
-	}
+			adscConn := s.Connect(nil, nil, watchAll)
 
-	lbe := adscConn.GetEndpoints()["outbound|8080||flipflop.com"]
-	if len(lbe.Endpoints) != 0 {
-		t.Fatalf("There should be no endpoints for outbound|8080||flipflop.com. Endpoints:\n%v", adscConn.EndpointsJSON())
-	}
+			// Validate that endpoints are pushed correctly.
+			testEndpoints("10.0.0.53", "outbound|8080||flipflop.com", adscConn, t)
 
-	// Validate that keys in service still exist in EndpointIndex - this prevents full push.
-	if _, ok := s.Discovery.EndpointIndex.ShardsForService("flipflop.com", ""); !ok {
-		t.Fatalf("Expected service key %s to be present in EndpointIndex. But missing %v", "flipflop.com", s.Discovery.EndpointIndex.Shardz())
-	}
+			// Clear the endpoint and validate it does not trigger a full push.
+			s.Discovery.MemRegistry.SetEndpoints("flipflop.com", "", []*model.IstioEndpoint{})
 
-	// Set the endpoints again and validate it does not trigger full push.
-	s.Discovery.MemRegistry.SetEndpoints("flipflop.com", "",
-		[]*model.IstioEndpoint{
-			{
-				Address:         "10.10.1.1",
-				ServicePortName: "http",
-				EndpointPort:    8080,
-			},
+			upd, _ := adscConn.Wait(5*time.Second, v3.EndpointType)
+			assert.Equal(t, upd, []string{v3.EndpointType}, "expected partial push")
+
+			lbe := adscConn.GetEndpoints()["outbound|8080||flipflop.com"]
+			if len(lbe.Endpoints) != 0 {
+				t.Fatalf("There should be no endpoints for outbound|8080||flipflop.com. Endpoints:\n%v", adscConn.EndpointsJSON())
+			}
+
+			// Validate that keys in service still exist in EndpointIndex - this prevents full push.
+			if _, ok := s.Discovery.EndpointIndex.ShardsForService("flipflop.com", ""); !ok {
+				t.Fatalf("Expected service key %s to be present in EndpointIndex. But missing %v", "flipflop.com", s.Discovery.EndpointIndex.Shardz())
+			}
+
+			// Set the endpoints again and validate it does not trigger full push.
+			s.Discovery.MemRegistry.SetEndpoints("flipflop.com", "",
+				[]*model.IstioEndpoint{
+					{
+						Address:         "10.10.1.1",
+						ServicePortName: "http",
+						EndpointPort:    8080,
+						ServiceAccount:  tt.newSa,
+					},
+				})
+
+			upd, _ = adscConn.Wait(5*time.Second, v3.EndpointType)
+
+			if tt.expectFullPush {
+				if !contains(upd, v3.ClusterType) {
+					t.Fatalf("expected a CDS push, got: %+v", upd)
+				}
+
+				if !contains(upd, v3.EndpointType) {
+					t.Fatalf("expected an EDS push, got: %+v", upd)
+				}
+			} else {
+				if contains(upd, v3.ClusterType) {
+					t.Fatalf("expected no CDS push, got: %+v", upd)
+				}
+
+				if !contains(upd, v3.EndpointType) {
+					t.Fatalf("expected an EDS push, got: %+v", upd)
+				}
+			}
+
+			testEndpoints("10.10.1.1", "outbound|8080||flipflop.com", adscConn, t)
+			if shard, ok := s.Discovery.EndpointIndex.ShardsForService("flipflop.com", ""); !ok {
+				t.Fatalf("Expected service key %s to be present in EndpointIndex. But missing %v", "flipflop.com", s.Discovery.EndpointIndex.Shardz())
+			} else {
+				assert.Equal(t, shard.ServiceAccounts.SortedList(), []string{tt.newSa})
+			}
 		})
-
-	upd, _ = adscConn.Wait(5*time.Second, v3.EndpointType)
-
-	if contains(upd, v3.ClusterType) {
-		t.Fatalf("expecting only EDS update as part of a partial push. But received CDS also %+v", upd)
 	}
-
-	if len(upd) > 0 && !contains(upd, v3.EndpointType) {
-		t.Fatalf("expecting EDS push as part of a partial push. But did not receive %+v", upd)
-	}
-
-	testEndpoints("10.10.1.1", "outbound|8080||flipflop.com", adscConn, t)
 }
 
 // Validate that deleting a service clears entries from EndpointIndex.
@@ -708,27 +738,6 @@ func TestUpdateServiceAccount(t *testing.T) {
 				t.Errorf("expect UpdateServiceAccount %v, but got %v", tc.expect, ret)
 			}
 		})
-	}
-}
-
-func TestZeroEndpointShardSA(t *testing.T) {
-	cluster1Endppoints := []*model.IstioEndpoint{
-		{Address: "10.172.0.1", ServiceAccount: "sa1"},
-	}
-	s := new(xds.DiscoveryServer)
-	s.Cache = model.DisabledCache{}
-	s.EndpointIndex = model.NewEndpointIndex()
-	originalEndpointsShard, _ := s.EndpointIndex.GetOrCreateEndpointShard("test", "test")
-	originalEndpointsShard.Shards = map[model.ShardKey][]*model.IstioEndpoint{
-		c1Key: cluster1Endppoints,
-	}
-	originalEndpointsShard.ServiceAccounts = map[string]struct{}{
-		"sa1": {},
-	}
-	s.EDSCacheUpdate(c1Key, "test", "test", []*model.IstioEndpoint{})
-	modifiedShard, _ := s.EndpointIndex.GetOrCreateEndpointShard("test", "test")
-	if len(modifiedShard.ServiceAccounts) != 0 {
-		t.Errorf("endpoint shard service accounts got %v want 0", len(modifiedShard.ServiceAccounts))
 	}
 }
 
@@ -1238,6 +1247,7 @@ func addEdsCluster(s *xds.FakeDiscoveryServer, hostName string, portName string,
 			Address:         address,
 			EndpointPort:    uint32(port),
 			ServicePortName: portName,
+			ServiceAccount:  "sa",
 		},
 		ServicePort: &model.Port{
 			Name:     portName,

--- a/releasenotes/notes/full-push-regression.yaml
+++ b/releasenotes/notes/full-push-regression.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue: [39652]
+releaseNotes:
+- |
+  **Improved** xDS pushing to trigger partial pushes when scaling workloads down to zero instances and back up.


### PR DESCRIPTION
backporting fix to maistra-2.3 branch:
https://github.com/maistra/istio/commit/9f1cbfb27a15023827d7a774860fc8b3a5a2629d

* Disable full push on scale from 1->0->1

Fixes https://github.com/istio/istio/issues/39652

This reverts https://github.com/istio/istio/pull/36882. At the time, that PR was needed because EDS ServiceAccounts and CDS ServiceAccounts were decoupled; Since https://github.com/istio/istio/pull/39133, this is no longer true, and the fix in 36882 is not needed any longer.

This PR *removes* the test added in 36882 (since it tests low level details that are not relevant anymore). It improves the existing TestEndpointFlipFlops test -- while that test *would* have caught the regression, it didn't actually set any service accounts so it was missed. The update changes it to correctly detect the behavior (it now fails without this PR, passes with it).

* add note

* fix note

* Add new SA case

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
