### PR TITLE
OSSM-2042: Deployment of SMCP named "default" fails

### DIFF
--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -119,7 +119,7 @@ func (s *Server) initMeshNetworks(args *PilotArgs, fileWatcher filewatcher.FileW
 
 func getMeshConfigMapName(revision string) string {
 	name := defaultMeshConfigMapName
-	if revision == "" || revision == "default" {
+	if revision == "" {
 		return name
 	}
 	return name + "-" + revision

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -112,7 +112,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 
 func getInjectorConfigMapName(revision string) string {
 	name := defaultInjectorConfigMapName
-	if revision == "" || revision == "default" {
+	if revision == "" {
 		return name
 	}
 	return name + "-" + revision


### PR DESCRIPTION
**Please provide a description of this PR:**

Fixes `x509: certificate is not valid for istiod-default.istio-system.svc` and `'Internal error occurred: failed calling webhook "sidecar-injector.istio.io": failed to call webhook: the server could not find the requested resource'` errors for `prometheus` and `istio-*gateway` deployments when SMCP name is `default`.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
