### PR TITLE
[maistra-2.6] xds: push CDS on AUTO_PASSTHROUGH Gateway change

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -337,6 +337,9 @@ type Proxy struct {
 	// The merged gateways associated with the proxy if this is a Router
 	MergedGateway *MergedGateway
 
+	// PrevMergedGateway contains information about merged gateway associated with the proxy previously
+	PrevMergedGateway *PrevMergedGateway
+
 	// ServiceTargets contains a list of all Services associated with the proxy, contextualized for this particular proxy.
 	// These are unique to this proxy, as the port information is specific to it - while a ServicePort is shared with the
 	// service, the target port may be distinct per-endpoint. So this maintains a view specific to this proxy.
@@ -930,7 +933,15 @@ func (node *Proxy) SetGatewaysForProxy(ps *PushContext) {
 	if node.Type != Router {
 		return
 	}
+	var prevMergedGateway MergedGateway
+	if node.MergedGateway != nil {
+		prevMergedGateway = *node.MergedGateway
+	}
 	node.MergedGateway = ps.mergeGateways(node)
+	node.PrevMergedGateway = &PrevMergedGateway{
+		ContainsAutoPassthroughGateways: prevMergedGateway.ContainsAutoPassthroughGateways,
+		AutoPassthroughSNIHosts:         prevMergedGateway.GetAutoPassthrughGatewaySNIHosts(),
+	}
 }
 
 func (node *Proxy) SetServiceTargets(serviceDiscovery ServiceDiscovery) {

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -20,6 +20,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/util/sets"
 )
 
 // nolint lll
@@ -157,6 +158,70 @@ func TestMergeGateways(t *testing.T) {
 				t.Errorf("Incorrect number of gateways. Expected: %v Got: %d", tt.gatewaysNum, len(mgw.GatewayNameForServer))
 			}
 		})
+	}
+}
+
+func TestGetAutoPassthroughSNIHosts(t *testing.T) {
+	gateway := config.Config{
+		Meta: config.Meta{
+			Name:      "gateway",
+			Namespace: "istio-system",
+		},
+		Spec: &networking.Gateway{
+			Selector: map[string]string{"istio": "ingressgateway"},
+			Servers: []*networking.Server{
+				{
+					Hosts: []string{"static.example.com"},
+					Port:  &networking.Port{Name: "http", Number: 80, Protocol: "HTTP"},
+				},
+				{
+					Hosts: []string{"www.example.com"},
+					Port:  &networking.Port{Name: "https", Number: 443, Protocol: "HTTPS"},
+					Tls:   &networking.ServerTLSSettings{Mode: networking.ServerTLSSettings_SIMPLE},
+				},
+				{
+					Hosts: []string{"a.apps.svc.cluster.local", "b.apps.svc.cluster.local"},
+					Port:  &networking.Port{Name: "tls", Number: 15443, Protocol: "TLS"},
+					Tls:   &networking.ServerTLSSettings{Mode: networking.ServerTLSSettings_AUTO_PASSTHROUGH},
+				},
+			},
+		},
+	}
+	svc := &Service{
+		Attributes: ServiceAttributes{
+			Labels: map[string]string{},
+		},
+	}
+	gatewayServiceTargets := []ServiceTarget{
+		{
+			Service: svc,
+			Port: ServiceInstancePort{
+				ServicePort: &Port{Port: 80},
+				TargetPort:  80,
+			},
+		},
+		{
+			Service: svc,
+			Port: ServiceInstancePort{
+				ServicePort: &Port{Port: 443},
+				TargetPort:  443,
+			},
+		},
+		{
+			Service: svc,
+			Port: ServiceInstancePort{
+				ServicePort: &Port{Port: 15443},
+				TargetPort:  15443,
+			},
+		},
+	}
+	instances := []gatewayWithInstances{{gateway: gateway, instances: gatewayServiceTargets}}
+	mgw := MergeGateways(instances, &Proxy{}, nil)
+	hosts := mgw.GetAutoPassthrughGatewaySNIHosts()
+	expectedHosts := sets.Set[string]{}
+	expectedHosts.InsertAll("a.apps.svc.cluster.local", "b.apps.svc.cluster.local")
+	if !hosts.Equals(expectedHosts) {
+		t.Errorf("expected to get: [a.apps.svc.cluster.local,b.apps.svc.cluster.local], got: %s", hosts)
 	}
 }
 

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -60,8 +60,7 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 		return true
 	}
 
-	autoPassthroughModeChanged := proxy.MergedGateway.HasAutoPassthroughGateways() != proxy.PrevMergedGateway.HasAutoPassthroughGateway()
-	autoPassthroughHostsChanged := !proxy.MergedGateway.GetAutoPassthrughGatewaySNIHosts().Equals(proxy.PrevMergedGateway.GetAutoPassthroughSNIHosts())
+	checkGateway := false
 	for config := range req.ConfigsUpdated {
 		if proxy.Type == model.Router {
 			if features.FilterGatewayClusterConfig {
@@ -69,12 +68,20 @@ func cdsNeedsPush(req *model.PushRequest, proxy *model.Proxy) bool {
 					return true
 				}
 			}
-			if config.Kind == kind.Gateway && (autoPassthroughModeChanged || autoPassthroughHostsChanged) {
-				return true
+			if config.Kind == kind.Gateway {
+				// Do the check outside of the loop since its slow; just trigger we need it
+				checkGateway = true
 			}
 		}
 
 		if _, f := skippedCdsConfigs[config.Kind]; !f {
+			return true
+		}
+	}
+	if checkGateway {
+		autoPassthroughModeChanged := proxy.MergedGateway.HasAutoPassthroughGateways() != proxy.PrevMergedGateway.HasAutoPassthroughGateway()
+		autoPassthroughHostsChanged := !proxy.MergedGateway.GetAutoPassthrughGatewaySNIHosts().Equals(proxy.PrevMergedGateway.GetAutoPassthroughSNIHosts())
+		if autoPassthroughModeChanged || autoPassthroughHostsChanged {
 			return true
 		}
 	}

--- a/releasenotes/notes/push-cds-on-auto-passthrough-gateway-change.yaml
+++ b/releasenotes/notes/push-cds-on-auto-passthrough-gateway-change.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+releaseNotes:
+  - |
+    **Fixed** returning 503 errors by auto-passthrough gateways created after enabling mTLS.


### PR DESCRIPTION
This is a backport of https://github.com/istio/istio/pull/50757. We will need these commits to ensure reliable migration from federation 2.x to 3.x where we will use auto-passthrough gateways.