### PR TITLE
OSSM-4818 Set dynamically-determined UID/GID in gateways

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -55,6 +55,30 @@ spec:
       - name: istio-proxy
         image: "{{ .ProxyImage }}"
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+        securityContext:
+        {{- if .KubeVersion122 }}
+          # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+          capabilities:
+            drop:
+            - ALL
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: {{ .ProxyUID | default "1337" }}
+          runAsGroup: {{ .ProxyGID | default "1337" }}
+          runAsNonRoot: true
+        {{- else }}
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+          runAsUser: 0
+          runAsGroup: 1337
+          runAsNonRoot: false
+          allowPrivilegeEscalation: true
+          readOnlyRootFilesystem: true
+        {{- end }}
         ports:
         - containerPort: 15021
           name: status-port

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -298,6 +298,12 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 	log.Info("reconciling")
 
+	var ns *corev1.Namespace
+	if d.namespaces != nil {
+		ns = d.namespaces.Get(gw.Namespace, "")
+	}
+	proxyUID, proxyGID := GetProxyIDs(ns)
+
 	defaultName := getDefaultName(gw.Name, &gw.Spec)
 	input := TemplateInput{
 		Gateway:        &gw,
@@ -307,6 +313,8 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		ClusterID:      d.clusterID.String(),
 		KubeVersion122: kube.IsAtLeastVersion(d.client, 22),
 		Revision:       d.revision,
+		ProxyUID:       proxyUID,
+		ProxyGID:       proxyGID,
 	}
 
 	if overwriteControllerVersion {
@@ -500,6 +508,8 @@ type TemplateInput struct {
 	ClusterID      string
 	KubeVersion122 bool
 	Revision       string
+	ProxyUID       int64
+	ProxyGID       int64
 }
 
 func extractServicePorts(gw gateway.Gateway) []corev1.ServicePort {

--- a/pilot/pkg/config/kube/gateway/openshift.go
+++ b/pilot/pkg/config/kube/gateway/openshift.go
@@ -1,0 +1,184 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Functions below were copied from
+// https://github.com/openshift/apiserver-library-go/blob/c22aa58bb57416b9f9f190957d07c9e7669c26df/pkg/securitycontextconstraints/sccmatching/matcher.go
+// These functions are not exported, and, if they were, when imported bring k8s.io/kubernetes as dependency, which is problematic
+// License is Apache 2.0: https://github.com/openshift/apiserver-library-go/blob/c22aa58bb57416b9f9f190957d07c9e7669c26df/LICENSE
+
+package gateway
+
+import (
+	"fmt"
+	"strings"
+
+	securityv1 "github.com/openshift/api/security/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"istio.io/istio/tools/istio-iptables/pkg/constants"
+)
+
+// GetProxyIDs returns the UID and GID to be used in the RunAsUser and RunAsGroup fields in the template
+// Inspects the namespace metadata for hints and fallbacks to the usual value of 1337.
+func GetProxyIDs(namespace *corev1.Namespace) (uid int64, gid int64) {
+	uid = constants.DefaultProxyUIDInt
+	gid = constants.DefaultProxyUIDInt
+
+	if namespace == nil {
+		return
+	}
+
+	// Check for OpenShift specifics and returns the max number in the range specified in the namespace annotation
+	if _, uidMax, err := getPreallocatedUIDRange(namespace); err == nil {
+		uid = *uidMax
+	}
+	if groups, err := getPreallocatedSupplementalGroups(namespace); err == nil && len(groups) > 0 {
+		gid = groups[0].Max
+	}
+
+	return
+}
+
+// getPreallocatedUIDRange retrieves the annotated value from the namespace, splits it to make
+// the min/max and formats the data into the necessary types for the strategy options.
+func getPreallocatedUIDRange(ns *corev1.Namespace) (*int64, *int64, error) {
+	annotationVal, ok := ns.Annotations[securityv1.UIDRangeAnnotation]
+	if !ok {
+		return nil, nil, fmt.Errorf("unable to find annotation %s", securityv1.UIDRangeAnnotation)
+	}
+	if len(annotationVal) == 0 {
+		return nil, nil, fmt.Errorf("found annotation %s but it was empty", securityv1.UIDRangeAnnotation)
+	}
+	uidBlock, err := ParseBlock(annotationVal)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	min := int64(uidBlock.Start)
+	max := int64(uidBlock.End)
+	log.Debugf("got preallocated values for min: %d, max: %d for uid range in namespace %s", min, max, ns.Name)
+	return &min, &max, nil
+}
+
+// getPreallocatedSupplementalGroups gets the annotated value from the namespace.
+func getPreallocatedSupplementalGroups(ns *corev1.Namespace) ([]securityv1.IDRange, error) {
+	groups, err := getSupplementalGroupsAnnotation(ns)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("got preallocated value for groups: %s in namespace %s", groups, ns.Name)
+
+	blocks, err := parseSupplementalGroupAnnotation(groups)
+	if err != nil {
+		return nil, err
+	}
+
+	idRanges := []securityv1.IDRange{}
+	for _, block := range blocks {
+		rng := securityv1.IDRange{
+			Min: int64(block.Start),
+			Max: int64(block.End),
+		}
+		idRanges = append(idRanges, rng)
+	}
+	return idRanges, nil
+}
+
+// getSupplementalGroupsAnnotation provides a backwards compatible way to get supplemental groups
+// annotations from a namespace by looking for SupplementalGroupsAnnotation and falling back to
+// UIDRangeAnnotation if it is not found.
+func getSupplementalGroupsAnnotation(ns *corev1.Namespace) (string, error) {
+	groups, ok := ns.Annotations[securityv1.SupplementalGroupsAnnotation]
+	if !ok {
+		log.Debugf("unable to find supplemental group annotation %s falling back to %s", securityv1.SupplementalGroupsAnnotation, securityv1.UIDRangeAnnotation)
+
+		groups, ok = ns.Annotations[securityv1.UIDRangeAnnotation]
+		if !ok {
+			return "", fmt.Errorf("unable to find supplemental group or uid annotation for namespace %s", ns.Name)
+		}
+	}
+
+	if len(groups) == 0 {
+		return "", fmt.Errorf("unable to find groups using %s and %s annotations", securityv1.SupplementalGroupsAnnotation, securityv1.UIDRangeAnnotation)
+	}
+	return groups, nil
+}
+
+// parseSupplementalGroupAnnotation parses the group annotation into blocks.
+func parseSupplementalGroupAnnotation(groups string) ([]Block, error) {
+	blocks := []Block{}
+	segments := strings.Split(groups, ",")
+	for _, segment := range segments {
+		block, err := ParseBlock(segment)
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, block)
+	}
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("no blocks parsed from annotation %s", groups)
+	}
+	return blocks, nil
+}
+
+// Functions below were copied from
+// https://github.com/openshift/library-go/blob/561433066966536ac17f3c9852d7d85f7b7e1e36/pkg/security/uid/uid.go
+// Copied here to avoid bringing tons of dependencies
+// License is Apache 2.0: https://github.com/openshift/library-go/blob/561433066966536ac17f3c9852d7d85f7b7e1e36/LICENSE
+
+type Block struct {
+	Start uint32
+	End   uint32
+}
+
+var (
+	ErrBlockSlashBadFormat = fmt.Errorf("block not in the format \"<start>/<size>\"")
+	ErrBlockDashBadFormat  = fmt.Errorf("block not in the format \"<start>-<end>\"")
+)
+
+func ParseBlock(in string) (Block, error) {
+	if strings.Contains(in, "/") {
+		var start, size uint32
+		n, err := fmt.Sscanf(in, "%d/%d", &start, &size)
+		if err != nil {
+			return Block{}, err
+		}
+		if n != 2 {
+			return Block{}, ErrBlockSlashBadFormat
+		}
+		return Block{Start: start, End: start + size - 1}, nil
+	}
+
+	var start, end uint32
+	n, err := fmt.Sscanf(in, "%d-%d", &start, &end)
+	if err != nil {
+		return Block{}, err
+	}
+	if n != 2 {
+		return Block{}, ErrBlockDashBadFormat
+	}
+	return Block{Start: start, End: end}, nil
+}
+
+func (b Block) String() string {
+	return fmt.Sprintf("%d/%d", b.Start, b.Size())
+}
+
+func (b Block) RangeString() string {
+	return fmt.Sprintf("%d-%d", b.Start, b.End)
+}
+
+func (b Block) Size() uint32 {
+	return b.End - b.Start + 1
+}

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/cluster-ip.yaml
@@ -129,6 +129,16 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 30
           httpGet:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-ip.yaml
@@ -127,6 +127,16 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 30
           httpGet:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/manual-sa.yaml
@@ -127,6 +127,16 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 30
           httpGet:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/multinetwork.yaml
@@ -131,6 +131,16 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 30
           httpGet:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/proxy-config-crd.yaml
@@ -127,6 +127,16 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 30
           httpGet:

--- a/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/deployment/simple.yaml
@@ -127,6 +127,16 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 30
           httpGet:

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.39.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.39.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1450,6 +1450,30 @@ templates:
           - name: istio-proxy
             image: "{{ .ProxyImage }}"
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+            securityContext:
+            {{- if .KubeVersion122 }}
+              # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+              capabilities:
+                drop:
+                - ALL
+              allowPrivilegeEscalation: false
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
+              runAsNonRoot: true
+            {{- else }}
+              capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+              runAsUser: 0
+              runAsGroup: 1337
+              runAsNonRoot: false
+              allowPrivilegeEscalation: true
+              readOnlyRootFilesystem: true
+            {{- end }}
             ports:
             - containerPort: 15021
               name: status-port

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -134,7 +134,8 @@ Only applies when traffic from all groups (i.e. "*") is being redirected to Envo
 )
 
 const (
-	DefaultProxyUID = "1337"
+	DefaultProxyUID    = "1337"
+	DefaultProxyUIDInt = int64(1337)
 )
 
 // Constants used in environment variables


### PR DESCRIPTION
Pick changes only related to the gateway deployment controller from the commit below.

* Remove the need of anyuid permission on OpenShift (#45394)

- Remove the hard-coded usages of `runAsUser` and `runAsGroup` in charts
- Where necessary, replace them with a helm field `.ProxyUID` and `.ProxyGID`.
- When running in OpenShift, these fields will be set at runtime based on annotations present on the pod's namespace.
- When not on OpenShift (strictly speaking, when such annotations are not present), these values fallback to the current, defauls value of 1337.

With this change we can remove the extra steps related to `anyuid` in the [OpenShift setup page](https://istio.io/v1.17/docs/setup/platform-setup/openshift/).

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
