### PR TITLE
OSSM-6309: fix flaky test `federation/ha/TestDiscovery`

### DIFF
--- a/tests/integration/servicemesh/federation/ha/ha_test.go
+++ b/tests/integration/servicemesh/federation/ha/ha_test.go
@@ -118,7 +118,7 @@ spec:
 
 					aSecondary.CallOrFail(t, withDefaults(echo.CallOptions{
 						Address: fmt.Sprintf("b.%s.svc.cluster.local", ns.Name()),
-						Count:   2,
+						Count:   5,
 						Check: check.And(
 							check.GRPCStatus(codes.OK),
 							check.ReachedClusters(t.AllClusters(), []cluster.Cluster{primary, secondary}),


### PR DESCRIPTION
`TestDiscovery` is flaky, because weighted load balancing is not 100% accurate and therefore it often fails for 2 requests.