### PR TITLE
Fix dnf update issue

### DIFF
--- a/maistra/Dockerfile.istio-cni
+++ b/maistra/Dockerfile.istio-cni
@@ -17,7 +17,8 @@ LABEL maintainer="Istio Feedback <istio-feedback@redhat.com>"
 ENV container="oci"
 ENV ISTIO_VERSION="${ISTIO_VERSION}"
 
-RUN dnf update -y && dnf clean all
+RUN sed -i -e 's/mirrorlist/#mirrorlist/g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    dnf update -y && dnf clean all
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/istio-cni /opt/cni/bin/istio-cni

--- a/maistra/Dockerfile.proxyv2
+++ b/maistra/Dockerfile.proxyv2
@@ -17,7 +17,8 @@ LABEL io.openshift.expose-services=""
 LABEL maintainer="Istio Feedback <istio-feedback@redhat.com>"
 
 # hadolint ignore=DL3039,DL3041
-RUN dnf -y upgrade --refresh --nobest && \
+RUN sed -i -e 's/mirrorlist/#mirrorlist/g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    dnf -y upgrade --refresh --nobest && \
     dnf -y install iptables iproute openssl && \
     dnf -y clean all
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -7,7 +7,8 @@ ARG istio_version
 ARG SIDECAR=envoy
 
 # hadolint ignore=DL3041
-RUN dnf -y upgrade --refresh --nobest && \
+RUN sed -i -e 's/mirrorlist/#mirrorlist/g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    dnf -y upgrade --refresh --nobest && \
     dnf -y install iptables iproute openssl && \
     dnf -y clean all
 

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_stream_8
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_stream_8
@@ -15,7 +15,8 @@ COPY sudoers /etc/sudoers
 # * hostname - used in the script istio-start.sh
 # * ps - for debugging purposes
 # hadolint ignore=DL3040,DL3041
-RUN dnf -y upgrade --refresh --nobest && \
+RUN sed -i -e 's/mirrorlist/#mirrorlist/g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    dnf -y upgrade --refresh --nobest && \
     dnf -y install iptables iproute openssl sudo hostname procps && \
     dnf -y clean all
 


### PR DESCRIPTION
This fixes the following issue:

Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist