### PR TITLE
OSSM-6615 Make sure IOR ignores services without selectors

### DIFF
--- a/pilot/pkg/config/kube/ior/controller.go
+++ b/pilot/pkg/config/kube/ior/controller.go
@@ -289,6 +289,11 @@ func (r *routeController) findService(gateway *networking.Gateway) (*types.Names
 		podLabels := labels.Set(pod.ObjectMeta.Labels)
 		// Look for a service whose selector matches the pod labels
 		for _, service := range services {
+			if len(service.Spec.Selector) == 0 {
+				// an empty label selector does not mean that the service should match all pods, but that the
+				// service endpoints are managed externally; IOR should therefore ignore this service
+				continue
+			}
 			svcSelector := labels.SelectorFromSet(service.Spec.Selector)
 
 			iorLog.Debugf("matching service selector %s against %s", svcSelector.String(), podLabels)

--- a/tests/integration/servicemesh/managingroutes/main_test.go
+++ b/tests/integration/servicemesh/managingroutes/main_test.go
@@ -248,14 +248,14 @@ func applyGatewayOrFail(ctx framework.TestContext, ns, name string, labels map[s
 	// retry because of flaky validation webhook
 	retry.UntilSuccessOrFail(ctx, func() error {
 		return ctx.ConfigIstio().EvalFile(ns, map[string]interface{}{"hosts": hosts, "name": name, "labels": labels}, gatewayTmpl).Apply()
-	}, retry.Timeout(3*time.Second))
+	}, retry.Timeout(15*time.Second))
 }
 
 func deleteGatewayOrFail(ctx framework.TestContext, ns, name string, labels map[string]string, hosts ...string) {
 	// retry because of flaky validation webhook
 	retry.UntilSuccessOrFail(ctx, func() error {
 		return ctx.ConfigIstio().EvalFile(ns, map[string]interface{}{"hosts": hosts, "name": name, "labels": labels}, gatewayTmpl).Delete()
-	}, retry.Timeout(3*time.Second))
+	}, retry.Timeout(15*time.Second))
 }
 
 func applyVirtualServiceOrFail(ctx framework.TestContext, ns, gatewayNs, gatewayName, virtualServiceName string) {
@@ -266,5 +266,5 @@ func applyVirtualServiceOrFail(ctx framework.TestContext, ns, gatewayNs, gateway
 	}
 	retry.UntilSuccessOrFail(ctx, func() error {
 		return ctx.ConfigIstio().EvalFile(ns, values, virtualSvcTmpl).Apply()
-	}, retry.Timeout(3*time.Second))
+	}, retry.Timeout(15*time.Second))
 }


### PR DESCRIPTION
Cherry-pick of #1022

* OSSM-6615 Make sure IOR ignores services without selectors

IOR finds a matching service for a pod by checking each service's label selector. However, this also matches services with an empty selector, which is wrong. These services should be ignored by IOR since an empty label selector indicates that the service endpoints are managed externally and not that the service should match all pods.

* Add test

* Increase timeout

The previous timeout was only 3s, which caused the retry.UntilSuccessOrFail to fail on the first attempt instead of allowing the retry to be performed.