### PR TITLE
OSSM-5312: Remove TagWatcher from gateway deployment controller

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
@@ -53,7 +53,11 @@ spec:
       serviceAccountName: {{.ServiceAccount | quote}}
       containers:
       - name: istio-proxy
+      {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+        image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+      {{- else }}
         image: "{{ .ProxyImage }}"
+      {{- end }}
         {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
         ports:
         - containerPort: 15021

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -38,7 +38,6 @@ import (
 	"istio.io/istio/pkg/config/analysis/incluster"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/revisions"
 	"istio.io/pkg/log"
 )
 
@@ -184,22 +183,14 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 					AddRunFunction(func(leaderStop <-chan struct{}) {
 						// We can only run this if the Gateway CRD is created
 						if configController.WaitForCRD(gvk.KubernetesGateway, leaderStop) {
-							var tagWatcher revisions.TagWatcher
-							// TagWatcher requires permission for MutatingWebhook, so it can't be used in multi-tenant mode
-							if !s.kubeClient.IsMultiTenant() {
-								tagWatcher = revisions.NewTagWatcher(s.kubeClient, args.Revision)
-							}
 							controller := gateway.NewDeploymentController(s.kubeClient, s.clusterID, s.environment,
-								s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, tagWatcher, args.Revision)
+								s.webhookInfo.getWebhookConfig, s.webhookInfo.addHandler, args.Revision)
 							// Start informers again. This fixes the case where informers for namespace do not start,
 							// as we create them only after acquiring the leader lock
 							// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
 							// basically lazy loading the informer, if we stop it when we lose the lock we will never
 							// recreate it again.
 							s.kubeClient.RunAndWait(stop)
-							if tagWatcher != nil {
-								go tagWatcher.Run(leaderStop)
-							}
 							controller.Run(leaderStop)
 						}
 					}).

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller_test.go
@@ -46,7 +46,6 @@ import (
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
-	"istio.io/istio/pkg/revisions"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/assert"
@@ -256,9 +255,8 @@ func TestVersionManagement(t *testing.T) {
 			Name: "default",
 		},
 	})
-	tw := revisions.NewTagWatcher(c, "default")
 	env := &model.Environment{}
-	d := NewDeploymentController(c, "", env, testInjectionConfig(t), func(fn func()) {}, tw, "")
+	d := NewDeploymentController(c, "", env, testInjectionConfig(t), func(fn func()) {}, "")
 	reconciles := atomic.NewInt32(0)
 	wantReconcile := int32(0)
 	expectReconciled := func() {
@@ -282,7 +280,6 @@ func TestVersionManagement(t *testing.T) {
 	}
 	stop := test.NewStop(t)
 	gws := clienttest.Wrap(t, d.gateways)
-	go tw.Run(stop)
 	go d.Run(stop)
 	c.RunAndWait(stop)
 	kube.WaitForCacheSync(stop, d.queue.HasSynced)

--- a/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/custom-template.yaml.34.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/default.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/enable-core-dump.yaml.5.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks-json.yaml.16.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-existing-cncf-networks.yaml.15.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-image-pull-secret.yaml.11.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.20.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello-probes.yaml.18.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.0.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.1.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.10.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.12.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.13.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.14.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.17.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.3.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/hello.yaml.4.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/kubevirtInterfaces.yaml.9.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/merge-probers.yaml.39.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/merge-probers.yaml.39.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/status_params.yaml.8.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
+++ b/pkg/kube/inject/testdata/inputs/traffic-params.yaml.7.template.gen.yaml
@@ -1448,7 +1448,11 @@ templates:
           serviceAccountName: {{.ServiceAccount | quote}}
           containers:
           - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
             image: "{{ .ProxyImage }}"
+          {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             ports:
             - containerPort: 15021

--- a/pkg/revisions/tag_watcher.go
+++ b/pkg/revisions/tag_watcher.go
@@ -30,6 +30,9 @@ import (
 
 // TagWatcher keeps track of the current tags and can notify watchers
 // when the tags change.
+//
+// TagWatcher is not supported, because it watches MutatingWebhooks and relies on istio.io/rev label,
+// which can be duplicated in OSSM, so it cannot work until we use revisions in our implementation of multi-tenancy.
 type TagWatcher interface {
 	Run(stopCh <-chan struct{})
 	HasSynced() bool


### PR DESCRIPTION
TagWatcher requires cluster-scoped permissions for MutatingWebhooks, so we can't support it in multi-tenant mode. On the other hand, it can't be used in cluster-wide mode as well, because TagWatcher watches MutatingWebhooks and relies on istio.io/rev label, which is not unique across control planes in OSSM. Additionally, TagWatcher causes skipping Gateways which do not have istio.io/rev label while the control plane is a revision different than "default".