### PR TITLE
OSSM-6310 Fix flaky IOR integration test

### DIFF
--- a/tests/integration/servicemesh/managingroutes/main_test.go
+++ b/tests/integration/servicemesh/managingroutes/main_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireMaxClusters(1).
 		Setup(router.InstallOpenShiftRouter).
-		Setup(maistra.ApplyServiceMeshCRDs).
+		SetupParallel(maistra.ApplyServiceMeshCRDs, maistra.ApplyGatewayAPICRDs).
 		Setup(namespace.Setup(&istioNamespace, namespace.Config{Prefix: "istio-system"})).
 		Setup(maistra.Install(namespace.Future(&istioNamespace), nil)).
 		// We cannot apply restricted RBAC before the control plane installation, because the operator always applies


### PR DESCRIPTION
Our IOR integration failure could be caused by not setting up GatewayAPI CRDs.