### PR TITLE
OSSM-6812: Do not set cipher suites by default

### DIFF
--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -75,9 +75,9 @@ func BuildInboundTLS(mTLSMode model.MutualTLSMode, node *model.Proxy,
 		ciphers = mc.MeshMTLS.CipherSuites
 	}
 	if ciphers == nil {
-		ciphers = tls_features.TLSCipherSuites.Get()
-		if len(ciphers) == 0 {
-			ciphers = SupportedCiphers
+		opensslCiphers := tls_features.TLSCipherSuites.Get()
+		if len(opensslCiphers) > 0 {
+			ciphers = opensslCiphers
 		}
 	}
 	// Set Minimum TLS version to match the default client version and allowed strong cipher suites for sidecars.

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -70,6 +70,10 @@ func TestGetMTLSCipherSuites(t *testing.T) {
 		expectedMTLSCipherSuites []string
 	}{
 		{
+			name:                     "Default MTLS supported Ciphers",
+			expectedMTLSCipherSuites: nil,
+		},
+		{
 			name: "Configure 1 MTLS cipher suite",
 			mesh: meshconfig.MeshConfig{
 				MeshMTLS: &meshconfig.MeshConfig_TLSConfig{

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -70,10 +70,6 @@ func TestGetMTLSCipherSuites(t *testing.T) {
 		expectedMTLSCipherSuites []string
 	}{
 		{
-			name:                     "Default MTLS supported Ciphers",
-			expectedMTLSCipherSuites: SupportedCiphers,
-		},
-		{
 			name: "Configure 1 MTLS cipher suite",
 			mesh: meshconfig.MeshConfig{
 				MeshMTLS: &meshconfig.MeshConfig_TLSConfig{

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -41,7 +41,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pilot/pkg/security/authn"
-	"istio.io/istio/pilot/pkg/security/authn/utils"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
@@ -1505,9 +1504,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 }
 
 func TestInboundMTLSSettings(t *testing.T) {
-	runTestInboundMTLSSettings(t, &tls.TlsParameters{
-		CipherSuites: utils.SupportedCiphers,
-	})
+	runTestInboundMTLSSettings(t, &tls.TlsParameters{})
 }
 
 func TestTLSProtocolVersionInboundMTLSSettings(t *testing.T) {
@@ -1521,7 +1518,6 @@ func TestTLSProtocolVersionInboundMTLSSettings(t *testing.T) {
 	runTestInboundMTLSSettings(t, &tls.TlsParameters{
 		TlsMinimumProtocolVersion: tls.TlsParameters_TLSv1_2,
 		TlsMaximumProtocolVersion: tls.TlsParameters_TLSv1_3,
-		CipherSuites:              utils.SupportedCiphers,
 	})
 }
 


### PR DESCRIPTION
We don't have to set default cipher suites, because Envoy-OpenSSL can detect proper defaults.