### PR TITLE
[maistra-2.4] OSSM-3647: Add feature flag `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY`

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -727,6 +727,10 @@ var (
 		"If enabled, will validate the identity of a workload matches the identity of the "+
 			"WorkloadEntry it is associating with for health checks and auto registration. "+
 			"This flag is added for backwards compatibility only and will be removed in future releases").Get()
+
+	ApplyWasmPluginsToInboundOnly = env.RegisterBoolVar("APPLY_WASM_PLUGINS_TO_INBOUND_ONLY", false,
+		"If enabled, WASM plugins will be only applied to inbound listeners. "+
+			"This flag is ignored when spec.match is defined in a WasmPlugin.").Get()
 )
 
 // EnableEndpointSliceController returns the value of the feature flag and whether it was actually specified.

--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -28,6 +28,7 @@ import (
 
 	extensions "istio.io/api/extensions/v1alpha1"
 	typeapi "istio.io/api/type/v1beta1"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model/credentials"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/util/protoconv"
@@ -75,6 +76,9 @@ type WasmPluginWrapper struct {
 }
 
 func (p *WasmPluginWrapper) MatchListener(proxyLabels map[string]string, li WasmPluginListenerInfo) bool {
+	if features.ApplyWasmPluginsToInboundOnly && p.Match == nil && li.Class == istionetworking.ListenerClassSidecarOutbound {
+		return false
+	}
 	workloadMatch := (p.Selector == nil || labels.Instance(p.Selector.MatchLabels).SubsetOf(proxyLabels))
 	return workloadMatch && matchTrafficSelectors(p.Match, li)
 }


### PR DESCRIPTION
This is a follow-up to #876, but adjusted to the newer WasmPlugin API.

In v2.4, `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` will be ignored when WasmPlugin has specified `spec.match`. Otherwise, users would not be able to migrate to the old API.

The only purpose of this flag is enabling safe migration from v2.2 to v2.3 and v2.4. Let's say, I have maistra-2.2 deployed and I use ServiceMeshExtensions with 3scale plugin. This is a step-by-step instruction for safe migration to maistra-2.4:
1. Create WasmPlugins, delete ServiceMeshExtensions and set `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` in pilot container, which will ignore the flag at this step.
2. Upgrade control plane to v2.3. `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` is respected by pilot and WASM plugins do not apply to outbound listeners, so there is no outage in apps with 3scale plugin.
3. Upgrade to v2.4. `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` is still respected, so `spec.match` can be added to WasmPlugin objects.
4. When all WasmPlugins use `spec.match[].mode: SERVER`, `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` can be removed from pilot container.