### PR TITLE
[OSSM-3337] Support for IPv6 in the bookinfo mongo sample app

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -56,6 +56,9 @@ spec:
         volumeMounts:
         - name: data-db
           mountPath: /data/db
+        args:
+        - '--ipv6'
+        - '--bind_ip_all'
       volumes:
       - name: data-db
         emptyDir: {}


### PR DESCRIPTION
**Please provide a description of this PR:**
Mongo DB from bookinfo samples doesn't work on IPv6 cluster.  It seems that the Mongo port is not bind correctly.
The `ratings-v2` pod contains the error:
```
MongoNetworkError: failed to connect to server [mongodb:27017] on first connect [Error: read ECONNRESET
```

**Fix:**
Added `--ipv6` and `--bind_ip_all` args to the Mongo DB container.
mongo pod log:
```
...
{"t":{"$date":"2024-09-10T08:11:50.607+00:00"},"s":"I",  "c":"CONTROL",  "id":21951,   "ctx":"initandlisten","msg":"Options set by command line","attr":{"options":{"net":{"bindIp":"*","ipv6":true}}}}
...
{"t":{"$date":"2024-09-10T08:11:51.516+00:00"},"s":"I",  "c":"NETWORK",  "id":23015,   "ctx":"listener","msg":"Listening on","attr":{"address":"0.0.0.0"}}
{"t":{"$date":"2024-09-10T08:11:51.516+00:00"},"s":"I",  "c":"NETWORK",  "id":23015,   "ctx":"listener","msg":"Listening on","attr":{"address":"::"}}
```

Reference: https://www.mongodb.com/docs/manual/core/security-mongodb-configuration/#ip-binding-in-self-managed-deployments

Tested on both IPv6 only and IPv4 only clusters and bookinfo app with ratings-v2 mongo db works correctly
![image](https://github.com/user-attachments/assets/a460e79b-d44c-47a8-9af5-0d098f7ab1ca)

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure

