### PR TITLE
OSSM-3647: Add feature flag `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY`

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -645,6 +645,9 @@ var (
 		"Whether to enable IOR component, which provides integration between Istio Gateways and OpenShift Routes").Get()
 
 	EnableFederation = env.RegisterBoolVar("PILOT_ENABLE_FEDERATION", false, "").Get()
+
+	ApplyWasmPluginsToInboundOnly = env.RegisterBoolVar("APPLY_WASM_PLUGINS_TO_INBOUND_ONLY", false,
+		"If enabled, WASM plugins will be applied to inbound listeners.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1163,9 +1163,11 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 
 	routerFilterCtx, reqIDExtensionCtx := configureTracing(lb.push, lb.node, connectionManager, httpOpts.class)
 
+	var wasm map[extensions.PluginPhase][]*model.WasmPluginWrapper
+	if !(features.ApplyWasmPluginsToInboundOnly && httpOpts.class == istionetworking.ListenerClassSidecarOutbound) {
+		wasm = lb.push.WasmPlugins(lb.node)
+	}
 	filters := []*hcm.HttpFilter{}
-	// TODO(jewertow): push wasm plugins only if istionetworking.ListenerClassSidecarInbound, look at ALPN
-	wasm := lb.push.WasmPlugins(lb.node)
 	// TODO: how to deal with ext-authz? It will be in the ordering twice
 	filters = append(filters, lb.authzCustomBuilder.BuildHTTP(httpOpts.class)...)
 	filters = extension.PopAppend(filters, wasm, extensions.PluginPhase_AUTHN)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1164,6 +1164,7 @@ func (lb *ListenerBuilder) buildHTTPConnectionManager(httpOpts *httpListenerOpts
 	routerFilterCtx, reqIDExtensionCtx := configureTracing(lb.push, lb.node, connectionManager, httpOpts.class)
 
 	filters := []*hcm.HttpFilter{}
+	// TODO(jewertow): push wasm plugins only if istionetworking.ListenerClassSidecarInbound, look at ALPN
 	wasm := lb.push.WasmPlugins(lb.node)
 	// TODO: how to deal with ext-authz? It will be in the ordering twice
 	filters = append(filters, lb.authzCustomBuilder.BuildHTTP(httpOpts.class)...)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -285,14 +285,11 @@ func TestOutboundListenerConfig_WithSidecar(t *testing.T) {
 func TestOutboundListenerConfig_WithWasmPlugin(t *testing.T) {
 	wasmPlugin := config.Config{
 		Meta: config.Meta{
-			Name:             "3scale-auth-plugin",
+			Name:             "wasm-plugin",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.WasmPlugin,
 		},
-		Spec: &extensions.WasmPlugin{
-			Url:   "oci://quay.io/3scale/threescale-wasm-auth:0.0.4",
-			Phase: extensions.PluginPhase_AUTHZ,
-		},
+		Spec: &extensions.WasmPlugin{},
 	}
 	cg := NewConfigGenTest(t, TestOptions{
 		Services: []*model.Service{
@@ -308,7 +305,7 @@ func TestOutboundListenerConfig_WithWasmPlugin(t *testing.T) {
 		FilterChains: []listenertest.FilterChainTest{{
 			TotalMatch: true,
 			HTTPFilters: []string{
-				"not-default.3scale-auth-plugin",
+				"not-default.wasm-plugin",
 				xdsfilters.MxFilterName,
 				xdsfilters.AlpnFilterName,
 				xdsfilters.Fault.Name,


### PR DESCRIPTION
**Background context:**

In Istio 1.12 (maistra-2.2) WASM plugins were applied to inbound listeners only. It was changed in Istio 1.14.x (maistra-2.3) and WASM plugins are applied to inbound and outbound listeners. This is a problem for users who use `threescale-auth-wasm` plugin with JWT authentication filter, because that filter is applied to inbound only and therefore threescale always rejects requests returning 403.

**Solution:**

This PR adds flag `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY`, which disables applying WASM plugins to outbound listeners. It will allow threescale users to safely upgrade from maistra-2.2 to maistra-2.3.