### PR TITLE
OSSM-8608 2.4 backport: fix: clear tmp files from previous run if exist before copy cni binaries again

### DIFF
--- a/cni/pkg/install/binaries.go
+++ b/cni/pkg/install/binaries.go
@@ -50,6 +50,17 @@ func copyBinaries(srcDir string, targetDirs []string, updateBinaries bool, skipB
 			}
 
 			srcFilepath := filepath.Join(srcDir, filename)
+			// remove previous tmp file if some exist before creating a new one
+			// the only possible returned error is [ErrBadPattern], when pattern is malformed. Can be ignored in this case
+			matches, _ := filepath.Glob(filepath.Join(targetDir, targetFilename) + ".tmp.*")
+			if len(matches) > 0 {
+				installLog.Infof("Target folder %s contains one or more temporary files with a %s name. The temp files will be deleted.", targetDir, targetFilename)
+				for _, file := range matches {
+					if err := os.Remove(file); err != nil {
+						installLog.Warnf("Failed to delete tmp file %s from previous run: %s", file, err)
+					}
+				}
+			}
 			err := file.AtomicCopy(srcFilepath, targetDir, targetFilename)
 			if err != nil {
 				return err

--- a/cni/pkg/install/binaries_test.go
+++ b/cni/pkg/install/binaries_test.go
@@ -18,6 +18,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	file2 "istio.io/istio/pkg/file"
+	"istio.io/istio/pkg/test/util/assert"
 )
 
 func TestCopyBinaries(t *testing.T) {
@@ -97,4 +100,30 @@ func TestCopyBinaries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCopyBinariesWhenTmpExist(t *testing.T) {
+	srcDir := t.TempDir()
+	os.WriteFile(filepath.Join(srcDir, "istio-cni"), []byte("content"), os.ModePerm)
+
+	targetDir := t.TempDir()
+	tmpFile1 := filepath.Join(targetDir, "v2-4-istio-cni.tmp.3816169537")
+	tmpFile2 := filepath.Join(targetDir, "v2-3-istio-cni.tmp.4977877")
+	os.WriteFile(tmpFile1, []byte("content"), os.ModePerm)
+	os.WriteFile(tmpFile2, []byte("content"), os.ModePerm)
+
+	err := copyBinaries(srcDir, []string{targetDir}, false, []string{}, "v2-4-")
+	assert.NoError(t, err)
+	// check that only the tmp file with prefix the v2-6- was removed
+	assert.Equal(t, file2.Exists(tmpFile1), false)
+	assert.Equal(t, file2.Exists(tmpFile2), true)
+
+	err = copyBinaries(srcDir, []string{targetDir}, false, []string{}, "v2-3-")
+	assert.NoError(t, err)
+	// check that also second tmp file with other prefix was removed
+	assert.Equal(t, file2.Exists(tmpFile2), false)
+
+	// check that bins are still there
+	assert.Equal(t, file2.Exists(filepath.Join(targetDir, "v2-3-istio-cni")), true)
+	assert.Equal(t, file2.Exists(filepath.Join(targetDir, "v2-4-istio-cni")), true)
 }

--- a/releasenotes/notes/54311.yaml
+++ b/releasenotes/notes/54311.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+  - 54311
+releaseNotes:
+- |
+  **Fixed** an issue where the CNI installation left temporary files when a container was repeatedly killed during the binary copy, which could have filled the storage space.


### PR DESCRIPTION
Backport fix https://github.com/istio/istio/pull/54312 from upstream
Downstream ticket: https://issues.redhat.com/browse/OSSM-8608