### PR TITLE
OSSM-8608 2.5 backport: fix: clear tmp files from previous run if exist before copy cni binaries again

### DIFF
--- a/cni/pkg/install/binaries.go
+++ b/cni/pkg/install/binaries.go
@@ -55,6 +55,17 @@ func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipB
 			}
 
 			srcFilepath := filepath.Join(srcDir, filename)
+			// remove previous tmp file if some exist before creating a new one
+			// the only possible returned error is [ErrBadPattern], when pattern is malformed. Can be ignored in this case
+			matches, _ := filepath.Glob(filepath.Join(targetDir, targetFilename) + ".tmp.*")
+			if len(matches) > 0 {
+				installLog.Infof("Target folder %s contains one or more temporary files with a %s name. The temp files will be deleted.", targetDir, targetFilename)
+				for _, file := range matches {
+					if err := os.Remove(file); err != nil {
+						installLog.Warnf("Failed to delete tmp file %s from previous run: %s", file, err)
+					}
+				}
+			}
 			err := file.AtomicCopy(srcFilepath, targetDir, targetFilename)
 			if err != nil {
 				return err

--- a/releasenotes/notes/54311.yaml
+++ b/releasenotes/notes/54311.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 54311
+releaseNotes:
+- |
+  **Fixed** an issue where the CNI installation left temporary files when a container was repeatedly killed during the binary copy, which could have filled the storage space.


### PR DESCRIPTION
Backport fix https://github.com/istio/istio/pull/54312 from upstream
Downstream ticket: https://issues.redhat.com/browse/OSSM-8608