### PR TITLE
OSSM-6079: Pass --resync flag to federation registry

### DIFF
--- a/pkg/servicemesh/federation/discovery/controller.go
+++ b/pkg/servicemesh/federation/discovery/controller.go
@@ -60,6 +60,7 @@ type Controller struct {
 	localNetwork      string
 	localClusterID    string
 	rm                common.ResourceManager
+	resyncPeriod      time.Duration
 	env               *model.Environment
 	federationManager server.FederationManager
 	statusManager     status.Manager
@@ -88,6 +89,7 @@ func NewController(opt Options) (*Controller, error) {
 		localClusterID:        opt.LocalClusterID,
 		localNetwork:          opt.LocalNetwork,
 		rm:                    opt.ResourceManager,
+		resyncPeriod:          opt.ResyncPeriod,
 		env:                   opt.Env,
 		sc:                    opt.ServiceController,
 		stopChannels:          make(map[cluster.ID]chan struct{}),
@@ -212,7 +214,7 @@ func (c *Controller) update(ctx context.Context, instance *v1.ServiceMeshPeer) e
 			ConfigStore:     c.ConfigStoreController,
 			StatusHandler:   statusHandler,
 			XDSUpdater:      c.xds,
-			ResyncPeriod:    time.Minute * 5,
+			ResyncPeriod:    c.resyncPeriod,
 			DomainSuffix:    c.env.DomainSuffix,
 			LocalClusterID:  c.localClusterID,
 			LocalNetwork:    c.localNetwork,

--- a/pkg/servicemesh/federation/federation.go
+++ b/pkg/servicemesh/federation/federation.go
@@ -134,6 +134,7 @@ func internalNew(opt Options, cs maistraclient.Interface) (*Federation, error) {
 	}
 	discoveryController, err := discovery.NewController(discovery.Options{
 		ResourceManager:   resourceManager,
+		ResyncPeriod:      opt.ResyncPeriod,
 		LocalClusterID:    opt.LocalClusterID,
 		LocalNetwork:      opt.LocalNetwork,
 		ServiceController: opt.ServiceController,

--- a/tests/integration/servicemesh/federation/discovery/discovery_test.go
+++ b/tests/integration/servicemesh/federation/discovery/discovery_test.go
@@ -58,7 +58,7 @@ var (
 	// Timeout is 6 minutes long, because we have hardcoded resync period 5 minutes long in the federation discovery controller.
 	defaultRetry = echo.Retry{
 		Options: []retry.Option{
-			retry.Timeout(6 * time.Minute),
+			retry.Timeout(30 * time.Second),
 			retry.Delay(1 * time.Second),
 		},
 	}

--- a/tests/integration/servicemesh/federation/discovery/discovery_test.go
+++ b/tests/integration/servicemesh/federation/discovery/discovery_test.go
@@ -55,7 +55,6 @@ var (
 		ServicePort: 7070,
 	}
 
-	// Timeout is 6 minutes long, because we have hardcoded resync period 5 minutes long in the federation discovery controller.
 	defaultRetry = echo.Retry{
 		Options: []retry.Option{
 			retry.Timeout(30 * time.Second),

--- a/tests/integration/servicemesh/federation/federation.go
+++ b/tests/integration/servicemesh/federation/federation.go
@@ -48,6 +48,15 @@ func SetupConfig(_ resource.Context, cfg *istio.Config) {
 	cfg.DifferentTrustDomains = true
 	cfg.ControlPlaneValues = `
 components:
+  pilot:
+    k8s:
+      overlays:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: istiod
+        patches:
+        - path: spec.template.spec.containers.[name:discovery].args[-1]
+          value: "--resync=3s"
   ingressGateways:
   - name: federation-ingress
     namespace: istio-system

--- a/tests/integration/servicemesh/federation/ha/ha_test.go
+++ b/tests/integration/servicemesh/federation/ha/ha_test.go
@@ -55,7 +55,7 @@ var (
 	// Timeout is 6 minutes long, because we have hardcoded resync period 5 minutes long in the federation discovery controller.
 	defaultRetry = echo.Retry{
 		Options: []retry.Option{
-			retry.Timeout(6 * time.Minute),
+			retry.Timeout(30 * time.Second),
 			retry.Delay(1 * time.Second),
 		},
 	}

--- a/tests/integration/servicemesh/federation/ha/ha_test.go
+++ b/tests/integration/servicemesh/federation/ha/ha_test.go
@@ -52,7 +52,6 @@ var (
 		ServicePort: 7070,
 	}
 
-	// Timeout is 6 minutes long, because we have hardcoded resync period 5 minutes long in the federation discovery controller.
 	defaultRetry = echo.Retry{
 		Options: []retry.Option{
 			retry.Timeout(30 * time.Second),


### PR DESCRIPTION
Federation registry used hard coded 5 minutes long resync period and therefore imported and exported services were applied with a long delay. I guess that it wasn't hard coded intentionally, so I passed `--resync` flag to federation registry ticker to shorten the timeout in federation tests and make them faster and less flaky.