### PR TITLE
Fix IOR wrongly copying argocd label from Gateway to route

### DIFF
--- a/pilot/pkg/config/kube/ior/controller.go
+++ b/pilot/pkg/config/kube/ior/controller.go
@@ -141,6 +141,20 @@ func filteredRouteAnnotation(routeAnnotation string) bool {
 	return false
 }
 
+func filteredRouteLabel(routeLabel string) bool {
+	filteredPrefixes := [...]string{
+		maistraPrefix,
+		"argocd.argoproj.io",
+	}
+
+	for _, prefix := range filteredPrefixes {
+		if strings.HasPrefix(routeLabel, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func buildRoute(metadata config.Meta, originalHost string, tls *networking.ServerTLSSettings, serviceNamespace string, serviceName string) *v1.Route {
 	actualHost, wildcard := getActualHost(originalHost, true)
 
@@ -169,7 +183,7 @@ func buildRoute(metadata config.Meta, originalHost string, tls *networking.Serve
 	labelMap[gatewayResourceVersionLabel] = metadata.ResourceVersion
 
 	for keyName, keyValue := range metadata.Labels {
-		if !strings.HasPrefix(keyName, maistraPrefix) {
+		if !filteredRouteLabel(keyName) {
 			labelMap[keyName] = keyValue
 		}
 	}


### PR DESCRIPTION
**Please provide a description of this PR:**

When IOR creates a route from a Gateway, it copies annotations **and labels**, including the ones managed by argoCD (https://argo-cd.readthedocs.io/en/stable/).
As a consequence, when deploying the Gateway with argocd, the argocd.argoproj.io/instance label (used by argoCD to track the objects it manages) is copied in the route. From this point ArgoCD constantly deletes the route (since it is not part of the desired manifest). This makes it impossible to deploy Gateway with argoCD, unless IOR automatic route creation is disabled.

Previous PR https://github.com/maistra/istio/pull/849 only filtered the argocd annotations when generating routes from Gateways, which is not enough as reported by @reiniervl. 
This PR filters the labels.


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
