### PR TITLE
OSSM-6694 Fix federation's resourceManager.HasSynced() and flaky TestStatusManager

### DIFF
--- a/pkg/servicemesh/federation/common/resources.go
+++ b/pkg/servicemesh/federation/common/resources.go
@@ -103,7 +103,11 @@ func (rm *resourceManager) Start(stopCh <-chan struct{}) {
 func (rm *resourceManager) HasSynced() bool {
 	return rm.smpi.Informer().HasSynced() &&
 		rm.sei.Informer().HasSynced() &&
-		rm.sii.Informer().HasSynced()
+		rm.sii.Informer().HasSynced() &&
+		rm.cmi.HasSynced() &&
+		rm.esi.HasSynced() &&
+		rm.pi.HasSynced() &&
+		rm.si.HasSynced()
 }
 
 func (rm *resourceManager) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {

--- a/pkg/servicemesh/federation/status/handler.go
+++ b/pkg/servicemesh/federation/status/handler.go
@@ -474,6 +474,8 @@ func (h *handler) Flush() error {
 		}
 	}
 
+	h.logger.Debugf("oldStatus=%+v", peer.Status)
+	h.logger.Debugf("newStatus=%+v", newStatus)
 	if reflect.DeepEqual(peer.Status, newStatus) { // TODO: peer.Status may be stale, causing us to skip the update when we shouldn't
 		h.logger.Debugf("no status updates for ServiceMeshPeer %s", h.mesh)
 		return nil


### PR DESCRIPTION
The federation controller's HasSynced() function only checked if some of its informers are synced instead of checking all of them.

The TestStatusManager test didn't use this HasSynced(), but called the HasSynced() function of some informers directly. It didn't check all informers that it should have, most importantly the pod informer.

This caused the test to be flaky, because the removeDeadPods function, which removes PodPeerDiscoveryStatuses associated with non-existent pods, erroneously removed the status that the test was checking. This happened when the podInformer wasn't yet synced and made it look as though the pod didn't exist.