### PR TITLE
OSSM-8235 fix broken httpbin samples

### DIFF
--- a/samples/extauthz/local-ext-authz.yaml
+++ b/samples/extauthz/local-ext-authz.yaml
@@ -65,12 +65,11 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-      - image: docker.io/kong/httpbin
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8001
-        command: ["gunicorn", "-b", "0.0.0.0:8001", "httpbin:app", "-k", "gevent"]
+        - containerPort: 8080
       - image: gcr.io/istio-testing/ext-authz:latest
         imagePullPolicy: IfNotPresent
         name: ext-authz

--- a/samples/extauthz/local-ext-authz.yaml
+++ b/samples/extauthz/local-ext-authz.yaml
@@ -88,7 +88,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8001
+    targetPort: 8080
   selector:
     app: httpbin
 ---

--- a/samples/httpbin/httpbin-nodeport.yaml
+++ b/samples/httpbin/httpbin-nodeport.yaml
@@ -27,7 +27,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin
 ---

--- a/samples/httpbin/httpbin-nodeport.yaml
+++ b/samples/httpbin/httpbin-nodeport.yaml
@@ -50,9 +50,8 @@ spec:
         version: v1
     spec:
       containers:
-      - image: docker.io/kong/httpbin
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
-        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]
+        - containerPort: 8080

--- a/samples/httpbin/httpbin-vault.yaml
+++ b/samples/httpbin/httpbin-vault.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin
 ---

--- a/samples/httpbin/httpbin-vault.yaml
+++ b/samples/httpbin/httpbin-vault.yaml
@@ -48,9 +48,8 @@ spec:
     spec:
       serviceAccountName: vault-citadel-sa    
       containers:
-      - image: docker.io/kong/httpbin
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
-        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]
+        - containerPort: 8080

--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -55,9 +55,8 @@ spec:
     spec:
       serviceAccountName: httpbin
       containers:
-      - image: docker.io/kong/httpbin
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
-        command: ["gunicorn", "-b", "0.0.0.0:8000", "httpbin:app", "-k", "gevent"]
+        - containerPort: 8080

--- a/samples/httpbin/httpbin.yaml
+++ b/samples/httpbin/httpbin.yaml
@@ -31,7 +31,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin
 ---


### PR DESCRIPTION
Since httpbin released 0.2.0, all httpbin samples on openshift are broken. 
See [this issue in the httpbin repo|https://github.com/Kong/httpbin/issues/60]. The [istio fix](https://github.com/istio/istio/pull/53287) for this doesn't work on openshift but istio has moved to a [go based httpbin](https://github.com/istio/istio/pull/53315) instead of the python/pipenv version which works without any additional arguments or env var settings.

