### PR TITLE
Revert "OSSM-5556: Set `net.ipv4.ip_unprivileged_port_start=0` in ingress and egress gateways (#951)"

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -61,9 +61,6 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         fsGroup: 1337
-        sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "0"
 {{- end }}
       serviceAccountName: {{ $gateway.name }}-service-account
 {{- if .Values.global.priorityClassName }}
@@ -212,6 +209,10 @@ spec:
           {{- if .Values.meshConfig.trustDomain }}
           - name: TRUST_DOMAIN
             value: "{{ .Values.meshConfig.trustDomain }}"
+          {{- end }}
+          {{- if not $gateway.runAsRoot }}
+          - name: ISTIO_META_UNPRIVILEGED_POD
+            value: "true"
           {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}

--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
@@ -61,9 +61,6 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         fsGroup: 1337
-        sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "0"
 {{- end }}
       serviceAccountName: {{ $gateway.name | default "istio-egressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}
@@ -99,6 +96,10 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
           env:
+          {{- if not $gateway.runAsRoot }}
+          - name: ISTIO_META_UNPRIVILEGED_POD
+            value: "true"
+          {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -5,12 +5,12 @@ gateways:
     name: istio-egressgateway
     ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http2
       protocol: TCP
     - port: 443
       name: https
-      targetPort: 443
+      targetPort: 8443
       protocol: TCP
 
     labels:

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -61,9 +61,6 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         fsGroup: 1337
-        sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "0"
 {{- end }}
       serviceAccountName: {{ $gateway.name }}-service-account
 {{- if .Values.global.priorityClassName }}
@@ -212,6 +209,10 @@ spec:
           {{- if .Values.meshConfig.trustDomain }}
           - name: TRUST_DOMAIN
             value: "{{ .Values.meshConfig.trustDomain }}"
+          {{- end }}
+          {{- if not $gateway.runAsRoot }}
+          - name: ISTIO_META_UNPRIVILEGED_POD
+            value: "true"
           {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}

--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
@@ -61,9 +61,6 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         fsGroup: 1337
-        sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "0"
 {{- end }}
       serviceAccountName: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}
@@ -99,6 +96,10 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
           env:
+          {{- if not $gateway.runAsRoot }}
+          - name: ISTIO_META_UNPRIVILEGED_POD
+            value: "true"
+          {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -17,11 +17,11 @@ gateways:
       name: status-port
       protocol: TCP
     - port: 80
-      targetPort: 80
+      targetPort: 8080
       name: http2
       protocol: TCP
     - port: 443
-      targetPort: 443
+      targetPort: 8443
       name: https
       protocol: TCP
 


### PR DESCRIPTION
#951 will not land in v2.5.0 and we will share a release note, so we should not include this fix in a Z-stream.