### PR TITLE
[maistra-2.4] OSSM-8001: Fix setting proxy GID

### DIFF
--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -891,74 +891,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 		}
 	}
 
-	var err error
-	var proxyUID *int64
-	var proxyGID *int64
-	tproxyInterceptionMode := pod.Annotations != nil && pod.Annotations["sidecar.istio.io/interceptionMode"] == string(model.InterceptionTproxy)
-	if len(pod.Spec.Containers) == 1 && pod.Spec.Containers[0].Name == ProxyContainerName {
-		// we're injecting a gateway pod
-		// we set proxyUID/GID to whatever UID/GID is specified in securityContext.RunAsUser/RunAsGroup
-		if pod.Spec.SecurityContext != nil {
-			if pod.Spec.SecurityContext.RunAsUser != nil {
-				proxyUID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsUser)
-				proxyGID = pointer.Int64Ptr(*proxyUID)
-			}
-			if pod.Spec.SecurityContext.RunAsGroup != nil {
-				proxyGID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsGroup)
-			}
-		}
-		container := pod.Spec.Containers[0]
-		if container.SecurityContext != nil {
-			if container.SecurityContext.RunAsUser != nil {
-				proxyUID = pointer.Int64Ptr(*container.SecurityContext.RunAsUser)
-				if proxyGID == nil {
-					proxyGID = pointer.Int64Ptr(*proxyUID)
-				}
-			}
-			if container.SecurityContext.RunAsGroup != nil {
-				proxyGID = pointer.Int64Ptr(*container.SecurityContext.RunAsGroup)
-			}
-		}
-	} else if tproxyInterceptionMode {
-		proxyUID = pointer.Int64(0)
-		proxyGID = pointer.Int64(DefaultSidecarProxyGID)
-	} else {
-		// we're injecting a normal pod (with app container and optional sidecar container)
-		// we set proxyUID to the main app container's UID incremented by 1
-		// we set proxyGID to the main app container's UID
-		proxyUID, err = getProxyUIDFromAnnotation(pod)
-		if err != nil {
-			log.Infof("Could not get proxyUID from annotation: %v", err)
-		}
-		if proxyUID == nil {
-			if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
-				proxyUID = pointer.Int64Ptr(*pod.Spec.SecurityContext.RunAsUser + 1)
-				// valid GID for fsGroup defaults to first int in UID range in OCP's restricted SCC
-				proxyGID = pod.Spec.SecurityContext.RunAsUser
-			}
-			for _, c := range pod.Spec.Containers {
-				if c.Name != ProxyContainerName && c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
-					uid := *c.SecurityContext.RunAsUser + 1
-					if proxyUID == nil || uid > *proxyUID {
-						proxyUID = &uid
-					}
-					if proxyGID == nil {
-						proxyGID = c.SecurityContext.RunAsUser
-					}
-				}
-			}
-		}
-	}
-
-	// We need to set the UID/GID to something, or the injected manifest will fail to parse (this happens because
-	// {{ .ProxyUID/GID }} in the charts get resolved to "nil" (with quotes), which can't be parsed as a float).
-	if proxyUID == nil {
-		proxyUID = pointer.Int64(DefaultSidecarProxyUID)
-	}
-	if proxyGID == nil {
-		proxyGID = pointer.Int64(DefaultSidecarProxyUID)
-	}
-
+	proxyUID, proxyGID := findProxyUGID(pod)
 	deploy, typeMeta := kube.GetDeployMetaFromPod(&pod)
 	params := InjectionParameters{
 		pod:                 &pod,
@@ -994,6 +927,75 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	}
 	totalSuccessfulInjections.Increment()
 	return &reviewResponse
+}
+
+func findProxyUGID(pod corev1.Pod) (proxyUID, proxyGID *int64) {
+	tproxyInterceptionMode := pod.Annotations != nil && pod.Annotations["sidecar.istio.io/interceptionMode"] == string(model.InterceptionTproxy)
+	if len(pod.Spec.Containers) == 1 && pod.Spec.Containers[0].Name == ProxyContainerName {
+		// we're injecting a gateway pod
+		// we set proxyUID/GID to whatever UID/GID is specified in securityContext.RunAsUser/RunAsGroup
+		if pod.Spec.SecurityContext != nil {
+			if pod.Spec.SecurityContext.RunAsUser != nil {
+				proxyUID = pointer.Int64(*pod.Spec.SecurityContext.RunAsUser)
+				proxyGID = pointer.Int64(*proxyUID)
+			}
+			if pod.Spec.SecurityContext.RunAsGroup != nil {
+				proxyGID = pointer.Int64(*pod.Spec.SecurityContext.RunAsGroup)
+			}
+		}
+		container := pod.Spec.Containers[0]
+		if container.SecurityContext != nil {
+			if container.SecurityContext.RunAsUser != nil {
+				proxyUID = pointer.Int64(*container.SecurityContext.RunAsUser)
+				if proxyGID == nil {
+					proxyGID = pointer.Int64(*proxyUID)
+				}
+			}
+			if container.SecurityContext.RunAsGroup != nil {
+				proxyGID = pointer.Int64(*container.SecurityContext.RunAsGroup)
+			}
+		}
+	} else if tproxyInterceptionMode {
+		proxyUID = pointer.Int64(0)
+		proxyGID = pointer.Int64(DefaultSidecarProxyGID)
+	} else {
+		// we're injecting a normal pod (with app container and optional sidecar container)
+		// we set proxyUID to the main app container's UID incremented by 1
+		// we set proxyGID to the main app container's UID
+		var err error
+		proxyUID, err = getProxyUIDFromAnnotation(pod)
+		if err != nil {
+			log.Warnf("Could not get proxyUID from annotation: %v", err)
+		}
+		if proxyUID == nil {
+			if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.RunAsUser != nil {
+				proxyUID = pointer.Int64(*pod.Spec.SecurityContext.RunAsUser + 1)
+				// valid GID for fsGroup defaults to first int in UID range in OCP's restricted SCC
+				proxyGID = pod.Spec.SecurityContext.RunAsUser
+			}
+			for _, c := range pod.Spec.Containers {
+				if c.Name != ProxyContainerName && c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
+					uid := *c.SecurityContext.RunAsUser + 1
+					if proxyUID == nil || uid > *proxyUID {
+						proxyUID = &uid
+					}
+					if proxyGID == nil {
+						proxyGID = c.SecurityContext.RunAsUser
+					}
+				}
+			}
+		}
+	}
+
+	// We need to set the UID/GID to something, or the injected manifest will fail to parse (this happens because
+	// {{ .ProxyUID/GID }} in the charts get resolved to "nil" (with quotes), which can't be parsed as a float).
+	if proxyUID == nil {
+		proxyUID = pointer.Int64(DefaultSidecarProxyUID)
+	}
+	if proxyGID == nil {
+		proxyGID = pointer.Int64(DefaultSidecarProxyUID)
+	}
+	return
 }
 
 func (wh *Webhook) serveInject(w http.ResponseWriter, r *http.Request) {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/api/annotation"
@@ -1294,6 +1295,262 @@ func TestParseInjectEnvs(t *testing.T) {
 			actual := parseInjectEnvs(tc.in)
 			if !reflect.DeepEqual(actual, tc.want) {
 				t.Fatalf("Expected result %#v, but got %#v", tc.want, actual)
+			}
+		})
+	}
+}
+
+func TestFindProxyUGID(t *testing.T) {
+	cases := []struct {
+		name        string
+		pod         corev1.Pod
+		expectedUID int64
+		expectedGID int64
+	}{{
+		name: "gateway: pod security context with UID and GID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "istio-proxy",
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  pointer.Int64(1000),
+					RunAsGroup: pointer.Int64(1001),
+				},
+			},
+		},
+		expectedUID: 1000,
+		expectedGID: 1001,
+	}, {
+		name: "gateway: pod security context with UID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "istio-proxy",
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser: pointer.Int64(1000),
+				},
+			},
+		},
+		expectedUID: 1000,
+		expectedGID: 1000,
+	}, {
+		name: "gateway: container security context with UID and GID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "istio-proxy",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  pointer.Int64(1000),
+						RunAsGroup: pointer.Int64(1001),
+					},
+				}},
+			},
+		},
+		expectedUID: 1000,
+		expectedGID: 1001,
+	}, {
+		name: "gateway: container security context with UID and GID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "istio-proxy",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: pointer.Int64(1000),
+					},
+				}},
+			},
+		},
+		expectedUID: 1000,
+		expectedGID: 1000,
+	}, {
+		name: "gateway: no security context",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "istio-proxy",
+				}},
+			},
+		},
+		expectedUID: 1337,
+		expectedGID: 1337,
+	}, {
+		name: "gateway: tproxy mode should be ignored",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					annotation.SidecarInterceptionMode.Name: string(model.InterceptionTproxy),
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "istio-proxy",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  pointer.Int64(1000),
+						RunAsGroup: pointer.Int64(1001),
+					},
+				}},
+			},
+		},
+		expectedUID: 1000,
+		expectedGID: 1001,
+	}, {
+		name: "tproxy: security context should be ignored; UID=0 and GID=1337 expected",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					annotation.SidecarInterceptionMode.Name: string(model.InterceptionTproxy),
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: pointer.Int64(1000),
+					},
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser: pointer.Int64(1000),
+				},
+			},
+		},
+		expectedUID: 0,
+		expectedGID: 1337,
+	}, {
+		name: "sidecar: pod security context: proxy UID should be incremented and GID should be equal to app UID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  pointer.Int64(1000),
+					RunAsGroup: pointer.Int64(1001),
+				},
+			},
+		},
+		expectedUID: 1001,
+		expectedGID: 1000,
+	}, {
+		name: "sidecar: pod security context with UID only: proxy UID should be incremented and GID should be equal to app UID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser: pointer.Int64(1000),
+				},
+			},
+		},
+		expectedUID: 1001,
+		expectedGID: 1000,
+	}, {
+		name: "sidecar: container security context with UID and GID: proxy UID should be incremented and GID should be equal to app UID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  pointer.Int64(1000),
+						RunAsGroup: pointer.Int64(1001),
+					},
+				}},
+			},
+		},
+		expectedUID: 1001,
+		expectedGID: 1000,
+	}, {
+		name: "sidecar: container security context with UID only: proxy UID should be incremented and GID should be equal to app UID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: pointer.Int64(1000),
+					},
+				}},
+			},
+		},
+		expectedUID: 1001,
+		expectedGID: 1000,
+	}, {
+		name: "sidecar: pod and container security contexts with UID and GID: pod security context should be preferred",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  pointer.Int64(1000),
+						RunAsGroup: pointer.Int64(1001),
+					},
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  pointer.Int64(2000),
+					RunAsGroup: pointer.Int64(2001),
+				},
+			},
+		},
+		expectedUID: 2001,
+		expectedGID: 2000,
+	}, {
+		name: "sidecar: pod and container security contexts: container security context is ignored even if pod security context has no GID",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  pointer.Int64(1000),
+						RunAsGroup: pointer.Int64(1001),
+					},
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser: pointer.Int64(2000),
+				},
+			},
+		},
+		expectedUID: 2001,
+		expectedGID: 2000,
+	}, {
+		name: "sidecar: pod security context with UID and GID set to 0: proxy UID should be incremented and GID should overlap with the app GID (bug)",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+				}},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  pointer.Int64(0),
+					RunAsGroup: pointer.Int64(0),
+				},
+			},
+		},
+		expectedUID: 1,
+		expectedGID: 0,
+	}, {
+		name: "sidecar: container security context with UID and GID set to 0: proxy UID should be incremented and GID should overlap with the app GID (bug)",
+		pod: corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "app",
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser:  pointer.Int64(0),
+						RunAsGroup: pointer.Int64(0),
+					},
+				}},
+			},
+		},
+		expectedUID: 1,
+		expectedGID: 0,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyUID, proxyGID := findProxyUGID(tc.pod)
+			if *proxyUID != tc.expectedUID {
+				t.Errorf("Expected UID %d, but got %d", tc.expectedUID, *proxyUID)
+			}
+			if *proxyGID != tc.expectedGID {
+				t.Errorf("Expected GID %d, but got %d", tc.expectedGID, *proxyGID)
 			}
 		})
 	}

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1476,7 +1476,7 @@ func TestFindProxyUGID(t *testing.T) {
 		expectedUID: 1001,
 		expectedGID: 1001,
 	}, {
-		name: "sidecar: pod and container security contexts with UID and GID: pod security context should be preferred",
+		name: "sidecar: pod and container security contexts: pod security context is chosen, because has bigger values",
 		pod: corev1.Pod{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{
@@ -1495,23 +1495,24 @@ func TestFindProxyUGID(t *testing.T) {
 		expectedUID: 2001,
 		expectedGID: 2002,
 	}, {
-		name: "sidecar: pod and container security contexts: container security context is ignored even if pod security context has no GID",
+		name: "sidecar: pod and container security contexts: container security context is chosen, because has bigger values",
 		pod: corev1.Pod{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name: "app",
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser:  pointer.Int64(1000),
-						RunAsGroup: pointer.Int64(1001),
+						RunAsUser:  pointer.Int64(2000),
+						RunAsGroup: pointer.Int64(2001),
 					},
 				}},
 				SecurityContext: &corev1.PodSecurityContext{
-					RunAsUser: pointer.Int64(2000),
+					RunAsUser:  pointer.Int64(1000),
+					RunAsGroup: pointer.Int64(1001),
 				},
 			},
 		},
 		expectedUID: 2001,
-		expectedGID: 2001,
+		expectedGID: 2002,
 	}, {
 		name: "sidecar: pod security context with UID and GID set to 0: proxy UID should be incremented and GID should overlap with the app GID",
 		pod: corev1.Pod{

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1431,7 +1431,7 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 1001,
-		expectedGID: 1000,
+		expectedGID: 1002,
 	}, {
 		name: "sidecar: pod security context with UID only: proxy UID should be incremented and GID should be equal to app UID",
 		pod: corev1.Pod{
@@ -1445,7 +1445,7 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 1001,
-		expectedGID: 1000,
+		expectedGID: 1001,
 	}, {
 		name: "sidecar: container security context with UID and GID: proxy UID should be incremented and GID should be equal to app UID",
 		pod: corev1.Pod{
@@ -1460,7 +1460,7 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 1001,
-		expectedGID: 1000,
+		expectedGID: 1002,
 	}, {
 		name: "sidecar: container security context with UID only: proxy UID should be incremented and GID should be equal to app UID",
 		pod: corev1.Pod{
@@ -1474,7 +1474,7 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 1001,
-		expectedGID: 1000,
+		expectedGID: 1001,
 	}, {
 		name: "sidecar: pod and container security contexts with UID and GID: pod security context should be preferred",
 		pod: corev1.Pod{
@@ -1493,7 +1493,7 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 2001,
-		expectedGID: 2000,
+		expectedGID: 2002,
 	}, {
 		name: "sidecar: pod and container security contexts: container security context is ignored even if pod security context has no GID",
 		pod: corev1.Pod{
@@ -1511,9 +1511,9 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 2001,
-		expectedGID: 2000,
+		expectedGID: 2001,
 	}, {
-		name: "sidecar: pod security context with UID and GID set to 0: proxy UID should be incremented and GID should overlap with the app GID (bug)",
+		name: "sidecar: pod security context with UID and GID set to 0: proxy UID should be incremented and GID should overlap with the app GID",
 		pod: corev1.Pod{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{
@@ -1526,9 +1526,9 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 1,
-		expectedGID: 0,
+		expectedGID: 1,
 	}, {
-		name: "sidecar: container security context with UID and GID set to 0: proxy UID should be incremented and GID should overlap with the app GID (bug)",
+		name: "sidecar: container security context with UID and GID set to 0: proxy UID should be incremented and GID should overlap with the app GID",
 		pod: corev1.Pod{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{
@@ -1541,7 +1541,7 @@ func TestFindProxyUGID(t *testing.T) {
 			},
 		},
 		expectedUID: 1,
-		expectedGID: 0,
+		expectedGID: 1,
 	}}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Our injection webhook had a bug in finding proxy GID, but it was hidden, because we were overwriting GID with UID in the injection template.
In general, we set UID=app_UID + 1 and GID=app_UID and we ignored explicitly set `runAsGroup`. This is incorrect, but users did not face any issue in restricted SCC, because there only `runAsUser` is set by OCP. In such a case, application GID is 0, so when we set proxyUID=appUID+1 and proxyGID=appUID we did not face any issues, because all IDs were unique.
This bug reveal when an application has explicitly set UID and GID, e.g. 0 and 0, because then the calculated app UID is 1 and app GID = 0. This means that GID of the app and proxy overlap, so the no-redirect rules for GID owner cause failures in traffic interception. In the last version of the Istio Operator we [fixed](https://github.com/maistra/istio-operator/pull/1787) the injection template and therefore that this long-living bug was exposed.

> [!IMPORTANT]
> Please review commits one by one, because then you will see how it worked (I added unit tests without changing logic in the first 2 commits) and how it works with the actual fixes.