### PR TITLE
OSSM-6692: Add `StripPodUnusedFields` to pod informer used by federation controller

### DIFF
--- a/pkg/servicemesh/federation/common/resources.go
+++ b/pkg/servicemesh/federation/common/resources.go
@@ -62,7 +62,9 @@ func NewResourceManager(opts ControllerOptions, mrc memberroll.MemberRollControl
 		inff: informerFactory,
 		cmi:  kclient.NewFiltered[*corev1.ConfigMap](opts.KubeClient, kclient.Filter{}),
 		esi:  kclient.NewFiltered[*discoveryv1.EndpointSlice](opts.KubeClient, kclient.Filter{}),
-		pi:   kclient.NewFiltered[*corev1.Pod](opts.KubeClient, kclient.Filter{}),
+		pi: kclient.NewFiltered[*corev1.Pod](opts.KubeClient, kclient.Filter{
+			ObjectTransform: kube.StripPodUnusedFields,
+		}),
 		si:   kclient.NewFiltered[*corev1.Service](opts.KubeClient, kclient.Filter{}),
 		smpi: informerFactory.Federation().V1().ServiceMeshPeers(),
 		sei:  informerFactory.Federation().V1().ExportedServiceSets(),


### PR DESCRIPTION
We need this change to avoid logging this [warning](https://github.com/maistra/istio/blob/ad6eab9a3bd67d755c97fbfbec87532c7ff34a42/pkg/kube/informerfactory/factory.go#L193). The condition for the warning is met, because there is another pod informer with `ObjectTransform: StripPodUnusedFields` created [here](https://github.com/maistra/istio/blob/ad6eab9a3bd67d755c97fbfbec87532c7ff34a42/pilot/pkg/serviceregistry/kube/controller/controller.go#L306).

This change also optimizes memory usage, because the federation controller will not cache irrelevant information about pods.