### PR TITLE
[maistra-2.5] OSSM-4390: sync Route informers before starting IOR controller (#828)

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -209,7 +209,11 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 			leaderelection.
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IORController, args.Revision, s.kubeClient).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
-					ior.Run(s.kubeClient, configController, leaderStop)
+					controller := ior.New(s.kubeClient, configController)
+
+					s.kubeClient.RunAndWaitRouteInformer(leaderStop)
+
+					controller.Run(leaderStop)
 				}).Run(stop)
 			return nil
 		})

--- a/pilot/pkg/config/kube/ior/ior.go
+++ b/pilot/pkg/config/kube/ior/ior.go
@@ -23,8 +23,8 @@ import (
 // IORLog is IOR-scoped log
 var IORLog = log.RegisterScope("ior", "IOR logging", 0)
 
-func Run(kubeClient kube.Client, store model.ConfigStoreController, stop <-chan struct{}) {
-	IORLog.Info("setting up IOR")
-	r := newRouteController(NewKubeClient(kubeClient), store)
-	r.Run(stop)
+func New(kubeClient kube.Client, store model.ConfigStoreController) *RouteController {
+	IORLog.Info("Creating new IOR controller")
+
+	return newRouteController(NewKubeClient(kubeClient), store)
 }

--- a/pilot/pkg/config/kube/ior/ior_test.go
+++ b/pilot/pkg/config/kube/ior/ior_test.go
@@ -46,7 +46,7 @@ func newClients(
 	*crdclient.Client,
 	KubeClient,
 	routeclient.Interface,
-	*routeController,
+	*RouteController,
 ) {
 	t.Helper()
 
@@ -72,6 +72,7 @@ func runClients(
 ) {
 	go store.Run(stop)
 	kubeClient.GetActualClient().RunAndWait(stop)
+	kubeClient.GetActualClient().RunAndWaitRouteInformer(stop)
 }
 
 func initClients(

--- a/pkg/kube/mock_client.go
+++ b/pkg/kube/mock_client.go
@@ -153,6 +153,10 @@ func (c MockClient) MetadataInformer() metadatainformer.SharedInformerFactory {
 	panic("not used in mock")
 }
 
+func (c MockClient) RunAndWaitRouteInformer(stop <-chan struct{}) {
+	panic("not used in mock")
+}
+
 func (c MockClient) RunAndWait(stop <-chan struct{}) {
 	panic("not used in mock")
 }


### PR DESCRIPTION
This is a manual cherry-pick of #828.