### PR TITLE
Use rocky linux 9 instead of centos 9

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/rockylinux/rockylinux:9
 
 WORKDIR /
 

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_rocky_linux_9
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_rocky_linux_9
@@ -1,0 +1,35 @@
+FROM quay.io/rockylinux/rockylinux:9
+
+# Install the certs.
+COPY certs/             /var/lib/istio/
+COPY certs/default/     /var/run/secrets/istio/
+
+RUN useradd -m --uid 1338 application
+# Sudoers used to allow to execute istio-start.sh
+COPY sudoers /etc/sudoers
+
+# installing the following packages:
+# * iptables and iproute - necessary to apply iptables rules for istio-proxy
+# * openssl - installs OpenSSL 1.1.1k; Maistra proxy expects to find libssl.so.1.1 under /lib64 - it can be verified with 'ldconfig -p | grep ssl'
+# * sudo - necessary to install istio-sidecar.rpm
+# * hostname - used in the script istio-start.sh
+# * ps - for debugging purposes
+# hadolint ignore=DL3039,DL3041
+RUN dnf -y upgrade --refresh --nobest && \
+    dnf -y install iptables iproute sudo hostname procps openssl-3.0.7 openssl-devel-3.0.7 && \
+    dnf -y clean all
+
+# Install the sidecar components
+COPY istio-sidecar.rpm  /tmp/istio-sidecar.rpm
+RUN rpm -vi /tmp/istio-sidecar.rpm && rm /tmp/istio-sidecar.rpm
+
+# It can only be done after installing istio-sidecar.rpm
+RUN chown -R istio-proxy /var/lib/istio
+
+# Install the Echo application
+COPY echo-start.sh /usr/local/bin/echo-start.sh
+ARG TARGETARCH
+COPY ${TARGETARCH:-amd64}/client /usr/local/bin/client
+COPY ${TARGETARCH:-amd64}/server /usr/local/bin/server
+
+ENTRYPOINT ["/usr/local/bin/echo-start.sh"]

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -270,7 +270,7 @@ var VMImages = map[echo.VMDistro]string{
 	echo.UbuntuXenial:  "app_sidecar_ubuntu_bionic",
 	echo.UbuntuJammy:   "app_sidecar_ubuntu_jammy",
 	echo.Debian11:      "app_sidecar_debian_11",
-	echo.CentosStream9: "app_sidecar_centos_stream_9",
+	echo.CentosStream9: "app_sidecar_rocky_linux_9",
 	// echo.Rockylinux8:  "app_sidecar_rockylinux_8", TODO(https://github.com/istio/istio/issues/38224)
 }
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -118,7 +118,7 @@ function build_images() {
   targets="docker.pilot docker.proxyv2 "
 
   # use ubuntu:jammy to test vms by default
-  nonDistrolessTargets="docker.app docker.app_sidecar_centos_stream_9 docker.ext-authz "
+  nonDistrolessTargets="docker.app docker.app_sidecar_rocky_linux_9 docker.ext-authz "
   if [[ "${JOB_TYPE:-presubmit}" == "postsubmit" ]]; then
     # We run tests across all VM types only in postsubmit
     nonDistrolessTargets+="docker.app_sidecar_ubuntu_bionic docker.app_sidecar_debian_11 "

--- a/tools/docker.yaml
+++ b/tools/docker.yaml
@@ -80,8 +80,8 @@ images:
   targets:
     - ${TARGET_OUT_LINUX}/extauthz
 
-- name: app_sidecar_centos_stream_9
-  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_centos_stream_9
+- name: app_sidecar_rocky_linux_9
+  dockerfile: pkg/test/echo/docker/Dockerfile.app_sidecar_rocky_linux_9
   files:
   - tools/packaging/common/envoy_bootstrap.json
   - tests/testdata/certs


### PR DESCRIPTION
**Please provide a description of this PR:**
Use rocky linux 9 instead of centos 9 due to missing opensssl-3.0.7 in centos9

```
[root@ffccd76d0efb /]# cat /etc/os-release
NAME="Rocky Linux"
VERSION="9.4 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.4"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Rocky Linux 9.4 (Blue Onyx)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2032-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
ROCKY_SUPPORT_PRODUCT_VERSION="9.4"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.4"
```

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
