### PR TITLE
OSSM-5698 Rebase injection proxy UID/GID

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -293,7 +293,8 @@ refresh-goldens:
 		./pkg/bootstrap/... \
 		./pkg/kube/inject/... \
 		./pilot/pkg/security/authz/builder/... \
-		./cni/pkg/plugin/...
+		./cni/pkg/plugin/... \
+		./istioctl/cmd/...
 
 update-golden: refresh-goldens
 

--- a/cni/pkg/plugin/redirect.go
+++ b/cni/pkg/plugin/redirect.go
@@ -217,7 +217,7 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
 		return nil, fmt.Errorf("annotation value error for value %s; annotationFound = %t: %v",
 			"redirectMode", isFound, valErr)
 	}
-
+	redir.noRedirectUID = defaultNoRedirectUID
 	if pi.ProxyUID != nil && *pi.ProxyUID != 0 {
 		redir.noRedirectUID = fmt.Sprintf("%d", *pi.ProxyUID)
 	} else {

--- a/istioctl/pkg/kubeinject/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
+++ b/istioctl/pkg/kubeinject/testdata/deployment/hello-with-proxyconfig-anno.yaml.injected
@@ -29,6 +29,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         name: hello
         ports:

--- a/istioctl/pkg/kubeinject/testdata/deployment/hello.yaml.injected
+++ b/istioctl/pkg/kubeinject/testdata/deployment/hello.yaml.injected
@@ -34,6 +34,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       initContainers:
       - image: docker.io/istio/proxy_init:unittest-test
         name: istio-init

--- a/istioctl/pkg/kubeinject/testdata/deployment/hello.yaml.iop.injected
+++ b/istioctl/pkg/kubeinject/testdata/deployment/hello.yaml.iop.injected
@@ -34,6 +34,8 @@ spec:
       - image: docker.io/istio/proxy_debug:unittest
         name: istio-proxy
         resources: {}
+        securityContext:
+          runAsUser: 1337
       initContainers:
       - image: docker.io/istio/proxy_init:unittest-testiop
         name: istio-init

--- a/pilot/pkg/config/kube/gateway/deploymentcontroller.go
+++ b/pilot/pkg/config/kube/gateway/deploymentcontroller.go
@@ -50,6 +50,7 @@ import (
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/istio/pkg/test/util/yml"
 	"istio.io/istio/pkg/util/sets"
+	iptablesconstants "istio.io/istio/tools/istio-iptables/pkg/constants"
 )
 
 // DeploymentController implements a controller that materializes a Gateway into an in cluster gateway proxy
@@ -323,12 +324,6 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 	}
 	log.Info("reconciling")
 
-	var ns *corev1.Namespace
-	if d.namespaces != nil {
-		ns = d.namespaces.Get(gw.Namespace, "")
-	}
-	proxyUID, proxyGID := inject.GetProxyIDs(ns)
-
 	defaultName := getDefaultName(gw.Name, &gw.Spec)
 
 	serviceType := gi.defaultServiceType
@@ -346,8 +341,8 @@ func (d *DeploymentController) configureIstioGateway(log *istiolog.Scope, gw gat
 		KubeVersion122: kube.IsAtLeastVersion(d.client, 22),
 		Revision:       d.revision,
 		ServiceType:    serviceType,
-		ProxyUID:       proxyUID,
-		ProxyGID:       proxyGID,
+		ProxyUID:       iptablesconstants.DefaultProxyUIDInt,
+		ProxyGID:       iptablesconstants.DefaultProxyUIDInt,
 	}
 
 	if overwriteControllerVersion {

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
@@ -53,6 +54,13 @@ import (
 // InjectionPolicy determines the policy for injecting the
 // sidecar proxy into the watched namespace(s).
 type InjectionPolicy string
+
+// Defaults values for injecting istio proxy into kubernetes
+// resources.
+const (
+	DefaultSidecarProxyUID = int64(1337)
+	DefaultSidecarProxyGID = int64(1337)
+)
 
 const (
 	// InjectionPolicyDisabled specifies that the sidecar injector
@@ -776,6 +784,8 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 			revision:            revision,
 			proxyEnvs:           map[string]string{},
 			injectedAnnotations: nil,
+			proxyUID:            ptr.To(DefaultSidecarProxyUID),
+			proxyGID:            ptr.To(DefaultSidecarProxyGID),
 		}
 		patchBytes, err = injectPod(params)
 	}

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -55,13 +55,6 @@ import (
 // sidecar proxy into the watched namespace(s).
 type InjectionPolicy string
 
-// Defaults values for injecting istio proxy into kubernetes
-// resources.
-const (
-	DefaultSidecarProxyUID = int64(1337)
-	DefaultSidecarProxyGID = int64(1337)
-)
-
 const (
 	// InjectionPolicyDisabled specifies that the sidecar injector
 	// will not inject the sidecar into resources by default for the
@@ -407,8 +400,6 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		return nil, nil, err
 	}
 
-	proxyUID, proxyGID := GetProxyIDs(params.namespace)
-
 	data := SidecarTemplateData{
 		TypeMeta:         params.typeMeta,
 		DeploymentMeta:   params.deployMeta,
@@ -419,8 +410,8 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		Values:           params.valuesConfig.asMap,
 		Revision:         params.revision,
 		ProxyImage:       ProxyImage(params.valuesConfig.asStruct, params.proxyConfig.Image, strippedPod.Annotations),
-		ProxyUID:         proxyUID,
-		ProxyGID:         proxyGID,
+		ProxyUID:         *params.proxyUID,
+		ProxyGID:         *params.proxyGID,
 		CompliancePolicy: common_features.CompliancePolicy,
 	}
 
@@ -784,8 +775,8 @@ func IntoObject(injector Injector, sidecarTemplate Templates, valuesConfig Value
 			revision:            revision,
 			proxyEnvs:           map[string]string{},
 			injectedAnnotations: nil,
-			proxyUID:            ptr.To(DefaultSidecarProxyUID),
-			proxyGID:            ptr.To(DefaultSidecarProxyGID),
+			proxyUID:            ptr.To(constants.DefaultProxyUIDInt),
+			proxyGID:            ptr.To(constants.DefaultProxyUIDInt),
 		}
 		patchBytes, err = injectPod(params)
 	}

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -623,6 +623,8 @@ spec:
     - name: hello
       image: fake.docker.io/google-samples/hello-go-gke:1.0
     - name: istio-proxy
+      securityContext:
+        runAsUser: 1337
       image: proxy
 `
 	runWebhook(t, webhook, []byte(input), []byte(fmt.Sprintf(expected, "sidecar,init")), false)

--- a/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/grpc-agent.yaml.injected
@@ -139,6 +139,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+        securityContext:
+          runAsUser: 1337
         volumeMounts:
         - mountPath: /var/run/secrets/workload-spiffe-uds
           name: workload-socket

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -144,7 +144,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsNonRoot: false
-          runAsUser: 0
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 600
           httpGet:

--- a/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.cni.injected
@@ -138,7 +138,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 4321
           runAsNonRoot: true
-          runAsUser: 1234
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 600
           httpGet:
@@ -171,7 +171,7 @@ spec:
         - -z
         - "15006"
         - -u
-        - "1234"
+        - "1337"
         - -m
         - REDIRECT
         - -i
@@ -203,7 +203,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 4321
           runAsNonRoot: true
-          runAsUser: 1234
+          runAsUser: 1337
       volumes:
       - name: workload-socket
       - name: credential-socket

--- a/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.injected
@@ -134,7 +134,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 4321
           runAsNonRoot: true
-          runAsUser: 1234
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 600
           httpGet:
@@ -167,7 +167,7 @@ spec:
         - -z
         - "15006"
         - -u
-        - "1234"
+        - "1337"
         - -m
         - REDIRECT
         - -i

--- a/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.tproxy.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override-runas.yaml.tproxy.injected
@@ -136,7 +136,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 4321
           runAsNonRoot: false
-          runAsUser: 0
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 600
           httpGet:
@@ -169,7 +169,7 @@ spec:
         - -z
         - "15006"
         - -u
-        - "1234"
+        - "1337"
         - -m
         - TPROXY
         - -i

--- a/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/proxy-override.yaml.injected
@@ -148,7 +148,7 @@ spec:
           readOnlyRootFilesystem: false
           runAsGroup: 1234
           runAsNonRoot: true
-          runAsUser: 1234
+          runAsUser: 1337
         startupProbe:
           failureThreshold: 600
           httpGet:

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -1166,7 +1166,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 		}
 	} else if tproxyInterceptionMode {
 		proxyUID = ptr.To(int64(0))
-		proxyGID = ptr.To(DefaultSidecarProxyGID)
+		proxyGID = ptr.To(iptablesconstants.DefaultProxyUIDInt)
 	} else {
 		// we're injecting a normal pod (with app container and optional sidecar container)
 		// we set proxyUID to the main app container's UID incremented by 1
@@ -1198,10 +1198,10 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	// We need to set the UID/GID to something, or the injected manifest will fail to parse (this happens because
 	// {{ .ProxyUID/GID }} in the charts get resolved to "nil" (with quotes), which can't be parsed as a float).
 	if proxyUID == nil {
-		proxyUID = ptr.To(DefaultSidecarProxyUID)
+		proxyUID = ptr.To(iptablesconstants.DefaultProxyUIDInt)
 	}
 	if proxyGID == nil {
-		proxyGID = ptr.To(DefaultSidecarProxyUID)
+		proxyGID = ptr.To(iptablesconstants.DefaultProxyUIDInt)
 	}
 
 	deploy, typeMeta := kube.GetDeployMetaFromPod(&pod)


### PR DESCRIPTION
[proxy-uid] OSSM-2292: Run sidecars with dynamically-determined user IDs (#689)

* [proxy-uid] MAISTRA-551: Run sidecars with dynamically-determined user IDs (#230) (#541)

Squashed commit, incorporates changes from:

  * MAISTRA-551 Run sidecar with a dynamically-determined runAsUser ID

  * MAISTRA-611 Partial injection of just the annotation and runAsUser id

  * MAISTRA-668 Fix expected output of webhook injection

  The sidecar injector now sets the securityContext.runAsUser field
  regardless if it is specified in the sidecar template or not. This is
  to allow the sidecar template to not include the field, which is
  required to ensure that istioctl kube-inject outputs manifests that
  pass the SCC admission controller (if the runAsUser is specified, the
  SCC controller will reject the pod, as the uid won't be in the proper
  range). The sidecar injector then injects the correct runAsUser id even
  if it isn't specified in the template.

  * MAISTRA-1751: Set securityContext.fsGroup to comply with restricted SCC (#256)

  This is a rewrite of 46f0f4a819 for the Maistra 2.1 / Istio 1.8 rebase.

  * MAISTRA-2452 Apply dynamically-determined user ID to the istio-validation init container








* [maistra-2.3] OSSM-1847 ensure ProxyUID and ProxyGID are initialized when using gat… (#618)

* OSSM-1847 ensure ProxyUID and ProxyGID are initialized when using gateway injection template



* do not default ProxyUID and ProxyGID for gateways



* initialize ProxyGID appropriately for gateway injection






* fix(gen): runs make gen

* chore: combines cni plugins golden files gen into one invocation









[maistra-2.4] OSSM-2324 Ensure ProxyUID and ProxyGID are never nil (#703)

* OSSM-2324 Ensure ProxyUID and ProxyGID are never nil

If they are nil, Helm renders them as "nil" (with quotes), which the YAML parser can't parse as a float.

* Remove redundant loop

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
