### PR TITLE
Prevent non-error from showing up in CI logs

### DIFF
--- a/common/scripts/kind_provisioner.sh
+++ b/common/scripts/kind_provisioner.sh
@@ -188,7 +188,7 @@ EOF
     return 9
   fi
   # Workaround kind issue causing taints to not be removed in 1.24
-  kubectl taint nodes "${NAME}"-control-plane node-role.kubernetes.io/control-plane- || true
+  kubectl taint nodes "${NAME}"-control-plane node-role.kubernetes.io/control-plane- 2>/dev/null || true
 
   # If metrics server configuration directory is specified then deploy in
   # the cluster just created


### PR DESCRIPTION
Prevent CI from highlighting the following as an error, because it's not an actual error:

error: taint "node-role.kubernetes.io/control-plane" not found